### PR TITLE
Add configuration, Add users relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,81 @@ running the migrations:
 php artisan migrate
 ```
 
-Finally add the `Spatie\Permission\Traits\HasRoles`-trait to the User model.
+You can publish the config-file with:
+```bash
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+```
+
+This is the contents of the published config file:
+
+```php
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Models
+    |--------------------------------------------------------------------------
+    */
+
+    'models' => [
+        /*
+         * The class name of the permission model to be used.
+         */
+        'permission' => 'Spatie\Permission\Models\Permission',
+
+        /*
+         * The class name of the role model to be used.
+         */
+        'role' => 'Spatie\Permission\Models\Role',
+
+        /*
+         * The class name of the user model to be used.
+         */
+        'user' => 'App\User',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Tables
+    |--------------------------------------------------------------------------
+    */
+
+    'tableNames' => [
+        /*
+         * The name of the "users" table to be used.
+         */
+        'users' => 'users',
+
+        /*
+         * The name of the "roles" table to be used.
+         */
+        'roles' => 'roles',
+
+        /*
+         * The name of the "permissions" table to be used.
+         */
+        'permissions' => 'permissions',
+
+        /*
+         * The name of the "user_has_permissions" table to be used.
+         */
+        'user_has_permissions' => 'user_has_permissions',
+
+        /*
+         * The name of the "user_has_roles" table to be used.
+         */
+        'user_has_roles' => 'user_has_roles',
+
+        /*
+         * The name of the "role_has_permissions" table to be used.
+         */
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+];
+```
+
+And finally add the `Spatie\Permission\Traits\HasRoles`-trait to the User model.
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,20 +77,52 @@ return [
     */
 
     'models' => [
-        /*
-         * The class name of the permission model to be used.
-         */
-        'permission' => 'Spatie\Permission\Models\Permission',
 
         /*
-         * The class name of the role model to be used.
-         */
-        'role' => 'Spatie\Permission\Models\Role',
+        |--------------------------------------------------------------------------
+        | Permission Model
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | Eloquent model should be used to retrieve your permissions. Of course, it
+        | is often just the "Permission" model but you may use whatever you like.
+        |
+        | The model you want to use as a Permission model needs to implement the
+        | `Spatie\Permission\Contracts\Permission` contract.
+        |
+        */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
 
         /*
-         * The class name of the user model to be used.
-         */
-        'user' => 'App\User',
+        |--------------------------------------------------------------------------
+        | Role Model
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | Eloquent model should be used to retrieve your roles. Of course, it
+        | is often just the "Role" model but you may use whatever you like.
+        |
+        | The model you want to use as a Role model needs to implement the
+        | `Spatie\Permission\Contracts\Role` contract.
+        |
+        */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+        /*
+        |--------------------------------------------------------------------------
+        | User Model
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | Eloquent model should be used to retrieve your users. Of course, it
+        | is often just the "User" model but you may use whatever you like.
+        |
+        */
+
+        'user' => App\User::class,
+
     ],
 
     /*
@@ -100,43 +132,91 @@ return [
     */
 
     'tableNames' => [
+
         /*
-         * The name of the "users" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Users Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your users. We have chosen a basic
+        | default value but you may easily change it to any table you like.
+        |
+        */
+
         'users' => 'users',
 
         /*
-         * The name of the "roles" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Roles Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your roles. We have chosen a basic
+        | default value but you may easily change it to any table you like.
+        |
+        */
+
         'roles' => 'roles',
 
         /*
-         * The name of the "permissions" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your permissions. We have chosen a basic
+        | default value but you may easily change it to any table you like.
+        |
+        */
+
         'permissions' => 'permissions',
 
         /*
-         * The name of the "user_has_permissions" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | User Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your users permissions. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
+
         'user_has_permissions' => 'user_has_permissions',
 
         /*
-         * The name of the "user_has_roles" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | User Roles Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your users roles. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
+
         'user_has_roles' => 'user_has_roles',
 
         /*
-         * The name of the "role_has_permissions" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Role Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your roles permissions. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
+
         'role_has_permissions' => 'role_has_permissions',
+
     ],
 
 ];
 ```
 
 And finally add the `Spatie\Permission\Traits\HasRoles`-trait to the User model.
-
-
 
 ## Usage
 
@@ -263,6 +343,15 @@ I have all of these roles!
 I don't have all of these roles...
 @endhasallroles
 ```
+
+## Extending
+
+If you need to extend or replace the existing `Role` or `Permission` models you just need to 
+keep the following things in mind:
+
+- Your `Role` model needs to implement the `Spatie\Permission\Contracts\Role` contract
+- Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
+- You must publish the configuration and update the `models.role` and `models.permission` values
 
 ## Change log
 

--- a/resources/config/laravel-permission.php
+++ b/resources/config/laravel-permission.php
@@ -1,0 +1,49 @@
+<?php
+
+return [
+
+    'models' => [
+        /*
+         * The class name of the permission model to be used.
+         */
+        'permission' => 'Spatie\Permission\Models\Permission',
+
+        /*
+         * The class name of the role model to be used.
+         */
+        'role' => 'Spatie\Permission\Models\Role',
+
+        /*
+         * The class name of the user model to be used.
+         */
+        'user' => 'App\User',
+    ],
+
+    'tables' => [
+        /*
+         * The name of the "roles" table to be used.
+         */
+        'roles' => 'roles',
+
+        /*
+         * The name of the "permissions" table to be used.
+         */
+        'permissions' => 'permissions',
+
+        /*
+         * The name of the "user_has_permissions" table to be used.
+         */
+        'user_has_permissions' => 'user_has_permissions',
+
+        /*
+         * The name of the "user_has_roles" table to be used.
+         */
+        'user_has_roles' => 'user_has_roles',
+
+        /*
+         * The name of the "role_has_permissions" table to be used.
+         */
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+];

--- a/resources/config/laravel-permission.php
+++ b/resources/config/laravel-permission.php
@@ -2,6 +2,12 @@
 
 return [
 
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Models
+    |--------------------------------------------------------------------------
+    */
+
     'models' => [
         /*
          * The class name of the permission model to be used.
@@ -19,7 +25,18 @@ return [
         'user' => 'App\User',
     ],
 
-    'tables' => [
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Tables
+    |--------------------------------------------------------------------------
+    */
+
+    'tableNames' => [
+        /*
+         * The name of the "users" table to be used.
+         */
+        'users' => 'users',
+
         /*
          * The name of the "roles" table to be used.
          */

--- a/resources/config/laravel-permission.php
+++ b/resources/config/laravel-permission.php
@@ -12,17 +12,17 @@ return [
         /*
          * The class name of the permission model to be used.
          */
-        'permission' => 'Spatie\Permission\Models\Permission',
+        'permission' => Spatie\Permission\Models\Permission::class,
 
         /*
          * The class name of the role model to be used.
          */
-        'role' => 'Spatie\Permission\Models\Role',
+        'role' => Spatie\Permission\Models\Role::class,
 
         /*
          * The class name of the user model to be used.
          */
-        'user' => 'App\User',
+        'user' => App\User::class,
     ],
 
     /*

--- a/resources/config/laravel-permission.php
+++ b/resources/config/laravel-permission.php
@@ -9,20 +9,52 @@ return [
     */
 
     'models' => [
+
         /*
-         * The class name of the permission model to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Permission Model
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | Eloquent model should be used to retrieve your permissions. Of course, it
+        | is often just the "Permission" model but you may use whatever you like.
+        |
+        | The model you want to use as a Permission model needs to implement the
+        | `Spatie\Permission\Contracts\Permission` contract.
+        |
+        */
+
         'permission' => Spatie\Permission\Models\Permission::class,
 
         /*
-         * The class name of the role model to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Role Model
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | Eloquent model should be used to retrieve your roles. Of course, it
+        | is often just the "Role" model but you may use whatever you like.
+        |
+        | The model you want to use as a Role model needs to implement the
+        | `Spatie\Permission\Contracts\Role` contract.
+        |
+        */
+
         'role' => Spatie\Permission\Models\Role::class,
 
         /*
-         * The class name of the user model to be used.
-         */
+        |--------------------------------------------------------------------------
+        | User Model
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | Eloquent model should be used to retrieve your users. Of course, it
+        | is often just the "User" model but you may use whatever you like.
+        |
+        */
+
         'user' => App\User::class,
+
     ],
 
     /*
@@ -32,35 +64,85 @@ return [
     */
 
     'tableNames' => [
+
         /*
-         * The name of the "users" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Users Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your users. We have chosen a basic
+        | default value but you may easily change it to any table you like.
+        |
+        */
+
         'users' => 'users',
 
         /*
-         * The name of the "roles" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Roles Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your roles. We have chosen a basic
+        | default value but you may easily change it to any table you like.
+        |
+        */
+
         'roles' => 'roles',
 
         /*
-         * The name of the "permissions" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your permissions. We have chosen a basic
+        | default value but you may easily change it to any table you like.
+        |
+        */
+
         'permissions' => 'permissions',
 
         /*
-         * The name of the "user_has_permissions" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | User Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your users permissions. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
+
         'user_has_permissions' => 'user_has_permissions',
 
         /*
-         * The name of the "user_has_roles" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | User Roles Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your users roles. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
+
         'user_has_roles' => 'user_has_roles',
 
         /*
-         * The name of the "role_has_permissions" table to be used.
-         */
+        |--------------------------------------------------------------------------
+        | Role Permissions Table
+        |--------------------------------------------------------------------------
+        |
+        | When using the "HasRoles" trait from this package, we need to know which
+        | table should be used to retrieve your roles permissions. We have chosen a
+        | basic default value but you may easily change it to any table you like.
+        |
+        */
+
         'role_has_permissions' => 'role_has_permissions',
+
     ],
 
 ];

--- a/resources/migrations/create_permission_tables.php.stub
+++ b/resources/migrations/create_permission_tables.php.stub
@@ -12,7 +12,7 @@ class CreatePermissionTables extends Migration
      */
     public function up()
     {
-        $config = config('laravel-permission.tables');
+        $config = config('laravel-permission.tableNames');
 
         Schema::create($config['roles'], function (Blueprint $table) {
             $table->increments('id');
@@ -26,18 +26,18 @@ class CreatePermissionTables extends Migration
             $table->timestamps();
         });
 
-        Schema::create($config['user_has_permissions'], function (Blueprint $table) {
+        Schema::create($config['user_has_permissions'], function (Blueprint $table) use ($config) {
             $table->integer('user_id')->unsigned();
             $table->integer('permission_id')->unsigned();
 
             $table->foreign('user_id')
                 ->references('id')
-                ->on('users')
+                ->on($config['users'])
                 ->onDelete('cascade');
 
             $table->foreign('permission_id')
                 ->references('id')
-                ->on('permissions')
+                ->on($config['permissions'])
                 ->onDelete('cascade');
 
             $table->primary(['user_id', 'permission_id']);
@@ -49,28 +49,28 @@ class CreatePermissionTables extends Migration
 
             $table->foreign('role_id')
                 ->references('id')
-                ->on('roles')
+                ->on($config['roles'])
                 ->onDelete('cascade');
 
             $table->foreign('user_id')
                 ->references('id')
-                ->on('users')
+                ->on($config['users'])
                 ->onDelete('cascade');
 
             $table->primary(['role_id', 'user_id']);
 
-            Schema::create($config['role_has_permissions'], function (Blueprint $table) {
+            Schema::create($config['role_has_permissions'], function (Blueprint $table) use ($config) {
                 $table->integer('permission_id')->unsigned();
                 $table->integer('role_id')->unsigned();
 
                 $table->foreign('permission_id')
                     ->references('id')
-                    ->on('permissions')
+                    ->on($config['permissions'])
                     ->onDelete('cascade');
 
                 $table->foreign('role_id')
                     ->references('id')
-                    ->on('roles')
+                    ->on($config['roles'])
                     ->onDelete('cascade');
 
                 $table->primary(['permission_id', 'role_id']);
@@ -85,7 +85,7 @@ class CreatePermissionTables extends Migration
      */
     public function down()
     {
-        $config = config('laravel-permission.tables');
+        $config = config('laravel-permission.tableNames');
 
         Schema::drop($config['role_has_permissions']);
         Schema::drop($config['user_has_roles']);

--- a/resources/migrations/create_permission_tables.php.stub
+++ b/resources/migrations/create_permission_tables.php.stub
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 
 class CreatePermissionTables extends Migration
 {
@@ -12,19 +12,21 @@ class CreatePermissionTables extends Migration
      */
     public function up()
     {
-        Schema::create('roles', function (Blueprint $table) {
+        $config = config('laravel-permission.tables');
+
+        Schema::create($config['roles'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('permissions', function (Blueprint $table) {
+        Schema::create($config['permissions'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('user_has_permissions', function (Blueprint $table) {
+        Schema::create($config['user_has_permissions'], function (Blueprint $table) {
             $table->integer('user_id')->unsigned();
             $table->integer('permission_id')->unsigned();
 
@@ -41,7 +43,7 @@ class CreatePermissionTables extends Migration
             $table->primary(['user_id', 'permission_id']);
         });
 
-        Schema::create('user_has_roles', function (Blueprint $table) {
+        Schema::create($config['user_has_roles'], function (Blueprint $table) use ($config) {
             $table->integer('role_id')->unsigned();
             $table->integer('user_id')->unsigned();
 
@@ -57,7 +59,7 @@ class CreatePermissionTables extends Migration
 
             $table->primary(['role_id', 'user_id']);
 
-            Schema::create('role_has_permissions', function (Blueprint $table) {
+            Schema::create($config['role_has_permissions'], function (Blueprint $table) {
                 $table->integer('permission_id')->unsigned();
                 $table->integer('role_id')->unsigned();
 
@@ -83,10 +85,12 @@ class CreatePermissionTables extends Migration
      */
     public function down()
     {
-        Schema::drop('role_has_permissions');
-        Schema::drop('user_has_roles');
-        Schema::drop('user_has_permissions');
-        Schema::drop('roles');
-        Schema::drop('permissions');
+        $config = config('laravel-permission.tables');
+
+        Schema::drop($config['role_has_permissions']);
+        Schema::drop($config['user_has_roles']);
+        Schema::drop($config['user_has_permissions']);
+        Schema::drop($config['roles']);
+        Schema::drop($config['permissions']);
     }
 }

--- a/src/Contracts/Permission.php
+++ b/src/Contracts/Permission.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\Permission\Contracts;
+
+interface Permission
+{
+    /**
+     * A permission can be applied to roles.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function roles();
+
+    /**
+     * A permission can be applied to users.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users();
+
+    /**
+     * Find a permission by its name.
+     *
+     * @param string $name
+     *
+     * @throws PermissionDoesNotExist
+     */
+    public static function findByName($name);
+}

--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\Permission\Contracts;
+
+interface Role
+{
+    /**
+     * A role may be given various permissions.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function permissions();
+
+    /**
+     * A role may be assigned to various users.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users();
+
+    /**
+     * Find a role by its name.
+     *
+     * @param string $name
+     *
+     * @throws RoleDoesNotExist
+     */
+    public static function findByName($name);
+}

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -3,13 +3,19 @@
 namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 
-class Permission extends Model
+class Permission extends Model implements PermissionContract
 {
     use RefreshesPermissionCache;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
     public $guarded = ['id'];
 
     /**
@@ -19,7 +25,23 @@ class Permission extends Model
      */
     public function roles()
     {
-        return $this->belongsToMany(Role::class, 'role_has_permissions');
+        return $this->belongsToMany(
+            config('laravel-permission.models.role'),
+            config('laravel-permission.tables.role_has_permissions')
+        );
+    }
+
+    /**
+     * A permission can be applied to users.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users()
+    {
+        return $this->belongsToMany(
+            config('laravel-permission.models.user'),
+            config('laravel-permission.tables.user_has_permissions')
+        );
     }
 
     /**

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -12,11 +12,31 @@ class Permission extends Model implements PermissionContract
     use RefreshesPermissionCache;
 
     /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'permissions';
+
+    /**
      * The attributes that aren't mass assignable.
      *
      * @var array
      */
     public $guarded = ['id'];
+
+    /**
+     * Create a new Eloquent model instance.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->table = config('laravel-permission.tables.permissions');
+    }
 
     /**
      * A permission can be applied to roles.

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -12,13 +12,6 @@ class Permission extends Model implements PermissionContract
     use RefreshesPermissionCache;
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'permissions';
-
-    /**
      * The attributes that aren't mass assignable.
      *
      * @var array
@@ -28,14 +21,13 @@ class Permission extends Model implements PermissionContract
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array  $attributes
-     * @return void
+     * @param array $attributes
      */
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
 
-        $this->table = config('laravel-permission.tables.permissions');
+        $this->setTable(config('laravel-permission.tableNames.permissions'));
     }
 
     /**
@@ -47,7 +39,7 @@ class Permission extends Model implements PermissionContract
     {
         return $this->belongsToMany(
             config('laravel-permission.models.role'),
-            config('laravel-permission.tables.role_has_permissions')
+            config('laravel-permission.tableNames.role_has_permissions')
         );
     }
 
@@ -60,7 +52,7 @@ class Permission extends Model implements PermissionContract
     {
         return $this->belongsToMany(
             config('laravel-permission.models.user'),
-            config('laravel-permission.tables.user_has_permissions')
+            config('laravel-permission.tableNames.user_has_permissions')
         );
     }
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -3,15 +3,21 @@
 namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 
-class Role extends Model
+class Role extends Model implements RoleContract
 {
     use HasPermissions;
     use RefreshesPermissionCache;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
     public $guarded = ['id'];
 
     /**
@@ -21,7 +27,23 @@ class Role extends Model
      */
     public function permissions()
     {
-        return $this->belongsToMany(Permission::class, 'role_has_permissions');
+        return $this->belongsToMany(
+            config('laravel-permission.models.permission'),
+            config('laravel-permission.tables.role_has_permissions')
+        );
+    }
+
+    /**
+     * A role may be assigned to various users.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function users()
+    {
+        return $this->belongsToMany(
+            config('laravel-permission.models.user'),
+            config('laravel-permission.tables.user_has_roles')
+        );
     }
 
     /**

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -14,13 +14,6 @@ class Role extends Model implements RoleContract
     use RefreshesPermissionCache;
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'roles';
-
-    /**
      * The attributes that aren't mass assignable.
      *
      * @var array
@@ -30,14 +23,13 @@ class Role extends Model implements RoleContract
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array  $attributes
-     * @return void
+     * @param array $attributes
      */
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
 
-        $this->table = config('laravel-permission.tables.roles');
+        $this->setTable(config('laravel-permission.tableNames.roles'));
     }
 
     /**
@@ -49,7 +41,7 @@ class Role extends Model implements RoleContract
     {
         return $this->belongsToMany(
             config('laravel-permission.models.permission'),
-            config('laravel-permission.tables.role_has_permissions')
+            config('laravel-permission.tableNames.role_has_permissions')
         );
     }
 
@@ -62,7 +54,7 @@ class Role extends Model implements RoleContract
     {
         return $this->belongsToMany(
             config('laravel-permission.models.user'),
-            config('laravel-permission.tables.user_has_roles')
+            config('laravel-permission.tableNames.user_has_roles')
         );
     }
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -14,11 +14,31 @@ class Role extends Model implements RoleContract
     use RefreshesPermissionCache;
 
     /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'roles';
+
+    /**
      * The attributes that aren't mass assignable.
      *
      * @var array
      */
     public $guarded = ['id'];
+
+    /**
+     * Create a new Eloquent model instance.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->table = config('laravel-permission.tables.roles');
+    }
 
     /**
      * A role may be given various permissions.

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Cache\Repository;
 use Log;
-use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Contracts\Permission;
 
 class PermissionRegistrar
 {
@@ -75,7 +75,7 @@ class PermissionRegistrar
     protected function getPermissions()
     {
         return $this->cache->rememberForever($this->cacheKey, function () {
-            return Permission::with('roles')->get();
+            return app(Permission::class)->with('roles')->get();
         });
     }
 }

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -38,12 +38,20 @@ class PermissionServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../resources/config/laravel-permission.php', 'laravel-permission');
 
-        $config = config('laravel-permission.models');
+        $this->registerModelBindings();
+
+        $this->registerBladeExtensions();
+    }
+
+    /**
+     * Bind the Permission and Role model into the IoC.
+     */
+    protected function registerModelBindings()
+    {
+        $config = $this->app->config['laravel-permission.models'];
 
         $this->app->bind(PermissionContract::class, $config['permission']);
         $this->app->bind(RoleContract::class, $config['role']);
-
-        $this->registerBladeExtensions();
     }
 
     /**

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -4,6 +4,8 @@ namespace Spatie\Permission;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
+use Spatie\Permission\Contracts\Permission as PermissionContract;
+use Spatie\Permission\Contracts\Role as RoleContract;
 
 class PermissionServiceProvider extends ServiceProvider
 {
@@ -14,6 +16,10 @@ class PermissionServiceProvider extends ServiceProvider
      */
     public function boot(PermissionRegistrar $permissionLoader)
     {
+        $this->publishes([
+            __DIR__.'/../resources/config/laravel-permission.php' => $this->app->configPath().'/'.'laravel-permission.php',
+        ], 'config');
+
         if (!class_exists('CreatePermissionTables')) {
             // Publish the migration
             $timestamp = date('Y_m_d_His', time());
@@ -30,6 +36,13 @@ class PermissionServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/../resources/config/laravel-permission.php', 'laravel-permission');
+
+        $config = config('laravel-permission.models');
+
+        $this->app->bind(PermissionContract::class, $config['permission']);
+        $this->app->bind(RoleContract::class, $config['role']);
+
         $this->registerBladeExtensions();
     }
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Permission\Traits;
 
-use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Contracts\Permission;
 
 trait HasPermissions
 {
@@ -46,7 +46,7 @@ trait HasPermissions
     protected function getStoredPermission($permission)
     {
         if (is_string($permission)) {
-            return Permission::findByName($permission);
+            return app(Permission::class)->findByName($permission);
         }
 
         return $permission;

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -19,7 +19,7 @@ trait HasRoles
     {
         return $this->belongsToMany(
             config('laravel-permission.models.role'),
-            config('laravel-permission.tables.user_has_roles')
+            config('laravel-permission.tableNames.user_has_roles')
         );
     }
 
@@ -32,7 +32,7 @@ trait HasRoles
     {
         return $this->belongsToMany(
             config('laravel-permission.models.permission'),
-            config('laravel-permission.tables.user_has_permissions')
+            config('laravel-permission.tableNames.user_has_permissions')
         );
     }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Permission\Traits;
 
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
+use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Contracts\Role;
 
 trait HasRoles
 {
@@ -17,7 +17,10 @@ trait HasRoles
      */
     public function roles()
     {
-        return $this->belongsToMany(Role::class, 'user_has_roles');
+        return $this->belongsToMany(
+            config('laravel-permission.models.role'),
+            config('laravel-permission.tables.user_has_roles')
+        );
     }
 
     /**
@@ -27,7 +30,10 @@ trait HasRoles
      */
     public function permissions()
     {
-        return $this->belongsToMany(Permission::class, 'user_has_permissions');
+        return $this->belongsToMany(
+            config('laravel-permission.models.permission'),
+            config('laravel-permission.tables.user_has_permissions')
+        );
     }
 
     /**
@@ -120,7 +126,7 @@ trait HasRoles
     public function hasPermissionTo($permission)
     {
         if (is_string($permission)) {
-            $permission = Permission::findByName($permission);
+            $permission = app(Permission::class)->findByName($permission);
         }
 
         return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
@@ -162,7 +168,7 @@ trait HasRoles
     protected function hasDirectPermission(Permission $permission)
     {
         if (is_string($permission)) {
-            $permission = Permission::findByName($permission);
+            $permission = app(Permission::class)->findByName($permission);
         }
 
         return $this->permissions->contains('id', $permission->id);
@@ -176,7 +182,7 @@ trait HasRoles
     protected function getStoredRole($role)
     {
         if (is_string($role)) {
-            return Role::findByName($role);
+            return app(Role::class)->findByName($role);
         }
 
         return $role;

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -2,15 +2,18 @@
 
 namespace Spatie\Permission\Test;
 
-use Spatie\Permission\Models\Role;
+use Spatie\Permission\Contracts\Role;
 
 class BladeTest extends TestCase
 {
     public function setUp()
     {
         parent::setUp();
-        Role::create(['name' => 'member']);
-        Role::create(['name' => 'admin']);
+
+        $roleModel = app(Role::class);
+
+        $roleModel->create(['name' => 'member']);
+        $roleModel->create(['name' => 'admin']);
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Permission\Test;
 
 use Illuminate\Support\Facades\DB;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
+use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\PermissionRegistrar;
 
 class CacheTest extends TestCase
@@ -44,7 +44,7 @@ class CacheTest extends TestCase
      */
     public function permission_creation_and_updating_should_flush_the_cache()
     {
-        $permission = Permission::create(['name' => 'new']);
+        $permission = app(Permission::class)->create(['name' => 'new']);
         $this->assertCount(3, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
@@ -63,7 +63,7 @@ class CacheTest extends TestCase
      */
     public function role_creation_and_updating_should_flush_the_cache()
     {
-        $role = Role::create(['name' => 'new']);
+        $role = app(Role::class)->create(['name' => 'new']);
         $this->assertCount(3, DB::getQueryLog());
 
         $this->registrar->registerPermissions();

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Permission\Test;
 
-use Spatie\Permission\Models\Role;
+use Spatie\Permission\Contracts\Role;
 
 class HasRolesTest extends TestCase
 {
@@ -47,17 +47,19 @@ class HasRolesTest extends TestCase
      */
     public function it_can_determine_that_a_user_has_one_of_the_given_roles()
     {
-        Role::create(['name' => 'second role']);
+        $roleModel = app(Role::class);
 
-        $this->assertFalse($this->testUser->hasRole(Role::all()));
+        $roleModel->create(['name' => 'second role']);
+
+        $this->assertFalse($this->testUser->hasRole($roleModel->all()));
 
         $this->testUser->assignRole($this->testRole);
 
         $this->refreshTestUser();
 
-        $this->assertTrue($this->testUser->hasRole(Role::all()));
+        $this->assertTrue($this->testUser->hasRole($roleModel->all()));
 
-        $this->assertTrue($this->testUser->hasAnyRole(Role::all()));
+        $this->assertTrue($this->testUser->hasAnyRole($roleModel->all()));
     }
 
     /**
@@ -65,25 +67,27 @@ class HasRolesTest extends TestCase
      */
     public function it_can_determine_that_a_user_has_all_of_the_given_roles()
     {
-        $this->assertFalse($this->testUser->hasAllRoles(Role::first()));
+        $roleModel = app(Role::class);
+
+        $this->assertFalse($this->testUser->hasAllRoles($roleModel->first()));
 
         $this->assertFalse($this->testUser->hasAllRoles('testRole'));
 
-        $this->assertFalse($this->testUser->hasAllRoles(Role::all()));
+        $this->assertFalse($this->testUser->hasAllRoles($roleModel->all()));
 
-        Role::create(['name' => 'second role']);
+        $roleModel->create(['name' => 'second role']);
 
         $this->testUser->assignRole($this->testRole);
 
         $this->refreshTestUser();
 
-        $this->assertFalse($this->testUser->hasAllRoles(Role::all()));
+        $this->assertFalse($this->testUser->hasAllRoles($roleModel->all()));
 
         $this->testUser->assignRole('second role');
 
         $this->refreshTestUser();
 
-        $this->assertTrue($this->testUser->hasAllRoles(Role::all()));
+        $this->assertTrue($this->testUser->hasAllRoles($roleModel->all()));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,13 @@
 
 namespace Spatie\Permission\Test;
 
+use File;
 use Illuminate\Database\Schema\Blueprint;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
+use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\PermissionServiceProvider;
-use File;
 
 abstract class TestCase extends Orchestra
 {
@@ -36,8 +36,8 @@ abstract class TestCase extends Orchestra
         $this->reloadPermissions();
 
         $this->testUser = User::first();
-        $this->testRole = Role::first();
-        $this->testPermission = Permission::find(1);
+        $this->testRole = app(Role::class)->first();
+        $this->testPermission = app(Permission::class)->find(1);
     }
 
     /**
@@ -90,9 +90,9 @@ abstract class TestCase extends Orchestra
         (new \CreatePermissionTables())->up();
 
         User::create(['email' => 'test@user.com']);
-        Role::create(['name' => 'testRole']);
-        Permission::create(['name' => 'edit-articles']);
-        Permission::create(['name' => 'edit-news']);
+        $app[Role::class]->create(['name' => 'testRole']);
+        $app[Permission::class]->create(['name' => 'edit-articles']);
+        $app[Permission::class]->create(['name' => 'edit-news']);
     }
 
     /**


### PR DESCRIPTION
This pull requests adds the ability to configure the Models that should be used by Eloquent and the table names that should be used for migrations.

The models now use the `Role` and `Permission` contracts which are bound to the IoC so that they can be resolved to make swapping them out easier.

I've also added a `users` relation so that it is possible to get all associated users for a permission or role like this `Role::first()->users()->count()`.

This PR should solve issue https://github.com/spatie/laravel-permission/issues/18 and https://github.com/spatie/laravel-permission/issues/5.