### PR TITLE
if no permissions exist then return false

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -167,6 +167,10 @@ trait HasRoles
      */
     protected function hasDirectPermission(Permission $permission)
     {
+        if( ! $this->permissions) {
+            return false;
+        }
+        
         if (is_string($permission)) {
             $permission = app(Permission::class)->findByName($permission);
 


### PR DESCRIPTION
If the object doesn't have any permissions it would error out as ```$this->permissions``` would be null.