### PR TITLE
Make names column unique

### DIFF
--- a/resources/migrations/add_unique_index_to_roles_and_permissions_name_columns.php.stub
+++ b/resources/migrations/add_unique_index_to_roles_and_permissions_name_columns.php.stub
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddUniqueIndexToRolesAndPermissionsNameColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $config = config('laravel-permission.table_names');
+
+        Schema::table($config['roles'], function (Blueprint $table) {
+            $table->unique('name');
+        });
+
+        Schema::table($config['permissions'], function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $config = config('laravel-permission.table_names');
+
+       Schema::table($config['roles'], function (Blueprint $table) {
+            $table->dropUnique('name');
+        });
+
+        Schema::table($config['permissions'], function (Blueprint $table) {
+            $table->dropUnique('name');
+        });
+    }
+}

--- a/resources/migrations/create_permission_tables.php.stub
+++ b/resources/migrations/create_permission_tables.php.stub
@@ -16,13 +16,13 @@ class CreatePermissionTables extends Migration
 
         Schema::create($config['roles'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->unique();
             $table->timestamps();
         });
 
         Schema::create($config['permissions'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->unique();
             $table->timestamps();
         });
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -45,7 +45,7 @@ class PermissionServiceProvider extends ServiceProvider
             $this->migrations[dirname(__DIR__) . '/resources/migrations/create_permission_tables.php.stub'] = $this->app->databasePath() . '/migrations/' . $timestamp . '_create_permission_tables.php';
         }
 
-        if (!class_exists('AddUniqueIndexToRolesAndPermissionsNameColumns')) {
+        if (!class_exists('AddUniqueIndexToRolesAndPermissionsNameColumns') && class_exists('CreatePermissionTables')) {
             $this->migrations[dirname(__DIR__) . '/resources/migrations/add_unique_index_to_roles_and_permissions_name_columns.php.stub'] = $this->app->databasePath() . '/migrations/' . $timestamp . '_add_unique_index_to_roles_and_permissions_name_columns.php';
         }
     }


### PR DESCRIPTION
I've changed the migration to make the names column unique and added a second migration for updating users. Not sure if that's worth the trouble or not but there it is. The second migration only gets published if the first migration has previously been created.