### PR TITLE
Adding hasPermissionTo on role model

### DIFF
--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -26,4 +26,13 @@ interface Role
      * @throws RoleDoesNotExist
      */
     public static function findByName($name);
+
+    /**
+     * Determine if the user may perform the given permission.
+     *
+     * @param string|Permission $permission
+     *
+     * @return bool
+     */
+    public function hasPermissionTo($permission);
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\Contracts\Role as RoleContract;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
@@ -62,7 +63,7 @@ class Role extends Model implements RoleContract
      * Find a role by its name.
      *
      * @param string $name
-     * 
+     *
      * @return Role
      *
      * @throws RoleDoesNotExist
@@ -76,5 +77,25 @@ class Role extends Model implements RoleContract
         }
 
         return $role;
+    }
+
+    /**
+     * Determine if the user may perform the given permission.
+     *
+     * @param string|Permission $permission
+     *
+     * @return bool
+     */
+    public function hasPermissionTo($permission)
+    {
+        if (is_string($permission)) {
+            try {
+                $permission = app(Permission::class)->findByName($permission);
+            } catch (PermissionDoesNotExist $e) {
+                return false;
+            }
+        }
+
+        return $this->permissions->contains('id', $permission->id);
     }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -1,0 +1,24 @@
+<?php namespace Spatie\Permission\Test;
+
+class RoleTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testRole->givePermissionTo($this->testPermission);
+    }
+
+    /** @test */
+    public function it_returns_true_if_role_has_permission()
+    {
+        $this->assertTrue($this->testRole->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_returns_false_if_role_has_not_permission()
+    {
+        $this->assertFalse($this->testRole->hasPermissionTo('some-fake-permission'));
+    }
+}
+


### PR DESCRIPTION
Adding hasPermissionTo on role model with tests.

Edit:

I see the coverage on the Role model is 82% from phpstorm and 80% from travis gui (funny there's a difference). However the `hasPermissionTo` method is fully tested, according to phpstorm, it's the `users` method that isn't tested.