### PR TITLE
Update middleware example, to allow for multiple roles in routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,15 +395,23 @@ public function handle($request, Closure $next, $role, $permission)
         return redirect($urlOfYourLoginPage);
     }
 
-    if (! $request->user()->hasRole($role)) {
-       abort(403);
-    }
-    
-    if (! $request->user()->can($permission)) {
-       abort(403);
+    $roles = explode('|', $role);
+    if (! $request->user()->hasAnyRole($roles)) {
+        abort(403);
     }
 
-    return $next($request);
+    if ($permission === 'null') {
+        return $next($request);
+    }
+
+    $permissions = explode('|', $permission);
+    foreach($permissions as $permission) {
+        if ($request->user()->hasPermissionTo($permission)) {
+            return $next($request);
+        }
+    }
+
+    abort(403);
 }
 ```
 


### PR DESCRIPTION
I ran into a situation where I needed my middleware to handle some loosely-related permission/role combinations, so I opted to add a `|` to delineate between possible choices, and then loop over those options.

Examples of usage (in `routes.php` or `routes/web.php` or in controllers with `$this->middleware`):

1: `['middleware' => ['role:Level 1|Level 2|Level 5|Admin,null']]`

Passes if user has any `role` from the list of `Level 1`, `Level 2`, `Level 5` or `Admin`, regardless of any permissions (described here by the word `null`)

2: `['middleware' => ['role:Admin, add user|edit user']]`

Passes if user has `Admin` role, or either of these permissions: `add user` or `edit user`: