### PR TITLE
Mention the name of the published config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can publish the config-file with:
 php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
 ```
 
-This is the contents of the published config file:
+This is the contents of the published config file (laravel-permission.php):
 
 ```php
 return [


### PR DESCRIPTION
Following the (great!) installation instructions, but had to stop and check what was the name of the file published. Maybe adding it to the docs may help others? Thought about adding a comment `// config/laravel-permission.php`, but thought the ()'s would be better for this case maybe?

Thanks for laravel-permission, great job! 
Bruno