### PR TITLE
adds getMainRole method in hasRole Trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ A `Role` and a `Permission` are regular Eloquent-models. They can have a name an
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 
-$role = Role::create(['name' => 'writer']);
+$role = Role::create(['name' => 'writer','level' => 200]);
 $permission = Permission::create(['name' => 'edit articles']);
 ```
 
@@ -308,7 +308,12 @@ You can also determine if a user has all of a given list of roles:
 ```php
 $user->hasAllRoles(Role::all());
 ```
+You can also get the main (highest) role of a user, which returns a
+`Spatie\Permission\Models\Role`-object:
 
+```php
+$user->getMainRole();
+```
 The `assignRole`, `hasRole`, `hasAnyRole`, `hasAllRoles`  and `removeRole`-functions can accept a
  string, a `Spatie\Permission\Models\Role`-object or an `\Illuminate\Support\Collection`-object.
 

--- a/resources/migrations/create_permission_tables.php.stub
+++ b/resources/migrations/create_permission_tables.php.stub
@@ -17,6 +17,7 @@ class CreatePermissionTables extends Migration
         Schema::create($config['roles'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name')->unique();
+            $table->integer('level')->unsigned()->default(0);
             $table->timestamps();
         });
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -45,6 +45,7 @@ trait HasRoles
     {
         return $this->roles->orderByDesc('level')->first();
     }
+
     /**
      * Assign the given role to the user.
      *

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -37,6 +37,15 @@ trait HasRoles
     }
 
     /**
+     * get the main (highest) role of this user
+     *
+     * @return Role
+     */
+    public function getMainRole()
+    {
+        return $this->roles->orderByDesc('level')->first();
+    }
+    /**
      * Assign the given role to the user.
      *
      * @param array|string|\Spatie\Permission\Models\Role ...$roles


### PR DESCRIPTION
- Adds getMainRole method to the hasRole trait in order to get the main (highest) role of a user
- Adds an extra column to the create_permission_table.php.stub to make the level column available
- Updates the README to demonstrate the functionality, both adding a role with a level and retrieving the main role of the user.