### PR TITLE
Call to a member function compileSelect() on null

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -28,6 +28,12 @@ class PermissionServiceProvider extends ServiceProvider
             ], 'migrations');
         }
 
+        $this->mergeConfigFrom(
+            __DIR__.'/../resources/config/laravel-permission.php',
+            'laravel-permission'
+        );
+        $this->registerModelBindings();
+
         $permissionLoader->registerPermissions();
     }
 
@@ -36,10 +42,6 @@ class PermissionServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../resources/config/laravel-permission.php', 'laravel-permission');
-
-        $this->registerModelBindings();
-
         $this->registerBladeExtensions();
     }
 


### PR DESCRIPTION
Hi,

I'm trying to extend this package for support mongodb/moloquent using EmbedsMany relationships. This is the repo https://github.com/fahmiardi/laravel-mongodb-permission

But, when I want to publish the config, I've got this message
```bash
[Symfony\Component\Debug\Exception\FatalThrowableError]
Call to a member function compileSelect() on null
```

I think, I know the problem. With move the register model bindings before permission registrar, I solve this issue.

Please accept my PR.

Thanks.