### PR TITLE
Changed link to Laravel-auth to include Laravel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can test if a user has a permission with Laravel's default `can`-function.
 $user->can('edit articles');
 ```
 
-If you want a drop-in middleware to check permissions, check out our authorize package: https://github.com/spatie/laravel-authorize
+If you are using a Laravel version lower than 5.2.28, and want a drop-in middleware to check permissions, check out our authorize package: https://github.com/spatie/laravel-authorize
 
 Spatie is webdesign agency in Antwerp, Belgium. You'll find an overview of all 
 our open source projects [on our website](https://spatie.be/opensource).


### PR DESCRIPTION
The Laravel-authorize package is not needed on 5.2.28 and later, so i clarified that in the readme.