### PR TITLE
More verbose exceptions

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -52,7 +52,7 @@ class PermissionRegistrar
             return true;
         } catch (Exception $e) {
             Log::alert('Could not register permissions');
-            Log::alert(get_class($e). ': '.$e->getMessage());
+            Log::alert(get_class($e).': '.$e->getMessage());
 
             return false;
         }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -52,6 +52,7 @@ class PermissionRegistrar
             return true;
         } catch (Exception $e) {
             Log::alert('Could not register permissions');
+            Log::alert(get_class($e). ': '.$e->getMessage());
 
             return false;
         }


### PR DESCRIPTION
Any system exceptions fail silently. For example, if you have wrong database password, your log will just say "could not register permissions" instead of showing the query exception. There could be a better way to catch this exception, this is just what worked for me in my project.