### PR TITLE
Ambiguous id in query

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -65,7 +65,7 @@ trait HasRoles
         return $query->whereHas('roles', function ($query) use ($roles) {
             $query->where(function ($query) use ($roles) {
                 foreach ($roles as $role) {
-                    $query->orWhere('id', $role->id);
+                    $query->orWhere(config('laravel-permission.table_names.roles').'.id', $role->id);
                 }
             });
         });


### PR DESCRIPTION
Sometimes SQL complains about an ambiguous `id` in some queries selecting models with certain roles. 

For example:
```sql
select count(*) as aggregate from "users" where exists (
select * from `roles` inner join `user_has_roles` on `roles`.`id` = `user_has_roles`.`role_id`
    where `users`.`id` = `user_has_roles`.`user_id` and (`id` = ? or `id` = ?)
) and `users`.`deleted_at` is null
```
In this query the `('id' = ? or 'id' = ?)` part could reference both `roles` and `user_has_roles`

This PR adds the table prefix for the `roles` table as configured in the config file.