### PR TITLE
Ignore .editorconfig when exporting the package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
+/.editorconfig      export-ignore


### PR DESCRIPTION
This way, the `.editorconfig` file doesn't get downloaded by the likes of Composer. It'll still be there when people want to contribute to the repository using `git clone` though 🙂 