### PR TITLE
hasPermissionTo() string param uses permissions cache

### DIFF
--- a/src/Contracts/Permission.php
+++ b/src/Contracts/Permission.php
@@ -23,7 +23,9 @@ interface Permission
      *
      * @param string $name
      *
-     * @throws PermissionDoesNotExist
+     * @throws \Spatie\Permission\Exceptions\PermissionDoesNotExist
+     *
+     * @return Permission
      */
     public static function findByName($name);
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -62,10 +62,12 @@ class Permission extends Model implements PermissionContract
      * @param string $name
      *
      * @throws PermissionDoesNotExist
+     *
+     * @return Permission
      */
     public static function findByName($name)
     {
-        $permission = static::where('name', $name)->first();
+        $permission = static::getPermissions()->where('name', $name)->first();
 
         if (! $permission) {
             throw new PermissionDoesNotExist();

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -74,7 +74,7 @@ class PermissionRegistrar
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected function getPermissions()
+    public function getPermissions()
     {
         return $this->cache->rememberForever($this->cacheKey, function () {
             return app(Permission::class)->with('roles')->get();

--- a/src/Traits/RefreshesPermissionCache.php
+++ b/src/Traits/RefreshesPermissionCache.php
@@ -28,4 +28,14 @@ trait RefreshesPermissionCache
     {
         app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
+
+    /**
+     * Get the current cached permissions.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    protected static function getPermissions()
+    {
+        return app(PermissionRegistrar::class)->getPermissions();
+    }
 }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -93,4 +93,21 @@ class CacheTest extends TestCase
         $this->registrar->registerPermissions();
         $this->assertCount(5, DB::getQueryLog());
     }
+
+    /** @test */
+    public function has_permission_to_should_use_the_cache()
+    {
+        $this->testRole->givePermissionTo(['edit-articles', 'edit-news']);
+        $this->testUser->assignRole('testRole');
+        $this->assertCount(6, DB::getQueryLog());
+
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+        $this->assertCount(10, DB::getQueryLog());
+
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));
+        $this->assertCount(10, DB::getQueryLog());
+
+        $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
+        $this->assertCount(10, DB::getQueryLog());
+    }
 }


### PR DESCRIPTION
I'm migrating a project from [zizaco/entrust](https://github.com/Zizaco/entrust/) because it:

* is sparingly maintained
* conflicts with gate policy authorization

I'm much happier with this package but I have performance issues on some pages with too many database queries. The use case is 10 different roles accessing pages that each request require dozens of permission checks (out of 180 potential permissions.). Some pages have over 100 duplicate queries because `hasPermissionTo()` for string arguments doesn't maintain a `Permission` model object cache.

Currently the cache is only used to configure authorization abilities on the container. This will also use that `Permission` collection cache to prevent further database queries on each `auth()->user()->can()` or Blade `@can()` use.

## Codes changes

* `PermissionRegistrar@getPermissions()` is now public, accessible in the `Permission` and `Role` models through the `RefreshesPermissionCache` trait.
* `Permission::findByName()` always fetches from the cache first, not directly from the database.

## Testing

I wanted to do:

```php
\Illuminate\Support\Facades\Cache::shouldReceive('rememberForever')
     ->with('spatie.permission.cache')
     ->andReturn(EloquentCollection::make([$permission]));
```

But it looks like Mockery wasn't pulled in as a dev dependency for this project. I still wanted to write it in a way that the database is never referenced so let me know if you want me to re-implement it a different way.

Cheers,
Derek