### PR TITLE
Filter out duplicate roles and permissions

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -17,6 +17,7 @@ trait HasPermissions
     {
         $permissions = collect($permissions)
             ->flatten()
+            ->unique()
             ->map(function ($permission) {
                 return $this->getStoredPermission($permission);
             })

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -82,6 +82,7 @@ trait HasRoles
     {
         $roles = collect($roles)
             ->flatten()
+            ->unique()
             ->map(function ($role) {
                 return $this->getStoredRole($role);
             })

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -422,6 +422,18 @@ class HasRolesTest extends TestCase
         );
     }
 
+    /** @test */
+    public function it_filters_out_duplicate_roles_and_permissions()
+    {
+        $this->testUser->assignRole(['testRole', 'testRole2', 'testRole2']);
+        $this->testUser->givePermissionTo($this->testPermission, $this->testPermission);
+        $this->testRole->givePermissionTo($this->testPermission, $this->testPermission);
+
+        $this->assertCount(2, $this->testUser->roles()->get());
+        $this->assertCount(1, $this->testUser->getAllPermissions());
+        $this->assertCount(1, $this->testRole->permissions()->get());
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
This will prevent 'Integrity constraint violation' QueryException on `user_has_roles`, `user_has_permissions` and `role_has_permissions` tables.