### PR TITLE
Add support for role's id for hasRole

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -127,6 +127,10 @@ trait HasRoles
      */
     public function hasRole($roles)
     {
+        if (is_numeric($roles)) {
+            return $this->roles->contains('id', $roles);
+        }
+
         if (is_string($roles)) {
             return $this->roles->contains('name', $roles);
         }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -121,13 +121,13 @@ trait HasRoles
     /**
      * Determine if the user has (one of) the given role(s).
      *
-     * @param string|array|Role|\Illuminate\Support\Collection $roles
+     * @param int|string|array|Role|\Illuminate\Support\Collection $roles
      *
      * @return bool
      */
     public function hasRole($roles)
     {
-        if (is_numeric($roles)) {
+        if (is_int($roles)) {
             return $this->roles->contains('id', $roles);
         }
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -466,17 +466,17 @@ class HasRolesTest extends TestCase
         $role = $roleModel->create(['name' => 'role name']);
         $this->testUser->assignRole($role->name);
 
-        $this->assertFalse($this->testUser->hasRole('e2' . $role->id));
-        $this->assertFalse($this->testUser->hasRole($role->id . 'e2'));
+        $this->assertFalse($this->testUser->hasRole('e2'.$role->id));
+        $this->assertFalse($this->testUser->hasRole($role->id.'e2'));
 
-        $roleStartsWithE2 = $roleModel->create(['name' => 'e2' . $role->id]);
-        $roleEndsWithE2 = $roleModel->create(['name' => $role->id . 'e2']);
+        $roleStartsWithE2 = $roleModel->create(['name' => 'e2'.$role->id]);
+        $roleEndsWithE2 = $roleModel->create(['name' => $role->id.'e2']);
 
         $this->testUser->assignRole($roleStartsWithE2->name, $roleEndsWithE2->name);
 
         $this->refreshTestUser();
 
-        $this->assertTrue($this->testUser->hasRole('e2' . $role->id));
-        $this->assertTrue($this->testUser->hasRole($role->id . 'e2'));
+        $this->assertTrue($this->testUser->hasRole('e2'.$role->id));
+        $this->assertTrue($this->testUser->hasRole($role->id.'e2'));
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -443,4 +443,40 @@ class HasRolesTest extends TestCase
             $this->testUser->hasPermission($this->testPermission)
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_can_check_role_by_id()
+    {
+        $roleModel = app(Role::class);
+        $role = $roleModel->create(['name' => 'i know name']);
+
+        $this->testUser->assignRole($role->name);
+        $this->assertTrue($this->testUser->hasRole($role->id));
+        $this->assertFalse($this->testUser->hasRole($role->id * -1));
+    }
+
+    /**
+     * @test
+     */
+    public function it_cant_check_role_by_id_if_id_is_not_an_integer()
+    {
+        $roleModel = app(Role::class);
+        $role = $roleModel->create(['name' => 'role name']);
+        $this->testUser->assignRole($role->name);
+
+        $this->assertFalse($this->testUser->hasRole('e2' . $role->id));
+        $this->assertFalse($this->testUser->hasRole($role->id . 'e2'));
+
+        $roleStartsWithE2 = $roleModel->create(['name' => 'e2' . $role->id]);
+        $roleEndsWithE2 = $roleModel->create(['name' => $role->id . 'e2']);
+
+        $this->testUser->assignRole($roleStartsWithE2->name, $roleEndsWithE2->name);
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasRole('e2' . $role->id));
+        $this->assertTrue($this->testUser->hasRole($role->id . 'e2'));
+    }
 }


### PR DESCRIPTION
Useful, if admin can rename roles, but can't remove from db.