### PR TITLE
Check for duplicates when adding new Roles and Permissions

### DIFF
--- a/src/Exceptions/PermissionAlreadyExists.php
+++ b/src/Exceptions/PermissionAlreadyExists.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class PermissionAlreadyExists extends InvalidArgumentException
+{
+    public static function create(string $permissionName, string $guardName)
+    {
+        return new static("A `{$permissionName}` permission already exists for guard `{$guardName}`.");
+    }
+}

--- a/src/Exceptions/RoleAlreadyExists.php
+++ b/src/Exceptions/RoleAlreadyExists.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class RoleAlreadyExists extends InvalidArgumentException
+{
+    public static function create(string $roleName, string $guardName)
+    {
+        return new static("A role `{$roleName}` already exists for guard `{$guardName}`.");
+    }
+}

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
@@ -18,13 +19,22 @@ class Permission extends Model implements PermissionContract
 
     public function __construct(array $attributes = [])
     {
-        if (empty($attributes['guard_name'])) {
-            $attributes['guard_name'] = config('auth.defaults.guard');
-        }
+        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
 
         $this->setTable(config('permission.table_names.permissions'));
+    }
+
+    public static function create(array $attributes = [])
+    {
+        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
+
+        if (static::getPermissions()->where('name', $attributes['name'])->where('guard_name', $attributes['guard_name'])->first()) {
+            throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
+        }
+
+        return static::query()->create($attributes);
     }
 
     /**

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -4,11 +4,11 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 
 class Permission extends Model implements PermissionContract

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -3,10 +3,10 @@
 namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -19,13 +20,22 @@ class Role extends Model implements RoleContract
 
     public function __construct(array $attributes = [])
     {
-        if (empty($attributes['guard_name'])) {
-            $attributes['guard_name'] = config('auth.defaults.guard');
-        }
+        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
 
         $this->setTable(config('permission.table_names.roles'));
+    }
+
+    public static function create(array $attributes = [])
+    {
+        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
+
+        if (static::where('name', $attributes['name'])->where('guard_name', $attributes['guard_name'])->first()) {
+            throw RoleAlreadyExists::create($attributes['name'], $attributes['guard_name']);
+        }
+
+        return static::query()->create($attributes);
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -59,17 +59,17 @@ class CacheTest extends TestCase
     public function role_creation_and_updating_should_flush_the_cache()
     {
         $role = app(Role::class)->create(['name' => 'new']);
-        $this->assertCount(1, DB::getQueryLog());
+        $this->assertCount(2, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(3, DB::getQueryLog());
+        $this->assertCount(4, DB::getQueryLog());
 
         $role->name = 'other name';
         $role->save();
-        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(5, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(6, DB::getQueryLog());
+        $this->assertCount(7, DB::getQueryLog());
     }
 
     /** @test */

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Exceptions\PermissionAlreadyExists;
+
+class PermissionTest extends TestCase
+{
+    /** @test */
+    public function it_throws_an_exception_when_the_permission_already_exists()
+    {
+        $this->expectException(PermissionAlreadyExists::class);
+
+        app(Permission::class)->create(['name' => 'test-permission']);
+        app(Permission::class)->create(['name' => 'test-permission']);
+    }
+}

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -3,9 +3,9 @@
 namespace Spatie\Permission\Test;
 
 use Spatie\Permission\Contracts\Role;
-use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 class RoleTest extends TestCase

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Test;
 
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
@@ -16,6 +17,15 @@ class RoleTest extends TestCase
         Permission::create(['name' => 'other-permission']);
 
         Permission::create(['name' => 'wrong-guard-permission', 'guard_name' => 'admin']);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_role_already_exists()
+    {
+        $this->expectException(RoleAlreadyExists::class);
+
+        app(Role::class)->create(['name' => 'test-role']);
+        app(Role::class)->create(['name' => 'test-role']);
     }
 
     /** @test */
@@ -45,8 +55,6 @@ class RoleTest extends TestCase
 
         $this->testUserRole->givePermissionTo($this->testAdminPermission);
     }
-
-    ///
 
     /** @test */
     public function it_can_be_given_multiple_permissions_using_an_array()


### PR DESCRIPTION
In v1 this was done through `UNIQUE` constraints but this is no longer possible since the combination of the `name` and `guard_name` columns must be unique.