### PR TITLE
Fix permission/role relation to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-permission` will be documented in this file
 
+## 2.1.2 - 2017-04-20
+
+- fix a bug where the `role()`/`permission()` relation to user models would be saved incorrectly
+- add `users()` relation on `Permission` and `Role`
+
 ## 2.0.2 - 2017-04-13
 
 - check for duplicates when adding new roles and permissions

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
     "autoload": {
         "psr-4": {
             "Spatie\\Permission\\": "src"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
@@ -45,6 +46,20 @@ class Permission extends Model implements PermissionContract
         return $this->belongsToMany(
             config('permission.models.role'),
             config('permission.table_names.role_has_permissions')
+        );
+    }
+
+    /**
+     * A permission belongs to some users of the model associated with its guard.
+     */
+    public function users(): MorphToMany
+    {
+        return $this->morphedByMany(
+            getModelForGuard($this->attributes['guard_name']),
+            'model',
+            config('permission.table_names.model_has_permissions'),
+            'permission_id',
+            'model_id'
         );
     }
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -9,6 +9,7 @@ use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Role extends Model implements RoleContract
@@ -46,6 +47,20 @@ class Role extends Model implements RoleContract
         return $this->belongsToMany(
             config('permission.models.permission'),
             config('permission.table_names.role_has_permissions')
+        );
+    }
+
+    /**
+     * A role belongs to some users of the model associated with its guard.
+     */
+    public function users(): MorphToMany
+    {
+        return $this->morphedByMany(
+            getModelForGuard($this->attributes['guard_name']),
+            'model',
+            config('permission.table_names.model_has_roles'),
+            'role_id',
+            'model_id'
         );
     }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -17,7 +17,7 @@ trait HasRoles
      */
     public function roles(): MorphToMany
     {
-        return $this->morphedByMany(
+        return $this->morphToMany(
             config('permission.models.role'),
             'model',
             config('permission.table_names.model_has_roles'),
@@ -31,7 +31,7 @@ trait HasRoles
      */
     public function permissions(): MorphToMany
     {
-        return $this->morphedByMany(
+        return $this->morphToMany(
             config('permission.models.permission'),
             'model',
             config('permission.table_names.model_has_permissions'),

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @param string $guard
+ *
+ * @return string|null
+ */
+function getModelForGuard(string $guard)
+{
+    return collect(config('auth.guards'))
+        ->map(function ($guard) {
+            return config("auth.providers.{$guard['provider']}.model");
+        })->get($guard);
+}

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -15,4 +15,30 @@ class PermissionTest extends TestCase
         app(Permission::class)->create(['name' => 'test-permission']);
         app(Permission::class)->create(['name' => 'test-permission']);
     }
+
+    /** @test */
+    public function it_belongs_to_a_guard()
+    {
+        $permission = app(Permission::class)->create(['name' => 'can-edit', 'guard_name' => 'admin']);
+
+        $this->assertEquals('admin', $permission->guard_name);
+    }
+
+    /** @test */
+    public function it_belongs_to_the_default_guard_by_default()
+    {
+        $this->assertEquals($this->app['config']->get('auth.defaults.guard'), $this->testUserPermission->guard_name);
+    }
+
+    /** @test */
+    public function it_has_user_models_of_the_right_class()
+    {
+        $this->testAdmin->givePermissionTo($this->testAdminPermission);
+
+        $this->testUser->givePermissionTo($this->testUserPermission);
+
+        $this->assertCount(1, $this->testUserPermission->users);
+        $this->assertTrue($this->testUserPermission->users->first()->is($this->testUser));
+        $this->assertInstanceOf(User::class, $this->testUserPermission->users->first());
+    }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -20,6 +20,18 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    public function it_has_user_models_of_the_right_class()
+    {
+        $this->testAdmin->assignRole($this->testAdminRole);
+
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertCount(1, $this->testUserRole->users);
+        $this->assertTrue($this->testUserRole->users->first()->is($this->testUser));
+        $this->assertInstanceOf(User::class, $this->testUserRole->users->first());
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_the_role_already_exists()
     {
         $this->expectException(RoleAlreadyExists::class);


### PR DESCRIPTION
- fix a bug where the `role()`/`permission()` relation to user models would be saved incorrectly
- add `users()` relation on `Permission` and `Role`

This fixes #270 and #269 