### PR TITLE
Add L5.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     "require": {
         "php" : ">=7.0",
         "illuminate/auth": "~5.4.0",
-        "illuminate/container": "~5.4.0",
-        "illuminate/contracts": "~5.4.0",
-        "illuminate/database": "~5.4.0"
+        "illuminate/container": "~5.4.0|5.5.*",
+        "illuminate/contracts": "~5.4.0|5.5.*",
+        "illuminate/database": "~5.4.0|5.5.*"
     },
     "require-dev": {
         "monolog/monolog": "^1.22",


### PR DESCRIPTION
Set support for L5.5-dev. For some reasons. Companies start building long term platforms. Building in L5.5-dev.

REF #315 