### PR TITLE
Allow the `guard_name` columns to be nullable.

### DIFF
--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -18,14 +18,14 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('guard_name');
+            $table->string('guard_name')->nullable();
             $table->timestamps();
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('guard_name');
+            $table->string('guard_name')->nullable();
             $table->timestamps();
         });
 


### PR DESCRIPTION
As per my comment here (https://github.com/spatie/laravel-permission/issues/335#issuecomment-314591736) I came across a problem where I couldn't create a role with the example in the readme (`$role = App\Role::create(['name' => 'writer']);`) as there was no text passed in for `guard_name`. This PR fixes this.