### PR TITLE
Bugfix HasRoles.php

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -218,13 +218,9 @@ trait HasRoles
      *
      * @return bool
      */
-    public function hasAnyPermission(...$permissions): bool
+    public function hasAnyPermission($permissions): bool
     {
-        if (is_array($permissions[0])) {
-            $permissions = $permissions[0];
-        }
-
-        foreach ($permissions as $permission) {
+        foreach ((array)$permissions as $permission) {
             if ($this->hasPermissionTo($permission)) {
                 return true;
             }


### PR DESCRIPTION
Issue happens on 7.1.7 when using variadic like: func(...$permissions) and then using this variable on a foreach. It does not split the array. This is an PHP bug for what I've seen.