### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         }
     ],
     "require": {
-        "php" : ">=7.0",
-        "illuminate/auth": "~5.4.0",
-        "illuminate/container": "~5.4.0",
-        "illuminate/contracts": "~5.4.0",
-        "illuminate/database": "~5.4.0"
+        "php": ">=7.0",
+        "illuminate/auth": "~5.4.0|~5.5.x-dev",
+        "illuminate/container": "~5.4.0|~5.5.x-dev",
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
+        "illuminate/database": "~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
         "monolog/monolog": "^1.22",
-        "orchestra/testbench": "~3.4.2",
-        "phpunit/phpunit" : "^6.0"
+        "orchestra/testbench": "~3.4.2|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/auth": "~5.4.0|~5.5.x-dev",
-        "illuminate/container": "~5.4.0|~5.5.x-dev",
-        "illuminate/contracts": "~5.4.0|~5.5.x-dev",
-        "illuminate/database": "~5.4.0|~5.5.x-dev"
+        "illuminate/auth": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/container": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/contracts": "~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/database": "~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "monolog/monolog": "^1.22",
-        "orchestra/testbench": "~3.4.2|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.2|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -57,3 +57,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-permission/phpunit.xml.dist

................................................................. 65 / 93 ( 69%)
............................                                      93 / 93 (100%)

Time: 1.25 minutes, Memory: 26.00MB

OK (93 tests, 182 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments