### PR TITLE
Added helpers to get the user's role names (nicely formatted and raw versions).

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -25,6 +25,7 @@ function getRoleNames(App\User $user): string
     if ($user) {
         return ucwords($user->roles->pluck('name')->implode(', '));
     }
+
     return '';
 }
 
@@ -40,5 +41,6 @@ function getRoleNamesRaw(App\User $user): string
     if ($user) {
         return $user->roles->pluck('name');
     }
+
     return '';
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,3 +12,33 @@ function getModelForGuard(string $guard)
             return config("auth.providers.{$guard['provider']}.model");
         })->get($guard);
 }
+
+/**
+ * Pass in a user instance, receive a nicely-formatted list of the user's roles.
+ *
+ * @param App\User $user
+ *
+ * @return string
+ */
+function getRoleNames(App\User $user): string
+{
+    if ($user) {
+        return ucwords($user->roles->pluck('name')->implode(', '));
+    }
+    return '';
+}
+
+/**
+ * Pass in a user instance, receive a raw list of the user's roles.
+ *
+ * @param App\User $user
+ *
+ * @return string
+ */
+function getRoleNamesRaw(App\User $user): string
+{
+    if ($user) {
+        return $user->roles->pluck('name');
+    }
+    return '';
+}

--- a/tests/RoleNamesTest.php
+++ b/tests/RoleNamesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+class RoleNamesTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $roleModel = app(Role::class);
+
+        $roleModel->create(['name' => 'member']);
+        $roleModel->create(['name' => 'writer']);
+        $roleModel->create(['name' => 'intern']);
+        $roleModel->create(['name' => 'super-admin']);
+    }
+
+    /** @test */
+    public function get_role_names_can_show_a_single_role_name()
+    {
+        $this->testUser->assignRole('member');
+        $this->assertSame(getRoleNames($this->testUser), 'Member');
+
+        $this->refreshTestUser();
+
+        $this->testUser->assignRole('super-admin');
+        $this->assertSame(getRoleNames($this->testUser), 'Super-admin');
+    }
+
+    /** @test */
+    public function get_role_names_can_show_multiple_role_names()
+    {
+        $this->testUser->assignRole('member');
+        $this->testUser->assignRole('writer');
+        $this->testUser->assignRole('intern');
+        $this->testUser->assignRole('super-admin');
+
+        $this->assertContains(getRoleNames($this->testUser), ['Member', 'Writer', 'Intern', 'Super-admin']);
+    }
+
+    /** @test */
+    public function get_role_names_raw_can_show_a_single_role_name()
+    {
+        $this->testUser->assignRole('member');
+        $this->assertSame(getRoleNames($this->testUser), '["member"]');
+
+        $this->refreshTestUser();
+
+        $this->testUser->assignRole('super-admin');
+        $this->assertSame(getRoleNames($this->testUser), '["super-admin"]');
+    }
+
+    /** @test */
+    public function get_role_names_raw_can_show_multiple_role_names()
+    {
+        $this->testUser->assignRole('member');
+        $this->testUser->assignRole('writer');
+        $this->testUser->assignRole('intern');
+        $this->testUser->assignRole('super-admin');
+
+        $this->assertContains(getRoleNames($this->testUser), ['["member"]', '["writer"]', '["intern"]', '["super-admin"]']);
+    }
+}

--- a/tests/RoleNamesTest.php
+++ b/tests/RoleNamesTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Permission\Test;
 
+use Spatie\Permission\Contracts\Role;
+
 class RoleNamesTest extends TestCase
 {
     public function setUp()


### PR DESCRIPTION
I've noticed a few users opening issues (e.g. #406 ) to get the user's role's names, and it's something I wanted to do myself, so here's how I did it. If this PR is not accepted then at least the code is here and may help someone else.

`getRoleNames()` will return a string like `'Member'`, or `'Member, Intern, Key-holder'`.

`getRoleNamesRaw()` will return a string like `'["member"]'` or `'["member", "key-holder"]'`.

Simply pass in an instance of `App\User` within a Blade template, e.g.:

```
{{ getRoleNames( Auth::user() ) }}
```

I've included tests but due to my inexperience with developing packages for Laravel, could not get them running.