### PR TITLE
README updated with Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,18 @@ $role->givePermissionTo('edit articles');
 $role->revokePermissionTo('edit articles');
 ```
 
+### DecryptException
+
+Working with a lot of permissions, your cache can grow quickly. When using the database cache driver, you might get a `DecryptException`. In that case, just change your cache migration file from:
+
+```php
+$table->text('value');
+```
+to:
+```php
+`$table->longText('value');
+```
+
 ## Need a UI?
 
 The package doesn't come with any screens out of the box, you should build that yourself. To get started check out [this extensive tutorial](https://scotch.io/tutorials/user-authorization-in-laravel-54-with-spatie-laravel-permission) by [Caleb Oki](http://www.caleboki.com/).


### PR DESCRIPTION
When using the database cache driver and a lot of permissions, the cache can't fit in the default laravel cache table. So you have to edit the migration file. Added some help under Troubleshooting.