### PR TITLE
Fixed issue with README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,9 +602,9 @@ keep the following things in mind:
 - Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
 - You can publish the configuration with this command:
 
-  ```bash
+```bash
  php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
-  ```
+```
   
   And update the `models.role` and `models.permission` values
 

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ keep the following things in mind:
 - You can publish the configuration with this command:
 
 ```bash
- php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
 ```
   
   And update the `models.role` and `models.permission` values


### PR DESCRIPTION
The extra spaces before the bash commands was messing up the README formatting in Github, so fixed that.