### PR TITLE
Role groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-permission` will be documented in this file
 
+## 2.4.1 -2017-08-05
+- Fix processing of pipe symbols in `@hasanyrole` and `@hasallroles` Blade directives
+
 ## 2.4.0 -2017-08-05
 - add `PermissionMiddleware` and `RoleMiddleware`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 All notable changes to `laravel-permission` will be documented in this file
 
-## 2.4.1 -2017-08-05
-- Fix processing of pipe symbols in `@hasanyrole` and `@hasallroles` Blade directives
+## 2.4.2 - 2017-08-11
+- automatically detach roles and permissions when a user gets deleted
+
+## 2.4.1 - 2017-08-05
+- fix processing of pipe symbols in `@hasanyrole` and `@hasallroles` Blade directives
 
 ## 2.4.0 -2017-08-05
 - add `PermissionMiddleware` and `RoleMiddleware`
 
 ## 2.3.2 - 2017-07-28
-- allow `hasAnyPmerission` to take an array of permissions
+- allow `hasAnyPermission` to take an array of permissions
 
 ## 2.3.1 - 2017-07-27
 - fix commands not using custom models
@@ -27,29 +30,23 @@ All notable changes to `laravel-permission` will be documented in this file
 - fixed a bug that didn't allow you to assign a role or permission when using multiple guards
 
 ## 2.1.4 - 2017-05-10
-
 - add `model_type` to the primary key of tables that use a polymorphic relationship
 
 ## 2.1.3 - 2017-04-21
-
 - fixed a bug where the role()/permission() relation to user models would be saved incorrectly
 - added users() relation on Permission and Role
 
 ## 2.1.2 - 2017-04-20
-
 - fix a bug where the `role()`/`permission()` relation to user models would be saved incorrectly
 - add `users()` relation on `Permission` and `Role`
 
 ## 2.0.2 - 2017-04-13
-
 - check for duplicates when adding new roles and permissions
 
 ## 2.0.1 - 2017-04-11
-
 - fix the order of the `foreignKey` and `relatedKey` in the relations
 
 ## 2.0.0 - 2017-04-10
-
 - cache expiration is now configurable and set to one day by default
 - roles and permissions can now be assigned to any model through the `HasRoles` trait
 - removed deprecated `hasPermission` method

--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ class User extends Authenticatable
 >class Page extends Model
 >{
 >    use HasRoles;
->    
+>
 >    protected $guard_name = 'web'; // or whatever guard you want to use
->    
+>
 >    // ...
 >}
 >```
@@ -217,7 +217,7 @@ The `HasRoles` adds Eloquent relationships to your models, which can be accessed
 
 ```php
 $permissions = $user->permissions;
-$roles = $user->roles()->pluck('name'); // Returns a collection
+$roles = $user->roles->pluck('name'); // Returns a collection
 ```
 
 The `HasRoles` also adds a scope to your models to scope the query to certain roles:

--- a/README.md
+++ b/README.md
@@ -600,10 +600,12 @@ keep the following things in mind:
 
 - Your `Role` model needs to implement the `Spatie\Permission\Contracts\Role` contract
 - Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
-- You must publish the configuration with this command:
+- You can publish the configuration with this command:
+
   ```bash
-  $ php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+ php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
   ```
+  
   And update the `models.role` and `models.permission` values
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -602,9 +602,9 @@ keep the following things in mind:
 - Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
 - You can publish the configuration with this command:
 
-  ```bash
- php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
-  ```
+```bash
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+```
   
   And update the `models.role` and `models.permission` values
 

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ This package is heavily based on [Jeffrey Way](https://twitter.com/jeffrey_way)'
 on [permissions and roles](https://laracasts.com/series/whats-new-in-laravel-5-1/episodes/16). His original code
 can be found [in this repo on GitHub](https://github.com/laracasts/laravel-5-roles-and-permissions-demo).
 
-Special thanks to [Alex Vanderbist](https://github.com/AlexVanderbist) who greatly helped with `v2`.
+Special thanks to [Alex Vanderbist](https://github.com/AlexVanderbist) who greatly helped with `v2`, and to [Chris Brown](https://github.com/drbyte) for his longtime support  helping us maintain the package.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,13 @@ Now add the service provider in `config/app.php` file:
 ];
 ```
 
-You can publish the migration with:
+You can publish [the migration](https://github.com/spatie/laravel-permission/blob/master/database/migrations/create_permission_tables.php.stub) with:
 
 ```bash
 php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"
 ```
 
-After the migration has been published you can create the role- and permission-tables by
-running the migrations:
+After the migration has been published you can create the role- and permission-tables by running the migrations:
 
 ```bash
 php artisan migrate
@@ -76,7 +75,7 @@ You can publish the config file with:
 php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
 ```
 
-These are the contents of the published `config/permission.php` config file:
+When published, [the `config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/master/config/permission.php) contains:
 
 ```php
 return [
@@ -170,7 +169,7 @@ return [
 
 ## Usage
 
-First add the `Spatie\Permission\Traits\HasRoles` trait to your User model(s):
+First add the `Spatie\Permission\Traits\HasRoles` trait to your `User` model(s):
 
 ```php
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -201,7 +200,7 @@ class User extends Authenticatable
 >```
 
 This package allows for users to be associated with permissions and roles. Every role is associated with multiple permissions.
-A `Role` and a `Permission` are regular Eloquent models. They have a name and can be created like this:
+A `Role` and a `Permission` are regular Eloquent models. They require a `name` and can be created like this:
 
 ```php
 use Spatie\Permission\Models\Role;
@@ -213,24 +212,30 @@ $permission = Permission::create(['name' => 'edit articles']);
 
 If you're using multiple guards the `guard_name` attribute needs to be set as well. Read about it in the [using multiple guards](#using-multiple-guards) section of the readme.
 
-The `HasRoles` adds Eloquent relationships to your models, which can be accessed directly or used as a base query:
+The `HasRoles` trait adds Eloquent relationships to your models, which can be accessed directly or used as a base query:
 
 ```php
+// get a list of all permissions directly assigned to the user
 $permissions = $user->permissions;
+
+// get all permissions inherited by the user via roles
+$permissions = $user->getAllPermissions();
+
+// get a collection of all defined roles
 $roles = $user->roles->pluck('name'); // Returns a collection
 ```
 
-The `HasRoles` also adds a scope to your models to scope the query to certain roles:
+The `HasRoles` trait also adds a scope to your models to scope the query to certain roles:
 
 ```php
-$users = User::role('writer')->get(); // Only returns users with the role 'writer'
+$users = User::role('writer')->get(); // Returns only users with the role 'writer'
 ```
 
 The scope can accept a string, a `\Spatie\Permission\Models\Role` object or an `\Illuminate\Support\Collection` object.
 
-### Using permissions
+### Using "direct" permissions (see below to use both roles and permissions)
 
-A permission can be given to any user with the `HasRoles` trait:
+A permission can be given to any user:
 
 ```php
 $user->givePermissionTo('edit articles');
@@ -273,15 +278,16 @@ test if a user has a permission with Laravel's default `can` function:
 $user->can('edit articles');
 ```
 
-### Using permissions and roles
+### Using permissions via roles
 
-A role can be assigned to any user with the `HasRoles` trait:
+A role can be assigned to any user:
 
 ```php
 $user->assignRole('writer');
 
 // You can also assign multiple roles at once
 $user->assignRole('writer', 'admin');
+// or as an array
 $user->assignRole(['writer', 'admin']);
 ```
 
@@ -294,7 +300,7 @@ $user->removeRole('writer');
 Roles can also be synced:
 
 ```php
-// All current roles will be removed from the user and replace by the array given
+// All current roles will be removed from the user and replaced by the array given
 $user->syncRoles(['writer', 'admin']);
 ```
 
@@ -340,16 +346,13 @@ $role->revokePermissionTo('edit articles');
 The `givePermissionTo` and `revokePermissionTo` functions can accept a
 string or a `Spatie\Permission\Models\Permission` object.
 
-Saved permission and roles are also registered with the `Illuminate\Auth\Access\Gate` class.
+
+Permissions are inherited from roles automatically. 
+Additionally, individual permissions can be assigned to the user too. 
+For instance:
 
 ```php
-$user->can('edit articles');
-```
-
-All permissions of roles that user is assigned to are inherited to the
-user automatically. In addition to these permissions particular permission can be assigned to the user too. For instance:
-
-```php
+$role = Role::findByName('writer');
 $role->givePermissionTo('edit articles');
 
 $user->assignRole('writer');
@@ -357,48 +360,55 @@ $user->assignRole('writer');
 $user->givePermissionTo('delete articles');
 ```
 
-In above example a role is given permission to edit articles and this role is assigned to a user. Now user can edit articles and additionally delete articles. The permission of 'delete articles' is his direct permission because it is assigned directly to him. When we call `$user->hasDirectPermission('delete articles')` it returns `true` and `false` for `$user->hasDirectPermission('edit articles')`.
+In the above example a role is given permission to edit articles and this role is assigned to a user. 
+Now the user can edit articles and additionally delete articles. The permission of 'delete articles' is the user's direct permission because it is assigned directly to them.
+When we call `$user->hasDirectPermission('delete articles')` it returns `true`, 
+but `false` for `$user->hasDirectPermission('edit articles')`.
 
-This method is useful if one has a form for setting permissions for roles and users in his application and want to restrict to change inherited permissions of roles of user, i.e. allowing to change only direct permissions of user.
+This method is useful if one builds a form for setting permissions for roles and users in an application and wants to restrict or change inherited permissions of roles of the user, i.e. allowing to change only direct permissions of the user.
 
-You can list all of theses permissions:
+You can list all of these permissions:
 
 ```php
 // Direct permissions
 $user->getDirectPermissions() // Or $user->permissions;
 
-// Permissions inherited from user's roles
+// Permissions inherited from the user's roles
 $user->getPermissionsViaRoles();
 
-// All permissions which apply on the user
+// All permissions which apply on the user (inherited and direct)
 $user->getAllPermissions();
 ```
 
-All theses responses are collections of `Spatie\Permission\Models\Permission` objects.
+All these responses are collections of `Spatie\Permission\Models\Permission` objects.
 
 If we follow the previous example, the first response will be a collection with the 'delete article' permission, the
 second will be a collection with the 'edit article' permission and the third will contain both.
 
 ### Using Blade directives
-This package also adds Blade directives to verify whether the currently logged in user has all or any of a given list of
-roles. Optionally you can pass in the `guard` that the check will be performed on as a second argument.
+This package also adds Blade directives to verify whether the currently logged in user has all or any of a given list of roles. 
 
+Optionally you can pass in the `guard` that the check will be performed on as a second argument.
+
+#### Blade and Roles
+Test for a specific role:
 ```php
 @role('writer')
-    I'm a writer!
+    I am a writer!
 @else
-    I'm not a writer...
+    I am not a writer...
 @endrole
 ```
-
+is the same as
 ```php
 @hasrole('writer')
-    I'm a writer!
+    I am a writer!
 @else
-    I'm not a writer...
+    I am not a writer...
 @endhasrole
 ```
 
+Test for any role in a list:
 ```php
 @hasanyrole(Role::all())
     I have one or more of these roles!
@@ -407,27 +417,41 @@ roles. Optionally you can pass in the `guard` that the check will be performed o
 @endhasanyrole
 // or
 @hasanyrole('writer|admin')
-    I have one or more of these roles!
+    I am either a writer or an admin or both!
 @else
     I have none of these roles...
 @endhasanyrole
 ```
+Test for all roles:
 
 ```php
 @hasallroles(Role::all())
     I have all of these roles!
 @else
-    I don't have all of these roles...
+    I do not have all of these roles...
 @endhasallroles
 // or
 @hasallroles('writer|admin')
-    I have all of these roles!
+    I am both a writer and an admin!
 @else
-    I don't have all of these roles...
+    I do not have all of these roles...
 @endhasallroles
 ```
 
-You can use Laravel's native `@can` directive to check if a user has a certain permission.
+#### Blade and Permissions
+This package doesn't add any permission-specific Blade directives. Instead, use Laravel's native `@can` directive to check if a user has a certain permission.
+
+```php
+@can('edit articles')
+  //
+@endcan
+```
+or
+```php
+@if(auth()->user()->can('edit articles') && $some_other_condition)
+  //
+@endif
+```
 
 ## Using multiple guards
 
@@ -437,31 +461,28 @@ However when using multiple guards they will act like namespaces for your permis
 
 ### Using permissions and roles with multiple guards
 
-By default the default guard (`auth.default.guard`) will be used as the guard for new permissions and roles. When creating permissions and roles for specific guards you'll have to specify their `guard_name` on the model:
+By default the default guard (`config('auth.default.guard')`) will be used as the guard for new permissions and roles. When creating permissions and roles for specific guards you'll have to specify their `guard_name` on the model:
 
 ```php
 // Create a superadmin role for the admin users
 $role = Role::create(['guard_name' => 'admin', 'name' => 'superadmin']);
 
-// Define a `create posts` permission for the admin users beloninging to the admin guard
-$permission = Permission::create(['guard_name' => 'admin', 'name' => 'create posts']);
+// Define a `publish articles` permission for the admin users belonging to the admin guard
+$permission = Permission::create(['guard_name' => 'admin', 'name' => 'publish articles']);
 
-// Define a different `create posts` permission for the regular users belonging to the web guard
-$permission = Permission::create(['guard_name' => 'web', 'name' => 'create posts']);
+// Define a *different* `publish articles` permission for the regular users belonging to the web guard
+$permission = Permission::create(['guard_name' => 'web', 'name' => 'publish articles']);
 ```
 
-This is how you can check if a user has permission for a specific guard:
+To check if a user has permission for a specific guard:
 
 ```php
-$permissionName = 'edit articles';
-$guardName = 'api';
-
-$user->hasPermissionTo($permissionName, $guardName);
+$user->hasPermissionTo('publish articles', 'admin');
 ```
 
 ### Assigning permissions and roles to guard users
 
-You can use the same methods to assign permissions and roles to users as described above in [using permissions and roles](#using-permissions-and-roles). Just make sure the `guard_name`s on the permission or role match the guard of the user, otherwise a `GuardDoesNotMatch` exception will be thrown.
+You can use the same methods to assign permissions and roles to users as described above in [using permissions via roles](#using-permissions-via-roles). Just make sure the `guard_name` on the permission or role matches the guard of the user, otherwise a `GuardDoesNotMatch` exception will be thrown.
 
 ### Using blade directives with multiple guards
 
@@ -469,9 +490,9 @@ You can use all of the blade directives listed in [using blade directives](#usin
 
 ```php
 @role('super-admin', 'admin')
-    I'm a super-admin!
+    I am a super-admin!
 @else
-    I'm not a super-admin...
+    I am not a super-admin...
 @endrole
 ```
 
@@ -487,20 +508,28 @@ protected $routeMiddleware = [
 ];
 ```
 
-Now you can protect your routes using the middleware you just set up:
+Then you can protect your routes using middleware rules:
 
 ```php
-Route::group(['middleware' => ['role:admin']], function () {
+Route::group(['middleware' => ['role:super-admin']], function () {
     //
 });
 
-Route::group(['middleware' => ['permission:access_backend']], function () {
+Route::group(['middleware' => ['permission:publish articles']], function () {
     //
 });
 
-Route::group(['middleware' => ['role:admin','permission:access_backend']], function () {
+Route::group(['middleware' => ['role:super-admin','permission:publish articles']], function () {
     //
 });
+```
+You can protect your controllers similarly, by setting desired middleware in the constructor:
+
+```php
+public function __construct
+{
+    $this->middleware(['role:super-admin','permission:publish articles']);
+}
 ```
 
 ## Using artisan commands
@@ -512,17 +541,17 @@ php artisan permission:create-role writer
 ```
 
 ```bash
-php artisan permission:create-permission edit-articles
+php artisan permission:create-permission 'edit articles'
 ```
 
-When creating permissions and roles for specific guards you'll can to specify the guard names as a second argument:
+When creating permissions and roles for specific guards you can specify the guard names as a second argument:
 
 ```bash
 php artisan permission:create-role writer web
 ```
 
 ```bash
-php artisan permission:create-permission edit-articles web
+php artisan permission:create-permission 'edit articles' web
 ```
 
 ## Database Seeding
@@ -546,17 +575,19 @@ Two notes about Database Seeding:
 	        app()['cache']->forget('spatie.permission.cache');
 
 	        // create permissions
-	        Permission::create(['name' => 'edit posts']);
-	        Permission::create(['name' => 'delete posts']);
-	        Permission::create(['name' => 'delete users']);
+	        Permission::create(['name' => 'edit articles']);
+	        Permission::create(['name' => 'delete articles']);
+	        Permission::create(['name' => 'publish articles']);
+	        Permission::create(['name' => 'unpublish articles']);
 
 	        // create roles and assign existing permissions
-	        $role = Role::create(['name' => 'Author']);
-	        $role->givePermissionTo('edit posts');
-	        $role->givePermissionTo('delete posts');
+	        $role = Role::create(['name' => 'writer']);
+	        $role->givePermissionTo('edit articles');
+	        $role->givePermissionTo('delete articles');
 
-	        $role = Role::create(['name' => 'Manager']);
-	        $role->givePermissionTo('delete users');
+	        $role = Role::create(['name' => 'admin']);
+	        $role->givePermissionTo('publish articles');
+	        $role->givePermissionTo('unpublish articles');
 	    }
 	}
 

--- a/config/permission.php
+++ b/config/permission.php
@@ -26,9 +26,28 @@ return [
 
         'role' => Spatie\Permission\Models\Role::class,
 
+        /*
+         * When using the "HasGroups" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your groups. Of course, it
+         * is often just the "Group" model but you may use whatever you like.
+         *
+         * The model you want to use as a Group model needs to implement the
+         * `Spatie\Permission\Contracts\Group` contract.
+         */
+
+        'group' => Spatie\Permission\Models\Group::class,
+
     ],
 
     'table_names' => [
+
+        /*
+         * When using the "HasGroups" trait from this package, we need to know which
+         * table should be used to retrieve your groups. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'groups' => 'role_groups',
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -69,6 +88,22 @@ return [
          */
 
         'role_has_permissions' => 'role_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_groups' => 'model_has_groups',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'group_has_permissions' => 'group_has_permissions',
     ],
 
     /*

--- a/config/permission.php
+++ b/config/permission.php
@@ -98,12 +98,20 @@ return [
         'model_has_groups' => 'model_has_groups',
 
         /*
-         * When using the "HasRoles" trait from this package, we need to know which
-         * table should be used to retrieve your roles permissions. We have chosen a
+         * When using the "HasGroups" trait from this package, we need to know which
+         * table should be used to retrieve your groups permissions. We have chosen a
          * basic default value but you may easily change it to any table you like.
          */
 
         'group_has_permissions' => 'group_has_permissions',
+
+        /*
+         * When using the "HasGroups" trait from this package, we need to know which
+         * table should be used to retrieve your groups permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'group_has_roles' => 'group_has_roles',
     ],
 
     /*

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -71,6 +71,60 @@ class CreatePermissionTables extends Migration
 
             $table->primary(['permission_id', 'role_id']);
         });
+
+        Schema::create('role_groups', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('description');
+            $table->string('guard_name');
+            $table->timestamps();
+        });
+
+        Schema::create('model_has_groups', function (Blueprint $table) {
+            $table->integer('group_id')->unsigned();
+            $table->morphs('model');
+
+            $table->foreign('group_id')
+                ->references('id')
+                ->on('role_groups')
+                ->onDelete('cascade');
+
+            $table->primary(['group_id', 'model_id', 'model_type']);
+        });
+
+        Schema::create('group_has_roles', function (Blueprint $table) {
+            $table->integer('group_id')->unsigned();
+            $table->integer('role_id')->unsigned();
+
+            $table->foreign('group_id')
+                ->references('id')
+                ->on('role_groups')
+                ->onDelete('cascade');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles')
+                ->onDelete('cascade');
+
+            $table->primary(['group_id', 'role_id']);
+        });
+
+        Schema::create('group_has_permissions', function (Blueprint $table) {
+            $table->integer('group_id')->unsigned();
+            $table->integer('permission_id')->unsigned();
+
+            $table->foreign('group_id')
+                ->references('id')
+                ->on('role_groups')
+                ->onDelete('cascade');
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on('permissions')
+                ->onDelete('cascade');
+
+            $table->primary(['group_id', 'permission_id']);
+        });
     }
 
     /**
@@ -85,7 +139,11 @@ class CreatePermissionTables extends Migration
         Schema::drop($tableNames['role_has_permissions']);
         Schema::drop($tableNames['model_has_roles']);
         Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['group_has_permissions']);
+        Schema::drop($tableNames['model_has_groups']);
         Schema::drop($tableNames['roles']);
         Schema::drop($tableNames['permissions']);
+        Schema::dropIfExists('groups');
+
     }
 }

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -18,7 +18,6 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('description')->nullable();
             $table->string('guard_name');
             $table->timestamps();
         });
@@ -26,7 +25,6 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['roles'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('description')->nullable();
             $table->string('guard_name');
             $table->timestamps();
         });

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -18,6 +18,7 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->string('description')->nullable();
             $table->string('guard_name');
             $table->timestamps();
         });
@@ -25,6 +26,7 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['roles'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
+            $table->string('description')->nullable();
             $table->string('guard_name');
             $table->timestamps();
         });

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -73,7 +73,6 @@ class CreatePermissionTables extends Migration
         Schema::create('role_groups', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->string('description');
             $table->string('guard_name');
             $table->timestamps();
         });

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -70,14 +70,14 @@ class CreatePermissionTables extends Migration
             $table->primary(['permission_id', 'role_id']);
         });
 
-        Schema::create('role_groups', function (Blueprint $table) {
+        Schema::create($tableNames['groups'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
         });
 
-        Schema::create('model_has_groups', function (Blueprint $table) {
+        Schema::create($tableNames['model_has_groups'], function (Blueprint $table) {
             $table->integer('group_id')->unsigned();
             $table->morphs('model');
 
@@ -89,7 +89,7 @@ class CreatePermissionTables extends Migration
             $table->primary(['group_id', 'model_id', 'model_type']);
         });
 
-        Schema::create('group_has_roles', function (Blueprint $table) {
+        Schema::create($tableNames['group_has_roles'], function (Blueprint $table) {
             $table->integer('group_id')->unsigned();
             $table->integer('role_id')->unsigned();
 
@@ -106,7 +106,7 @@ class CreatePermissionTables extends Migration
             $table->primary(['group_id', 'role_id']);
         });
 
-        Schema::create('group_has_permissions', function (Blueprint $table) {
+        Schema::create($tableNames['group_has_permissions'], function (Blueprint $table) {
             $table->integer('group_id')->unsigned();
             $table->integer('permission_id')->unsigned();
 
@@ -140,7 +140,7 @@ class CreatePermissionTables extends Migration
         Schema::drop($tableNames['model_has_groups']);
         Schema::drop($tableNames['roles']);
         Schema::drop($tableNames['permissions']);
-        Schema::dropIfExists('groups');
+        Schema::drop($tableNames['groups']);
 
     }
 }

--- a/src/Commands/CreateGroup.php
+++ b/src/Commands/CreateGroup.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\Permission\Models\Group;
+use Spatie\Permission\Contracts\Group as GroupContract;
+
+class CreateGroup extends Command
+{
+    protected $signature = 'permission:create-group
+        {name : The name of the group}
+        {guard? : The name of the guard}';
+
+    protected $description = 'Create a group';
+
+    public function handle()
+    {
+        $groupClass = app(GroupContract::class);
+
+        $group = $groupClass::create([
+            'name' => $this->argument('name'),
+            'guard_name' => $this->argument('guard'),
+        ]);
+
+        $this->info("Group `{$group->name}` created");
+    }
+}

--- a/src/Contracts/Group.php
+++ b/src/Contracts/Group.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Permission\Contracts;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+interface Group
+{
+    /**
+     * A group may be given various roles.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function roles(): BelongsToMany;
+
+    /**
+     * A group may be given various permissions.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function permissions(): BelongsToMany;
+
+    /**
+     * Find a group by its name and guard name.
+     *
+     * @param string $name
+     * @param string|null $guardName
+     *
+     * @return \Spatie\Permission\Contracts\Role
+     *
+     * @throws \Spatie\Permission\Exceptions\RoleDoesNotExist
+     */
+    public static function findByName(string $name, $guardName): Group;
+
+    /**
+     * Determine if the user may perform the given permission.
+     *
+     * @param string|\Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return bool
+     */
+    public function hasPermissionTo($permission): bool;
+}

--- a/src/Exceptions/GroupAlreadyExists.php
+++ b/src/Exceptions/GroupAlreadyExists.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class GroupAlreadyExists extends InvalidArgumentException
+{
+    public static function create(string $roleName, string $guardName)
+    {
+        return new static("A group `{$roleName}` already exists for guard `{$guardName}`.");
+    }
+}

--- a/src/Exceptions/GroupDoesNotExist.php
+++ b/src/Exceptions/GroupDoesNotExist.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class GroupDoesNotExist extends InvalidArgumentException
+{
+    public static function create(string $roleName)
+    {
+        return new static("There is no group named `{$roleName}`.");
+    }
+}

--- a/src/Middlewares/GroupMiddleware.php
+++ b/src/Middlewares/GroupMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Permission\Middlewares;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class GroupMiddleware
+{
+    public function handle($request, Closure $next, $role)
+    {
+        if (Auth::guest()) {
+            abort(403);
+        }
+
+        $role = is_array($role)
+            ? $role
+            : explode('|', $role);
+
+        if (! Auth::user()->hasAnyGroup($role)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -50,6 +50,17 @@ class Permission extends Model implements PermissionContract
     }
 
     /**
+     * A permission can be applied to groups.
+     */
+    public function groups(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            config('permission.models.group'),
+            config('permission.table_names.group_has_permissions')
+        );
+    }
+
+    /**
      * A permission belongs to some users of the model associated with its guard.
      */
     public function users(): MorphToMany

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -94,7 +94,7 @@ class Role extends Model implements RoleContract
      *
      * @return bool
      *
-     * @throws \Spatie\Permission\Exceptions\GuardMismatch
+     * @throws \Spatie\Permission\Exceptions\GuardDoesNotMatch
      */
     public function hasPermissionTo($permission): bool
     {

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -60,7 +60,7 @@ class PermissionRegistrar
     public function getPermissions(): Collection
     {
         return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () {
-            return app(Permission::class)->with('roles')->get();
+            return app(Permission::class)->with(['roles', 'groups'])->get();
         });
     }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
+use Spatie\Permission\Contracts\Group as GroupContract;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 
@@ -51,6 +52,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->app->bind(PermissionContract::class, $config['permission']);
         $this->app->bind(RoleContract::class, $config['role']);
+        $this->app->bind(GroupContract::class, $config['group']);
     }
 
     protected function registerBladeExtensions()
@@ -89,6 +91,41 @@ class PermissionServiceProvider extends ServiceProvider
                 return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
             });
             $bladeCompiler->directive('endhasallroles', function () {
+                return '<?php endif; ?>';
+            });
+            $bladeCompiler->directive('group', function ($arguments) {
+                list($group, $guard) = explode(',', $arguments.',');
+
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasGroup({$group})): ?>";
+            });
+            $bladeCompiler->directive('endgroup', function () {
+                return '<?php endif; ?>';
+            });
+
+            $bladeCompiler->directive('hasgroup', function ($arguments) {
+                list($group, $guard) = explode(',', $arguments.',');
+
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasGroup({$group})): ?>";
+            });
+            $bladeCompiler->directive('endhasgroup', function () {
+                return '<?php endif; ?>';
+            });
+
+            $bladeCompiler->directive('hasanygroup', function ($arguments) {
+                list($groups, $guard) = explode(',', $arguments.',');
+
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyGroup({$groups})): ?>";
+            });
+            $bladeCompiler->directive('endhasanygroup', function () {
+                return '<?php endif; ?>';
+            });
+
+            $bladeCompiler->directive('hasallgroups', function ($arguments) {
+                list($groups, $guard) = explode(',', $arguments.',');
+
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllGroups({$groups})): ?>";
+            });
+            $bladeCompiler->directive('endhasallgroups', function () {
                 return '<?php endif; ?>';
             });
         });

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -26,6 +26,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->commands([
+                Commands\CreateGroup::class,
                 Commands\CreateRole::class,
                 Commands\CreatePermission::class,
             ]);

--- a/src/Traits/HasGroups.php
+++ b/src/Traits/HasGroups.php
@@ -243,7 +243,7 @@ trait HasGroups
         {
             foreach ($group->roles as $role)
             {
-                if ($role->permissions->contain('id', $permission->id))
+                if ($role->permissions->contains('id', $permission->id))
                 {
                     return true;
                 }

--- a/src/Traits/HasGroups.php
+++ b/src/Traits/HasGroups.php
@@ -31,7 +31,7 @@ trait HasGroups
             'model',
             config('permission.table_names.model_has_groups'),
             'model_id',
-            'role_id'
+            'group_id'
         );
     }
 

--- a/src/Traits/HasGroups.php
+++ b/src/Traits/HasGroups.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Spatie\Permission\Traits;
+
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\Permission\Contracts\Group;
+use Spatie\Permission\Contracts\Permission;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+trait HasGroups
+{
+    use HasRoles;
+
+    public static function bootHasGroups()
+    {
+        static::deleting(function ($model) {
+            $model->groups()->detach();
+            $model->roles()->detach();
+            $model->permissions()->detach();
+        });
+    }
+
+    /**
+     * A model may have multiple groups.
+     */
+    public function groups(): MorphToMany
+    {
+        return $this->morphToMany(
+            config('permission.models.group'),
+            'model',
+            config('permission.table_names.model_has_groups'),
+            'model_id',
+            'role_id'
+        );
+    }
+
+    /**
+     * Scope the model query to certain groups only.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string|array|\Spatie\Permission\Contracts\Group|\Illuminate\Support\Collection $groups
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeGroup(Builder $query, $groups): Builder
+    {
+        if ($groups instanceof Collection) {
+            $groups = $groups->toArray();
+        }
+
+        if (! is_array($groups)) {
+            $groups = [$groups];
+        }
+
+        $groups = array_map(function ($group) {
+            if ($group instanceof Group) {
+                return $group;
+            }
+
+            return app(Group::class)->findByName($group, $this->getDefaultGuardName());
+        }, $groups);
+
+        return $query->whereHas('groups', function ($query) use ($groups) {
+            $query->where(function ($query) use ($groups) {
+                foreach ($groups as $group) {
+                    $query->orWhere(config('permission.table_names.groups').'.id', $group->id);
+                }
+            });
+        });
+    }
+
+    /**
+     * Assign the given group to the model.
+     *
+     * @param array|string|\Spatie\Permission\Contracts\Group ...$groups
+     *
+     * @return $this
+     */
+    public function assignGroup(...$groups)
+    {
+        $groups = collect($groups)
+            ->flatten()
+            ->map(function ($group) {
+                return $this->getStoredGroup($group);
+            })
+            ->each(function ($group) {
+                $this->ensureModelSharesGuard($group);
+            })
+            ->all();
+
+        $this->groups()->saveMany($groups);
+
+        $this->forgetCachedPermissions();
+
+        return $this;
+    }
+
+    /**
+     * Revoke the given group from the model.
+     *
+     * @param string|\Spatie\Permission\Contracts\Group ...$group
+     */
+    public function removeGroup($group)
+    {
+        $this->groups()->detach($this->getStoredGroup($group));
+    }
+
+    /**
+     * Remove all current groups and set the given ones.
+     *
+     * @param array|\Spatie\Permission\Contracts\Group ...$groups
+     *
+     * @return $this
+     */
+    public function syncGroups(...$groups)
+    {
+        $this->groups()->detach();
+
+        return $this->assignGroup($groups);
+    }
+
+    /**
+     * Determine if the model has (one of) the given group(s).
+     *
+     * @param string|array|\Spatie\Permission\Contracts\Group|\Illuminate\Support\Collection $groups
+     *
+     * @return bool
+     */
+    public function hasGroup($groups): bool
+    {
+        if (is_string($groups) && false !== strpos($groups, '|')) {
+            $groups = $this->convertPipeToArray($groups);
+        }
+
+        if (is_string($groups)) {
+            return $this->groups->contains('name', $groups);
+        }
+
+        if ($groups instanceof Group) {
+            return $this->groups->contains('id', $groups->id);
+        }
+
+        if (is_array($groups)) {
+            foreach ($groups as $group) {
+                if ($this->hasGroup($group)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $groups->intersect($this->groups)->isNotEmpty();
+    }
+
+    /**
+     * Determine if the model has any of the given group(s).
+     *
+     * @param string|array|\Spatie\Permission\Contracts\Group|\Illuminate\Support\Collection $groups
+     *
+     * @return bool
+     */
+    public function hasAnyGroup($groups): bool
+    {
+        return $this->hasGroup($groups);
+    }
+
+    /**
+     * Determine if the model has all of the given group(s).
+     *
+     * @param string|\Spatie\Permission\Contracts\Group|\Illuminate\Support\Collection $groups
+     *
+     * @return bool
+     */
+    public function hasAllGroups($groups): bool
+    {
+        if (is_string($groups) && false !== strpos($groups, '|')) {
+            $groups = $this->convertPipeToArray($groups);
+        }
+
+        if (is_string($groups)) {
+            return $this->groups->contains('name', $groups);
+        }
+
+        if ($groups instanceof Group) {
+            return $this->groups->contains('id', $groups->id);
+        }
+
+        $groups = collect()->make($groups)->map(function ($group) {
+            return $group instanceof Group ? $group->name : $group;
+        });
+
+        return $groups->intersect($this->groups->pluck('name')) == $groups;
+    }
+
+    /**
+     * Determine if the model may perform the given permission.
+     *
+     * @param string|\Spatie\Permission\Contracts\Permission $permission
+     * @param string|null $guardName
+     *
+     * @return bool
+     */
+    public function hasPermissionTo($permission, $guardName = null): bool
+    {
+        if (is_string($permission)) {
+            $permission = app(Permission::class)->findByName(
+                $permission,
+                $guardName ?? $this->getDefaultGuardName()
+            );
+        }
+
+        return $this->hasDirectPermission($permission)
+            || $this->hasPermissionViaRole($permission)
+            || $this->hasPermissionViaGroup($permission)
+            || $this->hasPermissionViaGroupRoles($permission);
+    }
+
+    /**
+     * Determine if the model has, via groups, the given permission.
+     *
+     * @param \Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return bool
+     */
+    protected function hasPermissionViaGroup(Permission $permission): bool
+    {
+
+        return $this->hasGroup($permission->groups);
+    }
+
+    /**
+     * Determine if the model has, via roles, the given permission.
+     *
+     * @param \Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return bool
+     */
+    protected function hasPermissionViaGroupRoles(Permission $permission): bool
+    {
+        foreach ($this->groups as $group)
+        {
+            foreach ($group->roles as $role)
+            {
+                if ($role->permissions->contain('id', $permission->id))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return all the permissions the model has via groups.
+     */
+    public function getPermissionsViaGroups(): Collection
+    {
+        return $this->load('groups', 'groups.permissions')
+            ->groups->flatMap(function ($group) {
+                return $group->permissions;
+            })->sort()->values();
+    }
+
+    /**
+     * Return all the permissions the model has via roles in groups.
+     */
+    public function getPermissionsViaGroupRoles(): Collection
+    {
+        $c = new Collection();
+        foreach ($this->groups as $group)
+        {
+            foreach ($group->roles as $role)
+            {
+                $p = $role->load('roles', 'roles.permissions')
+                    ->roles->flatMap(function ($role) {
+                        return $role->permissions;
+                    });
+                $c->merge($p);
+            }
+        }
+
+        return $c->sort()->values();
+    }
+
+    /**
+     * Return all the permissions the model has, both directly, via roles, via groups and via roles in groups.
+     */
+    public function getAllPermissions(): Collection
+    {
+        return $this->permissions
+            ->merge($this->getPermissionsViaRoles())
+            ->merge($this->getPermissionsViaGroups())
+            ->merge($this->getPermissionsViaGroupRoles())
+            ->sort()
+            ->values();
+    }
+
+    protected function getStoredGroup($group): Group
+    {
+        if (is_string($group)) {
+            return app(Group::class)->findByName($group, $this->getDefaultGuardName());
+        }
+
+        return $group;
+    }
+}

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -14,15 +14,9 @@ trait HasRoles
 
     public static function bootHasRoles()
     {
-        // Delete associated relations roles/permissions
         static::deleting(function ($model) {
             $model->roles()->detach();
             $model->permissions()->detach();
-        });
-
-        // Eager load relations by default
-        static::addGlobalScope('relations', function (Builder $builder) {
-            $builder->with(['roles', 'permissions']);
         });
     }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -12,6 +12,20 @@ trait HasRoles
 {
     use HasPermissions;
 
+    public static function bootHasRoles()
+    {
+        // Delete associated relations roles/permissions
+        static::deleting(function ($model) {
+            $model->roles()->detach();
+            $model->permissions()->detach();
+        });
+
+        // Eager load relations by default
+        static::addGlobalScope('relations', function (Builder $builder) {
+            $builder->with(['roles', 'permissions']);
+        });
+    }
+
     /**
      * A model may have multiple roles.
      */

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -341,4 +341,30 @@ trait HasRoles
 
         return explode('|', trim($pipeString, $quoteCharacter));
     }
+
+    /**
+     * Grant the given role(s) to a group.
+     *
+     * @param string|array|\Spatie\Permission\Contracts\Group|\Illuminate\Support\Collection $roles
+     *
+     * @return $this
+     */
+    public function giveRoleTo(...$roles)
+    {
+        $roles = collect($roles)
+            ->flatten()
+            ->map(function ($role) {
+                return $this->getStoredRole($role);
+            })
+            ->each(function ($role) {
+                $this->ensureModelSharesGuard($role);
+            })
+            ->all();
+
+        $this->roles()->saveMany($roles);
+
+        $this->forgetCachedPermissions();
+
+        return $this;
+    }
 }

--- a/src/Traits/RefreshesPermissionCache.php
+++ b/src/Traits/RefreshesPermissionCache.php
@@ -9,11 +9,7 @@ trait RefreshesPermissionCache
 {
     public static function bootRefreshesPermissionCache()
     {
-        static::created(function (Model $model) {
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-        });
-
-        static::updated(function (Model $model) {
+        static::saved(function (Model $model) {
             app(PermissionRegistrar::class)->forgetCachedPermissions();
         });
 

--- a/tests/Admin.php
+++ b/tests/Admin.php
@@ -3,7 +3,7 @@
 namespace Spatie\Permission\Test;
 
 use Illuminate\Auth\Authenticatable;
-use Spatie\Permission\Traits\HasRoles;
+use Spatie\Permission\Traits\HasGroups;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 
 class Admin extends Model implements AuthorizableContract, AuthenticatableContract
 {
-    use HasRoles, Authorizable, Authenticatable;
+    use HasGroups, Authorizable, Authenticatable;
 
     /**
      * The attributes that are mass assignable.

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -25,7 +25,7 @@ class CacheTest extends TestCase
 
         $this->registrar->registerPermissions();
 
-        $this->assertCount(2, DB::getQueryLog());
+        $this->assertCount(3, DB::getQueryLog());
 
         DB::flushQueryLog();
     }
@@ -45,14 +45,14 @@ class CacheTest extends TestCase
         $this->assertCount(1, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(3, DB::getQueryLog());
+        $this->assertCount(4, DB::getQueryLog());
 
         $permission->name = 'other name';
         $permission->save();
-        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(5, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(6, DB::getQueryLog());
+        $this->assertCount(8, DB::getQueryLog());
     }
 
     /** @test */
@@ -62,14 +62,14 @@ class CacheTest extends TestCase
         $this->assertCount(2, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(4, DB::getQueryLog());
+        $this->assertCount(5, DB::getQueryLog());
 
         $role->name = 'other name';
         $role->save();
-        $this->assertCount(5, DB::getQueryLog());
+        $this->assertCount(6, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(7, DB::getQueryLog());
+        $this->assertCount(9, DB::getQueryLog());
     }
 
     /** @test */
@@ -89,7 +89,7 @@ class CacheTest extends TestCase
         $this->assertCount(1, DB::getQueryLog());
 
         $this->registrar->registerPermissions();
-        $this->assertCount(3, DB::getQueryLog());
+        $this->assertCount(4, DB::getQueryLog());
     }
 
     /** @test */
@@ -100,12 +100,12 @@ class CacheTest extends TestCase
         $this->assertCount(4, DB::getQueryLog());
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
-        $this->assertCount(8, DB::getQueryLog());
+        $this->assertCount(9, DB::getQueryLog());
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));
-        $this->assertCount(8, DB::getQueryLog());
+        $this->assertCount(9, DB::getQueryLog());
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
-        $this->assertCount(8, DB::getQueryLog());
+        $this->assertCount(9, DB::getQueryLog());
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -3,11 +3,33 @@
 namespace Spatie\Permission\Test;
 
 use Artisan;
+use Spatie\Permission\Models\Group;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 
 class CommandTest extends TestCase
 {
+    /** @test */
+    public function it_can_create_a_group()
+    {
+        Artisan::call('permission:create-group', ['name' => 'new-group']);
+
+        $this->assertCount(1, Group::where('name', 'new-group')->get());
+    }
+
+    /** @test */
+    public function it_can_create_a_group_with_a_specific_guard()
+    {
+        Artisan::call('permission:create-group', [
+            'name' => 'new-group',
+            'guard' => 'api',
+        ]);
+
+        $this->assertCount(1, Group::where('name', 'new-group')
+            ->where('guard_name', 'api')
+            ->get());
+    }
+    
     /** @test */
     public function it_can_create_a_role()
     {

--- a/tests/GateTest.php
+++ b/tests/GateTest.php
@@ -59,4 +59,40 @@ class GateTest extends TestCase
 
         $this->assertFalse($this->testAdmin->can('edit-articles'));
     }
+
+    /** @test */
+    public function it_can_determine_if_a_user_has_a_permission_when_using_groups()
+    {
+        $this->testUserGroup->givePermissionTo($this->testUserPermission);
+
+        $this->testUser->assignGroup($this->testUserGroup);
+
+        $this->assertTrue($this->testUser->hasPermissionTo($this->testUserPermission));
+
+        $this->assertTrue($this->reloadPermissions());
+
+        $this->assertTrue($this->testUser->can('edit-articles'));
+
+        $this->assertFalse($this->testUser->can('non-existing-permission'));
+
+        $this->assertFalse($this->testUser->can('admin-permission'));
+    }
+
+    /** @test */
+    public function it_can_determine_if_a_user_with_a_different_guard_has_a_permission_when_using_groups()
+    {
+        $this->testAdminGroup->givePermissionTo($this->testAdminPermission);
+
+        $this->testAdmin->assignGroup($this->testAdminGroup);
+
+        $this->assertTrue($this->testAdmin->hasPermissionTo($this->testAdminPermission));
+
+        $this->assertTrue($this->reloadPermissions());
+
+        $this->assertTrue($this->testAdmin->can('admin-permission'));
+
+        $this->assertFalse($this->testAdmin->can('non-existing-permission'));
+
+        $this->assertFalse($this->testAdmin->can('edit-articles'));
+    }
 }

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Contracts\Group;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Spatie\Permission\Exceptions\GroupAlreadyExists;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+
+class GroupTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Permission::create(['name' => 'other-permission']);
+
+        Permission::create(['name' => 'wrong-guard-permission', 'guard_name' => 'admin']);
+    }
+
+    /** @test */
+    public function it_has_user_models_of_the_right_class()
+    {
+        $this->testAdmin->assignGroup($this->testAdminGroup);
+
+        $this->testUser->assignGroup($this->testUserGroup);
+
+        $this->assertCount(1, $this->testUserGroup->users);
+        $this->assertTrue($this->testUserGroup->users->first()->is($this->testUser));
+        $this->assertInstanceOf(User::class, $this->testUserGroup->users->first());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_group_already_exists()
+    {
+        $this->expectException(GroupAlreadyExists::class);
+
+        app(Group::class)->create(['name' => 'test-group']);
+        app(Group::class)->create(['name' => 'test-group']);
+    }
+
+    /** @test */
+    public function it_can_be_given_a_permission()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_given_a_permission_that_does_not_exist()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUserGroup->givePermissionTo('create-evil-empire');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_given_a_permission_that_belongs_to_another_guard()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUserGroup->givePermissionTo('admin-permission');
+
+        $this->expectException(GuardDoesNotMatch::class);
+
+        $this->testUserGroup->givePermissionTo($this->testAdminPermission);
+    }
+
+    /** @test */
+    public function it_can_be_given_multiple_permissions_using_an_array()
+    {
+        $this->testUserGroup->givePermissionTo(['edit-articles', 'edit-news']);
+
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-articles'));
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-news'));
+    }
+
+    /** @test */
+    public function it_can_be_given_multiple_permissions_using_multiple_arguments()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles', 'edit-news');
+
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-articles'));
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-news'));
+    }
+
+    /** @test */
+    public function it_can_sync_permissions()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->testUserGroup->syncPermissions('edit-news');
+
+        $this->assertFalse($this->testUserGroup->hasPermissionTo('edit-articles'));
+
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-news'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_syncing_permissions_that_do_not_exist()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUserGroup->syncPermissions('permission-does-not-exist');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_syncing_permissions_that_belong_to_a_different_guard()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUserGroup->syncPermissions('admin-permission');
+
+        $this->expectException(GuardDoesNotMatch::class);
+
+        $this->testUserGroup->syncPermissions($this->testAdminPermission);
+    }
+
+    /** @test */
+    public function it_will_remove_all_permissions_when_passing_an_empty_array_to_sync_permissions()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->testUserGroup->givePermissionTo('edit-news');
+
+        $this->testUserGroup->syncPermissions([]);
+
+        $this->assertFalse($this->testUserGroup->hasPermissionTo('edit-articles'));
+
+        $this->assertFalse($this->testUserGroup->hasPermissionTo('edit-news'));
+    }
+
+    /** @test */
+    public function it_can_revoked_a_permission()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->assertTrue($this->testUserGroup->hasPermissionTo('edit-articles'));
+
+        $this->testUserGroup->revokePermissionTo('edit-articles');
+
+        $this->testUserGroup = $this->testUserGroup->fresh();
+
+        $this->assertFalse($this->testUserGroup->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_be_given_a_permission_using_objects()
+    {
+        $this->testUserGroup->givePermissionTo($this->testUserPermission);
+
+        $this->assertTrue($this->testUserGroup->hasPermissionTo($this->testUserPermission));
+    }
+
+    /** @test */
+    public function it_returns_false_if_it_does_not_have_the_permission()
+    {
+        $this->assertFalse($this->testUserGroup->hasPermissionTo('other-permission'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_the_permission_does_not_exist()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUserGroup->hasPermissionTo('doesnt-exist');
+    }
+
+    /** @test */
+    public function it_returns_false_if_it_does_not_have_a_permission_object()
+    {
+        $permission = app(Permission::class)->findByName('other-permission');
+
+        $this->assertFalse($this->testUserGroup->hasPermissionTo($permission));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_a_permission_of_the_wrong_guard_is_passed_in()
+    {
+        $this->expectException(GuardDoesNotMatch::class);
+
+        $permission = app(Permission::class)->findByName('wrong-guard-permission', 'admin');
+
+        $this->testUserGroup->hasPermissionTo($permission);
+    }
+
+    /** @test */
+    public function it_belongs_to_a_guard()
+    {
+        $group = app(Group::class)->create(['name' => 'admin', 'guard_name' => 'admin']);
+
+        $this->assertEquals('admin', $group->guard_name);
+    }
+
+    /** @test */
+    public function it_belongs_to_the_default_guard_by_default()
+    {
+        $this->assertEquals($this->app['config']->get('auth.defaults.guard'), $this->testUserGroup->guard_name);
+    }
+}

--- a/tests/HasGroupsTest.php
+++ b/tests/HasGroupsTest.php
@@ -1,0 +1,423 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Contracts\Group;
+use Spatie\Permission\Exceptions\GroupDoesNotExist;
+use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+
+class HasGroupsTest extends TestCase
+{
+    /** @test */
+    public function it_can_determine_that_the_user_does_not_have_a_group()
+    {
+        $this->assertFalse($this->testUser->hasGroup('testGroup'));
+    }
+
+    /** @test */
+    public function it_can_assign_and_remove_a_group()
+    {
+        $this->testUser->assignGroup('testGroup');
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup'));
+
+        $this->testUser->removeGroup('testGroup');
+
+        $this->refreshTestUser();
+
+        $this->assertFalse($this->testUser->hasGroup('testGroup'));
+    }
+
+    /** @test */
+    public function it_can_assign_a_group_using_an_object()
+    {
+        $this->testUser->assignGroup($this->testUserGroup);
+
+        $this->assertTrue($this->testUser->hasGroup($this->testUserGroup));
+    }
+
+    /** @test */
+    public function it_can_assign_multiple_groups_at_once()
+    {
+        $this->testUser->assignGroup('testGroup', 'testGroup2');
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup'));
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup2'));
+    }
+
+    /** @test */
+    public function it_can_assign_multiple_groups_using_an_array()
+    {
+        $this->testUser->assignGroup(['testGroup', 'testGroup2']);
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup'));
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup2'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_assigning_a_group_that_does_not_exist()
+    {
+        $this->expectException(GroupDoesNotExist::class);
+
+        $this->testUser->assignGroup('evil-emperor');
+    }
+
+    /** @test */
+    public function it_can_only_assign_groups_from_the_correct_guard()
+    {
+        $this->expectException(GroupDoesNotExist::class);
+
+        $this->testUser->assignGroup('testAdminGroup');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_assigning_a_group_from_a_different_guard()
+    {
+        $this->expectException(GuardDoesNotMatch::class);
+
+        $this->testUser->assignGroup($this->testAdminGroup);
+    }
+
+    /** @test */
+    public function it_can_sync_groups_from_a_string()
+    {
+        $this->testUser->assignGroup('testGroup');
+
+        $this->testUser->syncGroups('testGroup2');
+
+        $this->assertFalse($this->testUser->hasGroup('testGroup'));
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup2'));
+    }
+
+    /** @test */
+    public function it_can_sync_multiple_groups()
+    {
+        $this->testUser->syncGroups('testGroup', 'testGroup2');
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup'));
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup2'));
+    }
+
+    /** @test */
+    public function it_can_sync_multiple_groups_from_an_array()
+    {
+        $this->testUser->syncGroups(['testGroup', 'testGroup2']);
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup'));
+
+        $this->assertTrue($this->testUser->hasGroup('testGroup2'));
+    }
+
+    /** @test */
+    public function it_will_remove_all_groups_when_an_empty_array_is_past_to_sync_groups()
+    {
+        $this->testUser->assignGroup('testGroup');
+
+        $this->testUser->assignGroup('testGroup2');
+
+        $this->testUser->syncGroups([]);
+
+        $this->assertFalse($this->testUser->hasGroup('testGroup'));
+
+        $this->assertFalse($this->testUser->hasGroup('testGroup2'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_syncing_a_group_from_another_guard()
+    {
+        $this->expectException(GroupDoesNotExist::class);
+
+        $this->testUser->syncGroups('testGroup', 'testAdminGroup');
+
+        $this->expectException(GuardDoesNotMatch::class);
+
+        $this->testUser->syncGroups('testGroup', $this->testAdminGroup);
+    }
+
+    /** @test */
+    public function it_deletes_pivot_table_entries_when_deleting_models()
+    {
+        $user = User::create(['email' => 'user@test.com']);
+
+        $user->assignGroup('testGroup');
+        $user->givePermissionTo('edit-articles');
+
+        $this->assertDatabaseHas('model_has_permissions', ['model_id' => $user->id]);
+        $this->assertDatabaseHas('model_has_groups', ['model_id' => $user->id]);
+
+        $user->delete();
+
+        $this->assertDatabaseMissing('model_has_permissions', ['model_id' => $user->id]);
+        $this->assertDatabaseMissing('model_has_groups', ['model_id' => $user->id]);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_a_string()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignGroup('testGroup');
+        $user2->assignGroup('testGroup2');
+
+        $scopedUsers = User::group('testGroup')->get();
+
+        $this->assertEquals($scopedUsers->count(), 1);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_an_array()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignGroup($this->testUserGroup);
+        $user2->assignGroup('testGroup2');
+
+        $scopedUsers1 = User::group([$this->testUserGroup])->get();
+        $scopedUsers2 = User::group(['testGroup', 'testGroup2'])->get();
+
+        $this->assertEquals($scopedUsers1->count(), 1);
+        $this->assertEquals($scopedUsers2->count(), 2);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_a_collection()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignGroup($this->testUserGroup);
+        $user2->assignGroup('testGroup2');
+
+        $scopedUsers1 = User::group([$this->testUserGroup])->get();
+        $scopedUsers2 = User::group(collect(['testGroup', 'testGroup2']))->get();
+
+        $this->assertEquals($scopedUsers1->count(), 1);
+        $this->assertEquals($scopedUsers2->count(), 2);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_an_object()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignGroup($this->testUserGroup);
+        $user2->assignGroup('testGroup2');
+
+        $scopedUsers = User::group($this->testUserGroup)->get();
+
+        $this->assertEquals($scopedUsers->count(), 1);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_trying_to_scope_a_group_from_another_guard()
+    {
+        $this->expectException(GroupDoesNotExist::class);
+
+        User::group('testAdminGroup')->get();
+
+        $this->expectException(GuardDoesNotMatch::class);
+
+        User::group($this->testAdminGroup)->get();
+    }
+
+    /** @test */
+    public function it_can_determine_that_a_user_has_one_of_the_given_groups()
+    {
+        $groupModel = app(Group::class);
+
+        $groupModel->create(['name' => 'second group']);
+
+        $this->assertFalse($this->testUser->hasGroup($groupModel->all()));
+
+        $this->testUser->assignGroup($this->testUserGroup);
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasGroup($groupModel->all()));
+
+        $this->assertTrue($this->testUser->hasAnyGroup($groupModel->all()));
+
+        $this->assertTrue($this->testUser->hasAnyGroup('testGroup'));
+
+        $this->assertFalse($this->testUser->hasAnyGroup('group does not exist'));
+
+        $this->assertTrue($this->testUser->hasAnyGroup(['testGroup']));
+
+        $this->assertTrue($this->testUser->hasAnyGroup(['testGroup', 'group does not exist']));
+
+        $this->assertFalse($this->testUser->hasAnyGroup(['group does not exist']));
+
+        $this->assertTrue($this->testUser->hasAnyGroup('testGroup', 'group does not exist'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_a_user_has_all_of_the_given_groups()
+    {
+        $groupModel = app(Group::class);
+
+        $this->assertFalse($this->testUser->hasAllGroups($groupModel->first()));
+
+        $this->assertFalse($this->testUser->hasAllGroups('testGroup'));
+
+        $this->assertFalse($this->testUser->hasAllGroups($groupModel->all()));
+
+        $groupModel->create(['name' => 'second group']);
+
+        $this->testUser->assignGroup($this->testUserGroup);
+
+        $this->refreshTestUser();
+
+        $this->assertFalse($this->testUser->hasAllGroups(['testGroup', 'second group']));
+
+        $this->testUser->assignGroup('second group');
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasAllGroups(['testGroup', 'second group']));
+    }
+
+    /** @test */
+    public function it_can_determine_that_a_user_does_not_have_a_group_from_another_guard()
+    {
+        $this->assertFalse($this->testUser->hasGroup('testAdminGroup'));
+
+        $this->assertFalse($this->testUser->hasGroup($this->testAdminGroup));
+
+        $this->testUser->assignGroup('testGroup');
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasAnyGroup(['testGroup', 'testAdminGroup']));
+
+        $this->assertFalse($this->testUser->hasAnyGroup('testAdminGroup', $this->testAdminGroup));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_does_not_have_a_permission()
+    {
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_permission_does_not_exist()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUser->hasPermissionTo('does-not-exist');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_permission_does_not_exist_for_this_guard()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUser->hasPermissionTo('admin-permission');
+    }
+
+    /** @test */
+    public function it_can_work_with_a_user_that_does_not_have_any_permissions_at_all()
+    {
+        $user = new User();
+
+        $this->assertFalse($user->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_has_any_of_the_permissions_directly()
+    {
+        $this->assertFalse($this->testUser->hasAnyPermission('edit-articles'));
+
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->refreshTestUser();
+
+        $this->testUser->revokePermissionTo($this->testUserPermission);
+
+        $this->assertTrue($this->testUser->hasAnyPermission('edit-articles', 'edit-news'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_has_any_of_the_permissions_directly_using_an_array()
+    {
+        $this->assertFalse($this->testUser->hasAnyPermission(['edit-articles']));
+
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasAnyPermission(['edit-news', 'edit-articles']));
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->refreshTestUser();
+
+        $this->testUser->revokePermissionTo($this->testUserPermission);
+
+        $this->assertTrue($this->testUser->hasAnyPermission(['edit-articles', 'edit-news']));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_has_any_of_the_permissions_via_group()
+    {
+        $this->testUserGroup->givePermissionTo('edit-articles');
+
+        $this->testUser->assignGroup('testGroup');
+
+        $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_user_has_direct_permission()
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->refreshTestUser();
+        $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
+        $this->testUser->revokePermissionTo('edit-articles');
+        $this->refreshTestUser();
+        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+
+        $this->testUser->assignGroup('testGroup');
+        $this->testUserGroup->givePermissionTo('edit-articles');
+        $this->refreshTestUser();
+        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_list_all_the_permissions_via_his_groups()
+    {
+        $groupModel = app(Group::class);
+        $groupModel->findByName('testGroup2')->givePermissionTo('edit-news');
+
+        $this->testUserGroup->givePermissionTo('edit-articles');
+        $this->testUser->assignGroup('testGroup', 'testGroup2');
+
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getPermissionsViaGroups()->pluck('name')
+        );
+    }
+
+    /** @test */
+    public function it_can_list_all_the_coupled_permissions_both_directly_and_via_groups()
+    {
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->testUserGroup->givePermissionTo('edit-articles');
+        $this->testUser->assignGroup('testGroup');
+
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getAllPermissions()->pluck('name')
+        );
+    }
+}

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -233,6 +233,8 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUser->hasAnyRole(['testRole', 'role does not exist']));
 
         $this->assertFalse($this->testUser->hasAnyRole(['role does not exist']));
+
+        $this->assertTrue($this->testUser->hasAnyRole('testRole', 'role does not exist'));
     }
 
     /** @test */

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Permission\Test;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Middlewares\GroupMiddleware;
 use Spatie\Permission\Middlewares\RoleMiddleware;
 use Spatie\Permission\Middlewares\PermissionMiddleware;
 use Symfony\Component\HttpKernel\Exception\HttpException;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Test;
 
 use Monolog\Handler\TestHandler;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Contracts\Group;
 use Illuminate\Database\Schema\Blueprint;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
@@ -17,6 +18,12 @@ abstract class TestCase extends Orchestra
 
     /** @var \Spatie\Permission\Test\Admin */
     protected $testAdmin;
+
+    /** @var \Spatie\Permission\Models\Group */
+    protected $testUserGroup;
+
+    /** @var \Spatie\Permission\Models\Group */
+    protected $testAdminGroup;
 
     /** @var \Spatie\Permission\Models\Role */
     protected $testUserRole;
@@ -39,10 +46,12 @@ abstract class TestCase extends Orchestra
         $this->reloadPermissions();
 
         $this->testUser = User::first();
+        $this->testUserGroup = app(Group::class)->find(1);
         $this->testUserRole = app(Role::class)->find(1);
         $this->testUserPermission = app(Permission::class)->find(1);
 
         $this->testAdmin = Admin::first();
+        $this->testAdminGroup = app(Group::class)->find(3);
         $this->testAdminRole = app(Role::class)->find(3);
         $this->testAdminPermission = app(Permission::class)->find(3);
 
@@ -110,6 +119,9 @@ abstract class TestCase extends Orchestra
 
         User::create(['email' => 'test@user.com']);
         Admin::create(['email' => 'admin@user.com']);
+        $app[Group::class]->create(['name' => 'testGroup']);
+        $app[Group::class]->create(['name' => 'testGroup2']);
+        $app[Group::class]->create(['name' => 'testAdminGroup', 'guard_name' => 'admin']);
         $app[Role::class]->create(['name' => 'testRole']);
         $app[Role::class]->create(['name' => 'testRole2']);
         $app[Role::class]->create(['name' => 'testAdminRole', 'guard_name' => 'admin']);

--- a/tests/User.php
+++ b/tests/User.php
@@ -4,7 +4,6 @@ namespace Spatie\Permission\Test;
 
 use Illuminate\Auth\Authenticatable;
 use Spatie\Permission\Traits\HasGroups;
-use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;

--- a/tests/User.php
+++ b/tests/User.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Test;
 
 use Illuminate\Auth\Authenticatable;
+use Spatie\Permission\Traits\HasGroups;
 use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\Authorizable;
@@ -11,7 +12,7 @@ use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 
 class User extends Model implements AuthorizableContract, AuthenticatableContract
 {
-    use HasRoles, Authorizable, Authenticatable;
+    use HasGroups, Authorizable, Authenticatable;
 
     /**
      * The attributes that are mass assignable.


### PR DESCRIPTION
More complex web applications need to divide roles into sections (or modules). E.g. group1 has section1 and section2 roles, group2 has section3 and section4 roles, etc. Each section role has its own permissions. I've added roles groups feature to laravel-permission that allows roles grouping in a described way. Permissions of child roles are visible from groups. Permissions can belong to groups. In other words. It is an additional permission level. Some group tests are missing, but could be added later. Most of work was a copypaste of Roles logic. For now I'd like just to know if the idea is correct. It works for me.

laravel-55 branch was used.