### PR TITLE
Change PermissionMiddleware to use cache

### DIFF
--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -13,12 +13,12 @@ class PermissionMiddleware
             abort(403);
         }
 
-        $permission = is_array($permission)
+        $permissions = is_array($permission)
             ? $permission
             : explode('|', $permission);
 
-        foreach ($permission as $p) {
-            if (Auth::user()->can($p)) {
+        foreach ($permissions as $permission) {
+            if (Auth::user()->can($permission)) {
                 return $next($request);
             }
         }

--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -17,10 +17,12 @@ class PermissionMiddleware
             ? $permission
             : explode('|', $permission);
 
-        if (! Auth::user()->hasAnyPermission(...$permission)) {
-            abort(403);
+        foreach ($permission as $p) {
+            if (Auth::user()->can($p)) {
+                return $next($request);
+            }
         }
 
-        return $next($request);
+        abort(403);
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -56,6 +56,11 @@ class MiddlewareTest extends TestCase
             $this->runMiddleware(
                 $this->roleMiddleware, 'testRole|testRole2'
             ), 200);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->roleMiddleware, ['testRole2', 'testRole']
+            ), 200);
     }
 
     /** @test */
@@ -124,7 +129,12 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(
             $this->runMiddleware(
-                $this->permissionMiddleware, 'edit-articles|edit-news'
+                $this->permissionMiddleware, 'edit-news|edit-articles'
+            ), 200);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, ['edit-news', 'edit-articles']
             ), 200);
     }
 


### PR DESCRIPTION
Calling `hasAnyPermission` directly will not trigger this package's cached data.
This PR changes it to call `$user->can` so that the Gate's defined rules are honoured.

Ref: discussion at https://github.com/spatie/laravel-permission/issues/356#issuecomment-326702605