### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ $permissions = $user->getAllPermissions();
 $roles = $user->getRoleNames(); // Returns a collection
 ```
 
-The `HasRoles` trait also add a `role` scopes to your models to scope the query to certain roles or permissions:
+The `HasRoles` trait also adds a `role` scope to your models to scope the query to certain roles or permissions:
 
 ```php
 $users = User::role('writer')->get(); // Returns only users with the role 'writer'


### PR DESCRIPTION
Changed:
> The `HasRoles` trait also __add__ a `role` __scopes__ to your models...

to:
> The `HasRoles` trait also __adds__ a `role` __scope__ to your models