### PR TITLE
Fix __construct middleware block in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Route::group(['middleware' => ['permission:publish articles|edit articles']], fu
 You can protect your controllers similarly, by setting desired middleware in the constructor:
 
 ```php
-public function __construct
+public function __construct()
 {
     $this->middleware(['role:super-admin','permission:publish articles|edit articles']);
 }


### PR DESCRIPTION
The construct block in the middleware section is missing the opening and closing `()`