### PR TITLE
Remove the unused import

### DIFF
--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -3,7 +3,6 @@
 namespace Spatie\Permission\Commands;
 
 use Illuminate\Console\Command;
-use Spatie\Permission\Models\Role;
 use Spatie\Permission\Contracts\Role as RoleContract;
 
 class CreateRole extends Command


### PR DESCRIPTION
It looks like `Spatie\Permission\Models\Role` is not used in this class.
Instead, RoleContract is used in handle method to create a Role instance.