### PR TITLE
Using Docker for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,13 @@ The package doesn't come with any screens out of the box, you should build that 
 composer test
 ```
 
+### Testing with Docker
+
+https://www.docker.com/
+``` bash
+composer test-versions
+```
+
 ### Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,12 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "test-versions": [
+            "docker-compose run --rm php7.0 './vendor/bin/phpunit'",
+            "docker-compose run --rm php7.1 './vendor/bin/phpunit'",
+            "docker-compose run --rm php7.2 './vendor/bin/phpunit'"
+        ]
     },
     "config": {
         "sort-packages": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  php7.0:
+    image: php:7.0
+    volumes:
+      - ".:/project"
+    working_dir: "/project"
+    tty: true
+  php7.1:
+    image: php:7.1
+    volumes:
+      - ".:/project"
+    working_dir: "/project"
+    tty: true
+  php7.2:
+    image: php:7.2-rc
+    volumes:
+      - ".:/project"
+    working_dir: "/project"
+    tty: true


### PR DESCRIPTION
Hi

This is a proposal PR about unit testing.
Now TravisCI runs multiple PHP versions tests when the PR is created.

I think it's better to run phpunit with those versions before Creating the new PR.
However, it's hard to install plural PHP versions without polluting the development environment.

I think Docker makes easy to run phpunit with multiple versions.

People can choose to run tests with Docker or not.
```
# without Docker
comoser test

# with Docker
composer test-versions
```

Offcourse if using Docker is not appropriate for this project, I will close this PR.

Thanks.