### PR TITLE
Throw custom UnauthorizedException in Middleware

### DIFF
--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -8,16 +8,16 @@ class UnauthorizedException extends HttpException
 {
     public static function forRoles(array $roles): self
     {
-        return new static(403, "User does not have the right roles.", null, []);
+        return new static(403, 'User does not have the right roles.', null, []);
     }
 
     public static function forPermissions(array $permissions): self
     {
-        return new static(403, "User does not have the right permissions.", null, []);
+        return new static(403, 'User does not have the right permissions.', null, []);
     }
 
     public static function notLoggedIn(): self
     {
-        return new static(403, "User is not logged in.", null, []);
+        return new static(403, 'User is not logged in.', null, []);
     }
 }

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class UnauthorizedException extends HttpException
+{
+    public static function forRoles(array $roles): self
+    {
+        return new static(403, "User does not have the right roles.", null, []);
+    }
+
+    public static function forPermissions(array $permissions): self
+    {
+        return new static(403, "User does not have the right permissions.", null, []);
+    }
+
+    public static function notLoggedIn(): self
+    {
+        return new static(403, "User is not logged in.", null, []);
+    }
+}

--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -4,13 +4,14 @@ namespace Spatie\Permission\Middlewares;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class PermissionMiddleware
 {
     public function handle($request, Closure $next, $permission)
     {
         if (Auth::guest()) {
-            abort(403);
+            throw UnauthorizedException::notLoggedIn();
         }
 
         $permissions = is_array($permission)
@@ -23,6 +24,6 @@ class PermissionMiddleware
             }
         }
 
-        abort(403);
+        throw UnauthorizedException::forPermissions($permissions);
     }
 }

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -4,21 +4,22 @@ namespace Spatie\Permission\Middlewares;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class RoleMiddleware
 {
     public function handle($request, Closure $next, $role)
     {
         if (Auth::guest()) {
-            abort(403);
+            throw UnauthorizedException::notLoggedIn();
         }
 
-        $role = is_array($role)
+        $roles = is_array($role)
             ? $role
             : explode('|', $role);
 
-        if (! Auth::user()->hasAnyRole($role)) {
-            abort(403);
+        if (! Auth::user()->hasAnyRole($roles)) {
+            throw UnauthorizedException::forRoles($roles);
         }
 
         return $next($request);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -5,8 +5,9 @@ namespace Spatie\Permission\Test;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Permission\Middlewares\RoleMiddleware;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middlewares\PermissionMiddleware;
+use Spatie\Permission\Middlewares\RoleMiddleware;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class MiddlewareTest extends TestCase
@@ -168,7 +169,7 @@ class MiddlewareTest extends TestCase
             return $middleware->handle(new Request(), function () {
                 return (new Response())->setContent('<html></html>');
             }, $parameter)->status();
-        } catch (HttpException $e) {
+        } catch (UnauthorizedException $e) {
             return $e->getStatusCode();
         }
     }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -5,10 +5,9 @@ namespace Spatie\Permission\Test;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Middlewares\RoleMiddleware;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middlewares\PermissionMiddleware;
-use Spatie\Permission\Middlewares\RoleMiddleware;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class MiddlewareTest extends TestCase
 {


### PR DESCRIPTION
Based on @lloricode's & @drbyte's ideas in #517. 

This PR throws a custom `Spatie\Permission\Exceptions\UnauthorizedException` in the permission/role middleware. The exception extends the original `HttpException` and has the same HTTP status codes as the original `abort()`s so no breaking changes.