### PR TITLE
Adding a clear cache command to clear permissions cache from command line .

### DIFF
--- a/src/Commands/ClearCache.php
+++ b/src/Commands/ClearCache.php
@@ -11,7 +11,6 @@ class ClearCache extends Command
 
     protected $signature = 'permission:clear-cache';
 
-
     protected $description = 'Clear permissions cache';
 
     public function handle()

--- a/src/Commands/ClearCache.php
+++ b/src/Commands/ClearCache.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\Permission\Contracts\Permission as PermissionContract;
+use \Spatie\Permission\Traits\HasPermissions;
+
+class ClearCache extends Command
+{
+    use HasPermissions;
+
+    protected $signature = 'permission:clear-cache';
+
+
+    protected $description = 'Clear permissions cache';
+
+    public function handle()
+    {
+        $this->forgetCachedPermissions();
+        $this->info("Permissions chache was cleard");
+    }
+}

--- a/src/Commands/ClearCache.php
+++ b/src/Commands/ClearCache.php
@@ -3,8 +3,7 @@
 namespace Spatie\Permission\Commands;
 
 use Illuminate\Console\Command;
-use Spatie\Permission\Contracts\Permission as PermissionContract;
-use \Spatie\Permission\Traits\HasPermissions;
+use Spatie\Permission\Traits\HasPermissions;
 
 class ClearCache extends Command
 {
@@ -18,6 +17,6 @@ class ClearCache extends Command
     public function handle()
     {
         $this->forgetCachedPermissions();
-        $this->info("Permissions chache was cleard");
+        $this->info('Permissions cache was cleared');
     }
 }

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -27,6 +27,7 @@ class PermissionServiceProvider extends ServiceProvider
             $this->commands([
                 Commands\CreateRole::class,
                 Commands\CreatePermission::class,
+                Commands\ClearCache::class,
             ]);
         }
 


### PR DESCRIPTION
This is useful when adding the or removing permissions from the database and not using the package methods.

