### PR TITLE
Gate::before should return null if fail.

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -31,7 +31,7 @@ class PermissionRegistrar
         $this->gate->before(function (Authenticatable $user, string $ability) {
             try {
                 if (method_exists($user, 'hasPermissionTo')) {
-                    return $user->hasPermissionTo($ability);
+                    return $user->hasPermissionTo($ability) ?: null;
                 }
             } catch (PermissionDoesNotExist $e) {
             }

--- a/tests/GateTest.php
+++ b/tests/GateTest.php
@@ -2,12 +2,26 @@
 
 namespace Spatie\Permission\Test;
 
+use Illuminate\Contracts\Auth\Access\Gate;
+
 class GateTest extends TestCase
 {
     /** @test */
     public function it_can_determine_if_a_user_does_not_have_a_permission()
     {
         $this->assertFalse($this->testUser->can('edit-articles'));
+    }
+
+    /** @test */
+    public function it_allows_other_gate_before_callbacks_to_run_if_a_user_does_not_have_a_permission()
+    {
+        $this->assertFalse($this->testUser->can('edit-articles'));
+
+        app(Gate::class)->before(function () {
+            return true;
+        });
+
+        $this->assertTrue($this->testUser->can('edit-articles'));
     }
 
     /** @test */


### PR DESCRIPTION
If you return false at Gate::before, you reject all other user-defined gates. Better to return null so the user-defined gates can take over. If no gates take over then is a fail too so more flexible.

As seen in the comments on this link where a user (Joseph Sibler of bouncer package) pointed out Jeffery mistake to return false in Gate::before

https://laracasts.com/series/whats-new-in-laravel-5-1/episodes/15

If I'm wrong about this let me know too. Cheers!