### PR TITLE
Ignore errors when assigning role/permission previously given to user

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -18,14 +18,14 @@ trait HasPermissions
      */
     public function givePermissionTo(...$permissions)
     {
-        $permissions = collect($permissions)
+        collect($permissions)
             ->flatten()
             ->map(function ($permission) {
                 return $this->getStoredPermission($permission);
             })
             ->each(function ($permission) {
                 $this->ensureModelSharesGuard($permission);
-		        if(! $this->can($permission->name)) {
+                if(! $this->hasPermissionTo($permission->name)) {
                     $this->permissions()->attach($permission->id);
                 }
             })

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -25,7 +25,7 @@ trait HasPermissions
             })
             ->each(function ($permission) {
                 $this->ensureModelSharesGuard($permission);
-                if(! $this->hasPermissionTo($permission->name)) {
+                if (! $this->hasPermissionTo($permission->name)) {
                     $this->permissions()->attach($permission->id);
                 }
             })

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -25,13 +25,11 @@ trait HasPermissions
             })
             ->each(function ($permission) {
                 $this->ensureModelSharesGuard($permission);
-		        if(!$this->can($permission->name)) {
+		        if(! $this->can($permission->name)) {
                     $this->permissions()->attach($permission->id);
                 }
             })
             ->all();
-
-        //$this->permissions()->saveMany($permissions);
 
         $this->forgetCachedPermissions();
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -25,10 +25,13 @@ trait HasPermissions
             })
             ->each(function ($permission) {
                 $this->ensureModelSharesGuard($permission);
+		        if(!$this->can($permission->name)) {
+                    $this->permissions()->attach($permission->id);
+                }
             })
             ->all();
 
-        $this->permissions()->saveMany($permissions);
+        //$this->permissions()->saveMany($permissions);
 
         $this->forgetCachedPermissions();
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -155,14 +155,14 @@ trait HasRoles
      */
     public function assignRole(...$roles)
     {
-        $roles = collect($roles)
+        collect($roles)
             ->flatten()
             ->map(function ($role) {
                 return $this->getStoredRole($role);
             })
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
-		        if(! $this->hasRole($role->name)) {
+                if(! $this->hasRole($role->name)) {
                     $this->roles()->attach($role->id);
                 }
             })

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -162,10 +162,13 @@ trait HasRoles
             })
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
+		        if(!$this->hasRole($role->name)) {
+                    $this->roles()->attach($role->id);
+                }
             })
             ->all();
 
-        $this->roles()->saveMany($roles);
+        //$this->roles()->saveMany($roles);
 
         $this->forgetCachedPermissions();
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -162,13 +162,11 @@ trait HasRoles
             })
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
-		        if(!$this->hasRole($role->name)) {
+		        if(! $this->hasRole($role->name)) {
                     $this->roles()->attach($role->id);
                 }
             })
             ->all();
-
-        //$this->roles()->saveMany($roles);
 
         $this->forgetCachedPermissions();
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -162,7 +162,7 @@ trait HasRoles
             })
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
-                if(! $this->hasRole($role->name)) {
+                if (! $this->hasRole($role->name)) {
                     $this->roles()->attach($role->id);
                 }
             })


### PR DESCRIPTION
If you are trying to assign a role or a permission previously added to a user, the system will show an query error.
Doing this, before add, I do a check and add if the user have not the role or permission.