### PR TITLE
assignRole and syncRoles using ids as well as names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 All notable changes to `laravel-permission` will be documented in this file
 
+## 2.7.6 - 2017-11-1
+- `HasRole::assignRole` and `HasRole::syncRoles` now accept role id's in addition to role names as arguments
+
 ## 2.7.5 - 2017-10-26
 - fixed `Gate::before` for custom gate callbacks
 
 ## 2.7.4 - 2017-10-26
 - added cache clearing command in `up` migration for permission tables
-- use config_path helper for beter Lumen support
-
+- use config_path helper for better Lumen support
 
 ## 2.7.3 - 2017-10-21
 - refactor middleware to throw custom `UnauthorizedException` (which raises an HttpException with 403 response)
@@ -40,7 +42,7 @@ The 403 response is backward compatible
 - add getRoleNames() method to return a collection of assigned roles
 
 ## 2.5.0 - 2017-08-30
-- add compatiblity with Laravel 5.5
+- add compatibility with Laravel 5.5
 
 ## 2.4.2 - 2017-08-11
 - automatically detach roles and permissions when a user gets deleted
@@ -125,7 +127,7 @@ The 403 response is backward compatible
 - added `Role` scope
 
 ## 1.5.3 - 2016-12-15
-- moved some things to `boot` method in SP to solve some compatibilty problems with other packages
+- moved some things to `boot` method in SP to solve some compatibility problems with other packages
 
 ## 1.5.2 - 2016-08-26
 - make compatible with L5.3
@@ -162,7 +164,7 @@ The 403 response is backward compatible
 
 ## 1.3.0 - 2015-12-25
 
-- added compatiblity for Laravel 5.2
+- added compatibility for Laravel 5.2
 
 ## 1.2.1 - 2015-12-22
 

--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -26,6 +26,17 @@ interface Role
     public static function findByName(string $name, $guardName): Role;
 
     /**
+     * Find a role by its id and guard name.
+     * @param int $id
+     * @param string|null $guardName
+     *
+     * @return \Spatie\Permission\Contracts\Role
+     *
+     * @throws \Spatie\Permission\Exceptions\RoleDoesNotExist
+     */
+    public static function findById(int $id, $guardName): Role;
+
+    /**
      * Determine if the user may perform the given permission.
      *
      * @param string|\Spatie\Permission\Contracts\Permission $permission

--- a/src/Exceptions/RoleDoesNotExist.php
+++ b/src/Exceptions/RoleDoesNotExist.php
@@ -6,8 +6,13 @@ use InvalidArgumentException;
 
 class RoleDoesNotExist extends InvalidArgumentException
 {
-    public static function create(string $roleName)
+    public static function named(string $roleName)
     {
         return new static("There is no role named `{$roleName}`.");
+    }
+
+    public static function withId(int $roleId)
+    {
+        return new static("There is no role with id `{$roleId}`.");
     }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -85,11 +85,25 @@ class Role extends Model implements RoleContract
         $role = static::where('name', $name)->where('guard_name', $guardName)->first();
 
         if (! $role) {
-            throw RoleDoesNotExist::create($name);
+            throw RoleDoesNotExist::named($name);
         }
 
         return $role;
     }
+
+    public static function findById(int $id, $guardName): RoleContract
+    {
+        $guardName = $guardName ?? config('auth.defaults.guard');
+
+        $role = static::where('id', $id)->where('guard_name', $guardName)->first();
+
+        if (! $role) {
+            throw RoleDoesNotExist::withId($id);
+        }
+
+        return $role;
+    }
+
 
     /**
      * Determine if the user may perform the given permission.

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -104,7 +104,6 @@ class Role extends Model implements RoleContract
         return $role;
     }
 
-
     /**
      * Determine if the user may perform the given permission.
      *

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -383,7 +383,7 @@ trait HasRoles
     {
         if (is_numeric($role)) {
             return app(Role::class)->findById($role, $this->getDefaultGuardName());
-        }else if (is_string($role)) {
+        } elseif (is_string($role)) {
             return app(Role::class)->findByName($role, $this->getDefaultGuardName());
         }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -381,7 +381,9 @@ trait HasRoles
 
     protected function getStoredRole($role): Role
     {
-        if (is_string($role)) {
+        if (is_numeric($role)) {
+            return app(Role::class)->findById($role, $this->getDefaultGuardName());
+        }else if (is_string($role)) {
             return app(Role::class)->findByName($role, $this->getDefaultGuardName());
         }
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -65,8 +65,6 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUser->hasRole('testRole2'));
     }
 
-
-
     /** @test */
     public function it_throws_an_exception_when_assigning_a_role_that_does_not_exist()
     {

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -38,9 +38,17 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_assign_a_role_using_an_id()
+    {
+        $this->testUser->assignRole($this->testUserRole->id);
+
+        $this->assertTrue($this->testUser->hasRole($this->testUserRole));
+    }
+
+    /** @test */
     public function it_can_assign_multiple_roles_at_once()
     {
-        $this->testUser->assignRole('testRole', 'testRole2');
+        $this->testUser->assignRole($this->testUserRole->id, 'testRole2');
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
@@ -50,12 +58,14 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_multiple_roles_using_an_array()
     {
-        $this->testUser->assignRole(['testRole', 'testRole2']);
+        $this->testUser->assignRole([$this->testUserRole->id, 'testRole2']);
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
         $this->assertTrue($this->testUser->hasRole('testRole2'));
     }
+
+
 
     /** @test */
     public function it_throws_an_exception_when_assigning_a_role_that_does_not_exist()


### PR DESCRIPTION
I implemented #548. Namely the ability to for `HasRole::syncRoles` and `HasRole::assignRole` to accept role ids as well as names.

I needed this for compatibility with a form framework (kristijanhusak/laravel-form-builder).

This is my first time contributing to a project so I hope I've done it correctly.