### PR TITLE
Add findOrCreate function to Permission model

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -105,7 +105,7 @@ class Permission extends Model implements PermissionContract
         $permission = static::getPermissions()->where('name', $name)->where('guard_name', $guardName)->first();
 
         if (! $permission) {
-            return static::create(['guard_name' => $guardName, 'name' => $name]);
+            return static::create(['name' => $name, 'guard_name' => $guardName]);
         }
 
         return $permission;

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -91,6 +91,27 @@ class Permission extends Model implements PermissionContract
     }
 
     /**
+     * Find or create permission by its name (and optionally guardName).
+     *
+     * @param string $name
+     * @param string|null $guardName
+     *
+     * @return \Spatie\Permission\Contracts\Permission
+     */
+    public static function findOrCreate(string $name, $guardName = null): PermissionContract
+    {
+        $guardName = $guardName ?? config('auth.defaults.guard');
+
+        $permission = static::getPermissions()->where('name', $name)->where('guard_name', $guardName)->first();
+
+        if (! $permission) {
+            return static::create(['guard_name' => $guardName, 'name' => $name]);
+        }
+
+        return $permission;
+    }
+
+    /**
      * Get the current cached permissions.
      */
     protected static function getPermissions(): Collection

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -181,6 +181,14 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    public function it_creates_permission_object_if_it_does_not_have_a_permission_object()
+    {
+        $permission = app(Permission::class)->findOrCreate('other-permission');
+
+        $this->assertFalse($this->testUserRole->hasPermissionTo($permission));
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_a_permission_of_the_wrong_guard_is_passed_in()
     {
         $this->expectException(GuardDoesNotMatch::class);

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -181,11 +181,17 @@ class RoleTest extends TestCase
     }
 
     /** @test */
-    public function it_creates_permission_object_if_it_does_not_have_a_permission_object()
+    public function it_creates_permission_object_with_findOrCreate_if_it_does_not_have_a_permission_object()
     {
-        $permission = app(Permission::class)->findOrCreate('other-permission');
+        $permission = app(Permission::class)->findOrCreate('another-permission');
 
         $this->assertFalse($this->testUserRole->hasPermissionTo($permission));
+
+        $this->testUserRole->givePermissionTo($permission);
+
+        $this->testUserRole = $this->testUserRole->fresh();
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo('another-permission'));
     }
 
     /** @test */


### PR DESCRIPTION
When trying to find a permission that does not exist, it could be added to the database so that it easily can be used in the application going forward. It could be further built by adding a boolean variable in the config-file wheter the developer wants it to trigger automatically everytime the @can/user->can() function is used.

Eg. for extending the User model:
```php
class User extends Authenticatable {

  public function hasAccess($permission, $guard = null) {
    if(!$this->can($permission)) {
      Permission:findOrCreate($permission, $guard);
      abort(403);
    }

    return true;
  }

}
```