### PR TITLE
Fixed getting default guard name

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -117,8 +117,9 @@ trait HasPermissions
     protected function getDefaultGuardName(): string
     {
         $default = config('auth.defaults.guard');
+        $guardNames = $this->getGuardNames();
 
-        return $default ?: $this->getGuardNames()->first();
+        return $guardNames->contains($default) ? $default : $this->getGuardNames()->first();
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -119,7 +119,7 @@ trait HasPermissions
         $default = config('auth.defaults.guard');
         $guardNames = $this->getGuardNames();
 
-        return $guardNames->contains($default) ? $default : $this->getGuardNames()->first();
+        return $guardNames->contains($default) ? $default : $guardNames->first();
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -118,7 +118,7 @@ trait HasPermissions
     {
         $default = config('auth.defaults.guard');
 
-        return $this->getGuardNames()->first() ?: $default;
+        return $default ?: $this->getGuardNames()->first();
     }
 
     /**


### PR DESCRIPTION
It did not return the default guard name but the first available option