### PR TITLE
Support  getting guard_name from extended model when using static methods

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Spatie\Permission;
+
+use Illuminate\Support\Collection;
+
+class Guard
+{
+    /**
+     * return collection of (guard_name) property if exist on class or object
+     * otherwise will return collection of guards names that exists in config/auth.php
+     * @param $model
+     * @return Collection
+     */
+    public static function getNames($model) : Collection
+    {
+        if (is_object($model)) {
+            $guardName = $model->guard_name ?? null;
+        }
+
+        if (!isset($guardName)) {
+            $class = is_object($model) ? get_class($model) : $model;
+
+            $guardName = (new \ReflectionClass($class))->getDefaultProperties()['guard_name'] ?? null;
+        }
+
+        if ($guardName) {
+            return collect($guardName);
+        }
+
+        return collect(config('auth.guards'))
+            ->map(function ($guard) {
+                return config("auth.providers.{$guard['provider']}.model");
+            })
+            ->filter(function ($model) use ($class) {
+                return $class === $model;
+            })
+            ->keys();
+    }
+
+    public static function getDefaultName($class): string
+    {
+        $default = config('auth.defaults.guard');
+
+        return static::getNames($class)->first() ?: $default;
+    }
+}

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -8,7 +8,7 @@ class Guard
 {
     /**
      * return collection of (guard_name) property if exist on class or object
-     * otherwise will return collection of guards names that exists in config/auth.php
+     * otherwise will return collection of guards names that exists in config/auth.php.
      * @param $model
      * @return Collection
      */
@@ -18,7 +18,7 @@ class Guard
             $guardName = $model->guard_name ?? null;
         }
 
-        if (!isset($guardName)) {
+        if (! isset($guardName)) {
             $class = is_object($model) ? get_class($model) : $model;
 
             $guardName = (new \ReflectionClass($class))->getDefaultProperties()['guard_name'] ?? null;

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Guard;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -29,7 +30,7 @@ class Permission extends Model implements PermissionContract
 
     public static function create(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
+        $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
         if (static::getPermissions()->where('name', $attributes['name'])->where('guard_name', $attributes['guard_name'])->first()) {
             throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
@@ -79,7 +80,7 @@ class Permission extends Model implements PermissionContract
      */
     public static function findByName(string $name, $guardName = null): PermissionContract
     {
-        $guardName = $guardName ?? config('auth.defaults.guard');
+        $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $permission = static::getPermissions()->where('name', $name)->where('guard_name', $guardName)->first();
 
@@ -100,7 +101,7 @@ class Permission extends Model implements PermissionContract
      */
     public static function findOrCreate(string $name, $guardName = null): PermissionContract
     {
-        $guardName = $guardName ?? config('auth.defaults.guard');
+        $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $permission = static::getPermissions()->where('name', $name)->where('guard_name', $guardName)->first();
 

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Permission\Models;
 
+use Spatie\Permission\Guard;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Permission\Guard;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Guard;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -30,7 +31,7 @@ class Role extends Model implements RoleContract
 
     public static function create(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
+        $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
         if (static::where('name', $attributes['name'])->where('guard_name', $attributes['guard_name'])->first()) {
             throw RoleAlreadyExists::create($attributes['name'], $attributes['guard_name']);
@@ -80,7 +81,7 @@ class Role extends Model implements RoleContract
      */
     public static function findByName(string $name, $guardName = null): RoleContract
     {
-        $guardName = $guardName ?? config('auth.defaults.guard');
+        $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $role = static::where('name', $name)->where('guard_name', $guardName)->first();
 
@@ -93,7 +94,7 @@ class Role extends Model implements RoleContract
 
     public static function findById(int $id, $guardName = null): RoleContract
     {
-        $guardName = $guardName ?? config('auth.defaults.guard');
+        $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $role = static::where('id', $id)->where('guard_name', $guardName)->first();
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Permission\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\Guard;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Traits;
 
 use Illuminate\Support\Collection;
+use Spatie\Permission\Guard;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -100,25 +101,12 @@ trait HasPermissions
 
     protected function getGuardNames(): Collection
     {
-        if ($this->guard_name) {
-            return collect($this->guard_name);
-        }
-
-        return collect(config('auth.guards'))
-            ->map(function ($guard) {
-                return config("auth.providers.{$guard['provider']}.model");
-            })
-            ->filter(function ($model) {
-                return get_class($this) === $model;
-            })
-            ->keys();
+        return Guard::getNames($this);
     }
 
     protected function getDefaultGuardName(): string
     {
-        $default = config('auth.defaults.guard');
-
-        return $this->getGuardNames()->first() ?: $default;
+        return Guard::getDefaultName($this);
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Permission\Traits;
 
-use Illuminate\Support\Collection;
 use Spatie\Permission\Guard;
+use Illuminate\Support\Collection;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;


### PR DESCRIPTION
this **PR** , doesn't alter the current behavior , it will allow static methods to access the **$guard_name**  for example:- 

```php
class ApiRole extends Spatie\Permission\Models\Role
{
    protected $guard_name = 'api';
}

/*
* so if we make this now we will get the role of guard  api , 
* while previous was getting the default auth.php guard and we had to make this ,
* ApiRole::findByName('admin','api');
*/

 ApiRole::findByName('admin'); 
```