### PR TITLE
Add reason for failed role/permission as exception property

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -77,4 +77,11 @@ return [
      */
 
     'cache_expiration_time' => 60 * 24,
+
+    /*
+     * When set to true, the name of the required permission/role is added to the
+     * exception message. This could be considered an information leak in some contexts,
+     * so enable if you know what you're doing.
+     */
+    'display_permission_in_exception' => false,
 ];

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -6,18 +6,52 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UnauthorizedException extends HttpException
 {
+    private $requiredRoles = [];
+
+    private $requiredPermissions = [];
+
     public static function forRoles(array $roles): self
     {
-        return new static(403, 'User does not have the right roles.', null, []);
+        $message = 'User does not have the right roles.';
+
+        if (config('permission.display_permission_in_exception')) {
+            $permStr = implode(', ', $roles);
+            $message = 'User does not have the right roles. Necessary roles are '.$permStr;
+        }
+
+        $exception = new static(403, $message, null, []);
+        $exception->requiredRoles = $roles;
+
+        return $exception;
     }
 
     public static function forPermissions(array $permissions): self
     {
-        return new static(403, 'User does not have the right permissions.', null, []);
+        $message = 'User does not have the right permissions.';
+
+        if (config('permission.display_permission_in_exception')) {
+            $permStr = implode(', ', $permissions);
+            $message = 'User does not have the right permissions. Necessary permissions are '.$permStr;
+        }
+
+        $exception = new static(403, $message, null, []);
+        $exception->requiredPermissions = $permissions;
+
+        return $exception;
     }
 
     public static function notLoggedIn(): self
     {
         return new static(403, 'User is not logged in.', null, []);
+    }
+
+    public function getRequiredRoles(): array
+    {
+        return $this->requiredRoles;
+    }
+
+    public function getRequiredPermissions(): array
+    {
+        return $this->requiredPermissions;
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -162,6 +162,42 @@ class MiddlewareTest extends TestCase
             ), 403);
     }
 
+    /** @test */
+    public function the_required_roles_can_be_fetched_from_the_exception()
+    {
+        Auth::login($this->testUser);
+
+        $requiredRoles = [];
+
+        try {
+            $this->roleMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, 'some-role');
+        } catch (UnauthorizedException $e) {
+            $requiredRoles = $e->getRequiredRoles();
+        }
+
+        $this->assertEquals(['some-role'], $requiredRoles);
+    }
+
+    /** @test */
+    public function the_required_permissions_can_be_fetched_from_the_exception()
+    {
+        Auth::login($this->testUser);
+
+        $requiredPermissions = [];
+
+        try {
+            $this->permissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, 'some-permission');
+        } catch (UnauthorizedException $e) {
+            $requiredPermissions = $e->getRequiredPermissions();
+        }
+
+        $this->assertEquals(['some-permission'], $requiredPermissions);
+    }
+
     protected function runMiddleware($middleware, $parameter)
     {
         try {


### PR DESCRIPTION
Resolves issue #593 by also allowing to access the permssions/roles required (as I originally intended to do for logging purposes)