### PR TITLE
Allow missing guard driver param (Spark compatibility)

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -30,6 +30,10 @@ class Guard
 
         return collect(config('auth.guards'))
             ->map(function ($guard) {
+                if (! isset($guard['provider'])) {
+                    return;
+                }
+
                 return config("auth.providers.{$guard['provider']}.model");
             })
             ->filter(function ($model) use ($class) {

--- a/tests/MultipleGuardsTest.php
+++ b/tests/MultipleGuardsTest.php
@@ -30,6 +30,7 @@ class MultipleGuardsTest extends TestCase
         $app['config']->set('auth.guards', [
             'web' => ['driver' => 'session', 'provider' => 'users'],
             'api' => ['driver' => 'jwt', 'provider' => 'users'],
+            'abc' => ['driver' => 'abc'],
         ]);
     }
 }


### PR DESCRIPTION
Laravel Spark has a custom `api` driver which doesn't include a `provider` index.
This update allows for that array entry to be missing, and no longer throw an error.

Fixes #640