### PR TITLE
Move permissions methods out of HasRoles trait

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -53,8 +53,7 @@ trait HasPermissions
             return array_merge($result, $permission->roles->all());
         }, []));
 
-        return $query->
-        where(function ($query) use ($permissions, $rolesWithPermissions) {
+        return $query->where(function ($query) use ($permissions, $rolesWithPermissions) {
             $query->whereHas('permissions', function ($query) use ($permissions) {
                 $query->where(function ($query) use ($permissions) {
                     foreach ($permissions as $permission) {

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -4,12 +4,194 @@ namespace Spatie\Permission\Traits;
 
 use Spatie\Permission\Guard;
 use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 trait HasPermissions
 {
+    public static function bootHasPermissions()
+    {
+        static::deleting(function ($model) {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+                return;
+            }
+
+            $model->permissions()->detach();
+        });
+    }
+
+    /**
+     * A model may have multiple direct permissions.
+     */
+    public function permissions(): MorphToMany
+    {
+        return $this->morphToMany(
+            config('permission.models.permission'),
+            'model',
+            config('permission.table_names.model_has_permissions'),
+            'model_id',
+            'permission_id'
+        );
+    }
+
+    /**
+     * Scope the model query to certain permissions only.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopePermission(Builder $query, $permissions): Builder
+    {
+        $permissions = $this->convertToPermissionModels($permissions);
+
+        $rolesWithPermissions = array_unique(array_reduce($permissions, function ($result, $permission) {
+            return array_merge($result, $permission->roles->all());
+        }, []));
+
+        return $query->
+            where(function ($query) use ($permissions, $rolesWithPermissions) {
+                $query->whereHas('permissions', function ($query) use ($permissions) {
+                    $query->where(function ($query) use ($permissions) {
+                        foreach ($permissions as $permission) {
+                            $query->orWhere(config('permission.table_names.permissions').'.id', $permission->id);
+                        }
+                    });
+                });
+                if (count($rolesWithPermissions) > 0) {
+                    $query->orWhereHas('roles', function ($query) use ($rolesWithPermissions) {
+                        $query->where(function ($query) use ($rolesWithPermissions) {
+                            foreach ($rolesWithPermissions as $role) {
+                                $query->orWhere(config('permission.table_names.roles').'.id', $role->id);
+                            }
+                        });
+                    });
+                }
+            });
+    }
+
+    /**
+     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     *
+     * @return array
+     */
+    protected function convertToPermissionModels($permissions): array
+    {
+        if ($permissions instanceof Collection) {
+            $permissions = $permissions->toArray();
+        }
+
+        $permissions = array_wrap($permissions);
+
+        return array_map(function ($permission) {
+            if ($permission instanceof Permission) {
+                return $permission;
+            }
+
+            return app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
+        }, $permissions);
+    }
+
+    /**
+     * Determine if the model may perform the given permission.
+     *
+     * @param string|\Spatie\Permission\Contracts\Permission $permission
+     * @param string|null $guardName
+     *
+     * @return bool
+     */
+    public function hasPermissionTo($permission, $guardName = null): bool
+    {
+        if (is_string($permission)) {
+            $permission = app(Permission::class)->findByName(
+                $permission,
+                $guardName ?? $this->getDefaultGuardName()
+            );
+        }
+
+        return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
+    }
+
+    /**
+     * Determine if the model has any of the given permissions.
+     *
+     * @param array ...$permissions
+     *
+     * @return bool
+     */
+    public function hasAnyPermission(...$permissions): bool
+    {
+        if (is_array($permissions[0])) {
+            $permissions = $permissions[0];
+        }
+
+        foreach ($permissions as $permission) {
+            if ($this->hasPermissionTo($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the model has, via roles, the given permission.
+     *
+     * @param \Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return bool
+     */
+    protected function hasPermissionViaRole(Permission $permission): bool
+    {
+        return $this->hasRole($permission->roles);
+    }
+
+    /**
+     * Determine if the model has the given permission.
+     *
+     * @param string|\Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return bool
+     */
+    public function hasDirectPermission($permission): bool
+    {
+        if (is_string($permission)) {
+            $permission = app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
+
+            if (! $permission) {
+                return false;
+            }
+        }
+
+        return $this->permissions->contains('id', $permission->id);
+    }
+
+    /**
+     * Return all the permissions the model has via roles.
+     */
+    public function getPermissionsViaRoles(): Collection
+    {
+        return $this->load('roles', 'roles.permissions')
+            ->roles->flatMap(function ($role) {
+                return $role->permissions;
+            })->sort()->values();
+    }
+
+    /**
+     * Return all the permissions the model has, both directly and via roles.
+     */
+    public function getAllPermissions(): Collection
+    {
+        return $this->permissions
+            ->merge($this->getPermissionsViaRoles())
+            ->sort()
+            ->values();
+    }
+
     /**
      * Grant the given permission(s) to a role.
      *

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -5,7 +5,6 @@ namespace Spatie\Permission\Traits;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\Permission\Contracts\Permission;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 trait HasRoles
@@ -20,7 +19,6 @@ trait HasRoles
             }
 
             $model->roles()->detach();
-            $model->permissions()->detach();
         });
     }
 
@@ -35,20 +33,6 @@ trait HasRoles
             config('permission.table_names.model_has_roles'),
             'model_id',
             'role_id'
-        );
-    }
-
-    /**
-     * A model may have multiple direct permissions.
-     */
-    public function permissions(): MorphToMany
-    {
-        return $this->morphToMany(
-            config('permission.models.permission'),
-            'model',
-            config('permission.table_names.model_has_permissions'),
-            'model_id',
-            'permission_id'
         );
     }
 
@@ -85,65 +69,6 @@ trait HasRoles
                 }
             });
         });
-    }
-
-    /**
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
-     *
-     * @return array
-     */
-    protected function convertToPermissionModels($permissions): array
-    {
-        if ($permissions instanceof Collection) {
-            $permissions = $permissions->toArray();
-        }
-
-        $permissions = array_wrap($permissions);
-
-        return array_map(function ($permission) {
-            if ($permission instanceof Permission) {
-                return $permission;
-            }
-
-            return app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
-        }, $permissions);
-    }
-
-    /**
-     * Scope the model query to certain permissions only.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
-     *
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function scopePermission(Builder $query, $permissions): Builder
-    {
-        $permissions = $this->convertToPermissionModels($permissions);
-
-        $rolesWithPermissions = array_unique(array_reduce($permissions, function ($result, $permission) {
-            return array_merge($result, $permission->roles->all());
-        }, []));
-
-        return $query->
-            where(function ($query) use ($permissions, $rolesWithPermissions) {
-                $query->whereHas('permissions', function ($query) use ($permissions) {
-                    $query->where(function ($query) use ($permissions) {
-                        foreach ($permissions as $permission) {
-                            $query->orWhere(config('permission.table_names.permissions').'.id', $permission->id);
-                        }
-                    });
-                });
-                if (count($rolesWithPermissions) > 0) {
-                    $query->orWhereHas('roles', function ($query) use ($rolesWithPermissions) {
-                        $query->where(function ($query) use ($rolesWithPermissions) {
-                            foreach ($rolesWithPermissions as $role) {
-                                $query->orWhere(config('permission.table_names.roles').'.id', $role->id);
-                            }
-                        });
-                    });
-                }
-            });
     }
 
     /**
@@ -271,107 +196,11 @@ trait HasRoles
     }
 
     /**
-     * Determine if the model may perform the given permission.
-     *
-     * @param string|\Spatie\Permission\Contracts\Permission $permission
-     * @param string|null $guardName
-     *
-     * @return bool
-     */
-    public function hasPermissionTo($permission, $guardName = null): bool
-    {
-        if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName(
-                $permission,
-                $guardName ?? $this->getDefaultGuardName()
-            );
-        }
-
-        return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
-    }
-
-    /**
-     * Determine if the model has any of the given permissions.
-     *
-     * @param array ...$permissions
-     *
-     * @return bool
-     */
-    public function hasAnyPermission(...$permissions): bool
-    {
-        if (is_array($permissions[0])) {
-            $permissions = $permissions[0];
-        }
-
-        foreach ($permissions as $permission) {
-            if ($this->hasPermissionTo($permission)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Determine if the model has, via roles, the given permission.
-     *
-     * @param \Spatie\Permission\Contracts\Permission $permission
-     *
-     * @return bool
-     */
-    protected function hasPermissionViaRole(Permission $permission): bool
-    {
-        return $this->hasRole($permission->roles);
-    }
-
-    /**
-     * Determine if the model has the given permission.
-     *
-     * @param string|\Spatie\Permission\Contracts\Permission $permission
-     *
-     * @return bool
-     */
-    public function hasDirectPermission($permission): bool
-    {
-        if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
-
-            if (! $permission) {
-                return false;
-            }
-        }
-
-        return $this->permissions->contains('id', $permission->id);
-    }
-
-    /**
      * Return all permissions the directory coupled to the model.
      */
     public function getDirectPermissions(): Collection
     {
         return $this->permissions;
-    }
-
-    /**
-     * Return all the permissions the model has via roles.
-     */
-    public function getPermissionsViaRoles(): Collection
-    {
-        return $this->load('roles', 'roles.permissions')
-            ->roles->flatMap(function ($role) {
-                return $role->permissions;
-            })->sort()->values();
-    }
-
-    /**
-     * Return all the permissions the model has, both directly and via roles.
-     */
-    public function getAllPermissions(): Collection
-    {
-        return $this->permissions
-            ->merge($this->getPermissionsViaRoles())
-            ->sort()
-            ->values();
     }
 
     public function getRoleNames(): Collection

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Test;
 
+use Spatie\Permission\Models\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
@@ -175,5 +176,136 @@ class HasPermissionsTest extends TestCase
         $this->testUserRole->revokePermissionTo(['edit-articles', 'edit-news']);
 
         $this->assertEquals(0, $this->testUserRole->permissions()->count());
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_does_not_have_a_permission()
+    {
+        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_permission_does_not_exist()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUser->hasPermissionTo('does-not-exist');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_the_permission_does_not_exist_for_this_guard()
+    {
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUser->hasPermissionTo('admin-permission');
+    }
+
+    /** @test */
+    public function it_can_work_with_a_user_that_does_not_have_any_permissions_at_all()
+    {
+        $user = new User();
+
+        $this->assertFalse($user->hasPermissionTo('edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_has_any_of_the_permissions_directly()
+    {
+        $this->assertFalse($this->testUser->hasAnyPermission('edit-articles'));
+
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->refreshTestUser();
+
+        $this->testUser->revokePermissionTo($this->testUserPermission);
+
+        $this->assertTrue($this->testUser->hasAnyPermission('edit-articles', 'edit-news'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_has_any_of_the_permissions_directly_using_an_array()
+    {
+        $this->assertFalse($this->testUser->hasAnyPermission(['edit-articles']));
+
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasAnyPermission(['edit-news', 'edit-articles']));
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->refreshTestUser();
+
+        $this->testUser->revokePermissionTo($this->testUserPermission);
+
+        $this->assertTrue($this->testUser->hasAnyPermission(['edit-articles', 'edit-news']));
+    }
+
+    /** @test */
+    public function it_can_determine_that_the_user_has_any_of_the_permissions_via_role()
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+
+        $this->testUser->assignRole('testRole');
+
+        $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_determine_that_user_has_direct_permission()
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+        $this->refreshTestUser();
+
+        $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
+        $this->assertEquals(
+            collect(['edit-articles']),
+            $this->testUser->getDirectPermissions()->pluck('name')
+        );
+
+        $this->testUser->revokePermissionTo('edit-articles');
+        $this->refreshTestUser();
+        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+
+        $this->testUser->assignRole('testRole');
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->refreshTestUser();
+        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
+    }
+
+    /** @test */
+    public function it_can_list_all_the_permissions_via_his_roles()
+    {
+        $roleModel = app(Role::class);
+        $roleModel->findByName('testRole2')->givePermissionTo('edit-news');
+
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->testUser->assignRole('testRole', 'testRole2');
+
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getPermissionsViaRoles()->pluck('name')
+        );
+    }
+
+    /** @test */
+    public function it_can_list_all_the_coupled_permissions_both_directly_and_via_roles()
+    {
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->testUser->assignRole('testRole');
+
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getAllPermissions()->pluck('name')
+        );
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -5,7 +5,6 @@ namespace Spatie\Permission\Test;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
-use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 class HasRolesTest extends TestCase
 {
@@ -302,131 +301,6 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUser->hasAnyRole(['testRole', 'testAdminRole']));
 
         $this->assertFalse($this->testUser->hasAnyRole('testAdminRole', $this->testAdminRole));
-    }
-
-    /** @test */
-    public function it_can_determine_that_the_user_does_not_have_a_permission()
-    {
-        $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
-    }
-
-    /** @test */
-    public function it_throws_an_exception_when_the_permission_does_not_exist()
-    {
-        $this->expectException(PermissionDoesNotExist::class);
-
-        $this->testUser->hasPermissionTo('does-not-exist');
-    }
-
-    /** @test */
-    public function it_throws_an_exception_when_the_permission_does_not_exist_for_this_guard()
-    {
-        $this->expectException(PermissionDoesNotExist::class);
-
-        $this->testUser->hasPermissionTo('admin-permission');
-    }
-
-    /** @test */
-    public function it_can_work_with_a_user_that_does_not_have_any_permissions_at_all()
-    {
-        $user = new User();
-
-        $this->assertFalse($user->hasPermissionTo('edit-articles'));
-    }
-
-    /** @test */
-    public function it_can_determine_that_the_user_has_any_of_the_permissions_directly()
-    {
-        $this->assertFalse($this->testUser->hasAnyPermission('edit-articles'));
-
-        $this->testUser->givePermissionTo('edit-articles');
-
-        $this->refreshTestUser();
-
-        $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
-
-        $this->testUser->givePermissionTo('edit-news');
-
-        $this->refreshTestUser();
-
-        $this->testUser->revokePermissionTo($this->testUserPermission);
-
-        $this->assertTrue($this->testUser->hasAnyPermission('edit-articles', 'edit-news'));
-    }
-
-    /** @test */
-    public function it_can_determine_that_the_user_has_any_of_the_permissions_directly_using_an_array()
-    {
-        $this->assertFalse($this->testUser->hasAnyPermission(['edit-articles']));
-
-        $this->testUser->givePermissionTo('edit-articles');
-
-        $this->refreshTestUser();
-
-        $this->assertTrue($this->testUser->hasAnyPermission(['edit-news', 'edit-articles']));
-
-        $this->testUser->givePermissionTo('edit-news');
-
-        $this->refreshTestUser();
-
-        $this->testUser->revokePermissionTo($this->testUserPermission);
-
-        $this->assertTrue($this->testUser->hasAnyPermission(['edit-articles', 'edit-news']));
-    }
-
-    /** @test */
-    public function it_can_determine_that_the_user_has_any_of_the_permissions_via_role()
-    {
-        $this->testUserRole->givePermissionTo('edit-articles');
-
-        $this->testUser->assignRole('testRole');
-
-        $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
-    }
-
-    /** @test */
-    public function it_can_determine_that_user_has_direct_permission()
-    {
-        $this->testUser->givePermissionTo('edit-articles');
-        $this->refreshTestUser();
-        $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
-        $this->testUser->revokePermissionTo('edit-articles');
-        $this->refreshTestUser();
-        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
-
-        $this->testUser->assignRole('testRole');
-        $this->testUserRole->givePermissionTo('edit-articles');
-        $this->refreshTestUser();
-        $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
-    }
-
-    /** @test */
-    public function it_can_list_all_the_permissions_via_his_roles()
-    {
-        $roleModel = app(Role::class);
-        $roleModel->findByName('testRole2')->givePermissionTo('edit-news');
-
-        $this->testUserRole->givePermissionTo('edit-articles');
-        $this->testUser->assignRole('testRole', 'testRole2');
-
-        $this->assertEquals(
-            collect(['edit-articles', 'edit-news']),
-            $this->testUser->getPermissionsViaRoles()->pluck('name')
-        );
-    }
-
-    /** @test */
-    public function it_can_list_all_the_coupled_permissions_both_directly_and_via_roles()
-    {
-        $this->testUser->givePermissionTo('edit-news');
-
-        $this->testUserRole->givePermissionTo('edit-articles');
-        $this->testUser->assignRole('testRole');
-
-        $this->assertEquals(
-            collect(['edit-articles', 'edit-news']),
-            $this->testUser->getAllPermissions()->pluck('name')
-        );
     }
 
     /** @test */


### PR DESCRIPTION
Diffs are a bit funky here so let me know if I should break this up into many commits or PRs to make it clean. Only added an assertion to the `it_can_determine_that_user_has_direct_permission`. Otherwise just copy and paste.