### PR TITLE
Allow assign/sync/remove Roles from Permission model

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,27 @@ $role = Role::create(['name' => 'writer']);
 $permission = Permission::create(['name' => 'edit articles']);
 ```
 
+A permission can be assigned to a role using 1 of these methods:
+
+```php
+$role->givePermissionTo($permission);
+$permission->assignRole($role);
+```
+
+Multiple permissions can be synced to a role using 1 of these methods:
+
+```php
+$role->syncPermissions($permissions);
+$permission->syncRoles($roles);
+```
+
+A permission can be removed from a role using 1 of these methods:
+
+```php
+$role->revokePermissionTo($permission);
+$permission->removeRole($role);
+```
+
 If you're using multiple guards the `guard_name` attribute needs to be set as well. Read about it in the [using multiple guards](#using-multiple-guards) section of the readme.
 
 The `HasRoles` trait adds Eloquent relationships to your models, which can be accessed directly or used as a base query:
@@ -684,36 +705,36 @@ Two notes about Database Seeding:
 
 2. Here's a sample seeder, which clears the cache, creates permissions and then assigns permissions to roles:
 
-	```php
-	use Illuminate\Database\Seeder;
-	use Spatie\Permission\Models\Role;
-	use Spatie\Permission\Models\Permission;
+    ```php
+    use Illuminate\Database\Seeder;
+    use Spatie\Permission\Models\Role;
+    use Spatie\Permission\Models\Permission;
 
-	class RolesAndPermissionsSeeder extends Seeder
-	{
-	    public function run()
-    	{
-        	// Reset cached roles and permissions
-	        app()['cache']->forget('spatie.permission.cache');
+    class RolesAndPermissionsSeeder extends Seeder
+    {
+        public function run()
+        {
+            // Reset cached roles and permissions
+            app()['cache']->forget('spatie.permission.cache');
 
-	        // create permissions
-	        Permission::create(['name' => 'edit articles']);
-	        Permission::create(['name' => 'delete articles']);
-	        Permission::create(['name' => 'publish articles']);
-	        Permission::create(['name' => 'unpublish articles']);
+            // create permissions
+            Permission::create(['name' => 'edit articles']);
+            Permission::create(['name' => 'delete articles']);
+            Permission::create(['name' => 'publish articles']);
+            Permission::create(['name' => 'unpublish articles']);
 
-	        // create roles and assign existing permissions
-	        $role = Role::create(['name' => 'writer']);
-	        $role->givePermissionTo('edit articles');
-	        $role->givePermissionTo('delete articles');
+            // create roles and assign existing permissions
+            $role = Role::create(['name' => 'writer']);
+            $role->givePermissionTo('edit articles');
+            $role->givePermissionTo('delete articles');
 
-	        $role = Role::create(['name' => 'admin']);
-	        $role->givePermissionTo('publish articles');
-	        $role->givePermissionTo('unpublish articles');
-	    }
-	}
+            $role = Role::create(['name' => 'admin']);
+            $role->givePermissionTo('publish articles');
+            $role->givePermissionTo('unpublish articles');
+        }
+    }
 
-	```
+    ```
 
 ## Extending
 
@@ -740,6 +761,9 @@ When you use the supplied methods for manipulating roles and permissions, the ca
 $user->assignRole('writer');
 $user->removeRole('writer');
 $user->syncRoles(params);
+$permission->assignRole('writer');
+$permission->removeRole('writer');
+$permission->syncRoles(params);
 $role->givePermissionTo('edit articles');
 $role->revokePermissionTo('edit articles');
 $role->syncPermissions(params);

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ $role = Role::create(['name' => 'writer']);
 $permission = Permission::create(['name' => 'edit articles']);
 ```
 
+
 A permission can be assigned to a role using 1 of these methods:
 
 ```php
@@ -705,36 +706,36 @@ Two notes about Database Seeding:
 
 2. Here's a sample seeder, which clears the cache, creates permissions and then assigns permissions to roles:
 
-    ```php
-    use Illuminate\Database\Seeder;
-    use Spatie\Permission\Models\Role;
-    use Spatie\Permission\Models\Permission;
+	```php
+	use Illuminate\Database\Seeder;
+	use Spatie\Permission\Models\Role;
+	use Spatie\Permission\Models\Permission;
 
-    class RolesAndPermissionsSeeder extends Seeder
-    {
-        public function run()
-        {
-            // Reset cached roles and permissions
-            app()['cache']->forget('spatie.permission.cache');
+	class RolesAndPermissionsSeeder extends Seeder
+	{
+	    public function run()
+    	{
+        	// Reset cached roles and permissions
+	        app()['cache']->forget('spatie.permission.cache');
 
-            // create permissions
-            Permission::create(['name' => 'edit articles']);
-            Permission::create(['name' => 'delete articles']);
-            Permission::create(['name' => 'publish articles']);
-            Permission::create(['name' => 'unpublish articles']);
+	        // create permissions
+	        Permission::create(['name' => 'edit articles']);
+	        Permission::create(['name' => 'delete articles']);
+	        Permission::create(['name' => 'publish articles']);
+	        Permission::create(['name' => 'unpublish articles']);
 
-            // create roles and assign existing permissions
-            $role = Role::create(['name' => 'writer']);
-            $role->givePermissionTo('edit articles');
-            $role->givePermissionTo('delete articles');
+	        // create roles and assign existing permissions
+	        $role = Role::create(['name' => 'writer']);
+	        $role->givePermissionTo('edit articles');
+	        $role->givePermissionTo('delete articles');
 
-            $role = Role::create(['name' => 'admin']);
-            $role->givePermissionTo('publish articles');
-            $role->givePermissionTo('unpublish articles');
-        }
-    }
+	        $role = Role::create(['name' => 'admin']);
+	        $role->givePermissionTo('publish articles');
+	        $role->givePermissionTo('unpublish articles');
+	    }
+	}
 
-    ```
+	```
 
 ## Extending
 
@@ -761,12 +762,12 @@ When you use the supplied methods for manipulating roles and permissions, the ca
 $user->assignRole('writer');
 $user->removeRole('writer');
 $user->syncRoles(params);
-$permission->assignRole('writer');
-$permission->removeRole('writer');
-$permission->syncRoles(params);
 $role->givePermissionTo('edit articles');
 $role->revokePermissionTo('edit articles');
 $role->syncPermissions(params);
+$permission->assignRole('writer');
+$permission->removeRole('writer');
+$permission->syncRoles(params);
 ```
 
 HOWEVER, if you manipulate permission/role data directly in the database instead of calling the supplied methods, then you will not see the changes reflected in the application unless you manually reset the cache.

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Spatie\Permission\Guard;
 use Illuminate\Support\Collection;
+use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
@@ -15,6 +16,7 @@ use Spatie\Permission\Contracts\Permission as PermissionContract;
 
 class Permission extends Model implements PermissionContract
 {
+    use HasRoles;
     use RefreshesPermissionCache;
 
     public $guarded = ['id'];

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -30,6 +30,20 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_assign_and_remove_a_role_on_a_permission()
+    {
+        $this->testUserPermission->assignRole('testRole');
+
+        $this->assertTrue($this->testUserPermission->hasRole('testRole'));
+
+        $this->testUserPermission->removeRole('testRole');
+
+        $this->refreshTestUserPermission();
+
+        $this->assertFalse($this->testUserPermission->hasRole('testRole'));
+    }
+
+    /** @test */
     public function it_can_assign_a_role_using_an_object()
     {
         $this->testUser->assignRole($this->testUserRole);
@@ -102,6 +116,18 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_sync_roles_from_a_string_on_a_permission()
+    {
+        $this->testUserPermission->assignRole('testRole');
+
+        $this->testUserPermission->syncRoles('testRole2');
+
+        $this->assertFalse($this->testUserPermission->hasRole('testRole'));
+
+        $this->assertTrue($this->testUserPermission->hasRole('testRole2'));
+    }
+
+    /** @test */
     public function it_can_sync_multiple_roles()
     {
         $this->testUser->syncRoles('testRole', 'testRole2');
@@ -122,7 +148,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
-    public function it_will_remove_all_roles_when_an_empty_array_is_past_to_sync_roles()
+    public function it_will_remove_all_roles_when_an_empty_array_is_passed_to_sync_roles()
     {
         $this->testUser->assignRole('testRole');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -126,7 +126,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * Refresh the testuser.
+     * Refresh the testUser.
      */
     public function refreshTestUser()
     {
@@ -139,6 +139,14 @@ abstract class TestCase extends Orchestra
     public function refreshTestAdmin()
     {
         $this->testAdmin = $this->testAdmin->fresh();
+    }
+
+    /**
+     * Refresh the testUserPermission.
+     */
+    public function refreshTestUserPermission()
+    {
+        $this->testUserPermission = $this->testUserPermission->fresh();
     }
 
     protected function clearLogTestHandler()


### PR DESCRIPTION
This will allow the Roles to be synced from a Permission.

My use case is on the CRUD pages for Permissions. When creating/editing a Permission, I'd like to be able to specify which role(s) it applies to.

Currently I am doing this:

```php
$permission->roles()->sync($request->roles);
app(PermissionRegistrar::class)->forgetCachedPermissions();
```

After this PR:

```php
$permission->syncRoles($request->roles);
```