### PR TITLE
Improve documentation on extending models

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,18 +717,23 @@ Two notes about Database Seeding:
 
 ## Extending
 
-If you need to extend or replace the existing `Role` or `Permission` models you just need to
-keep the following things in mind:
+If you need to EXTEND the existing `Role` or `Permission` models note that:
 
 - Your `Role` model needs to extend the `Spatie\Permission\Models\Role` model
 - Your `Permission` model needs to extend the `Spatie\Permission\Models\Permission` model
-- You can publish the configuration with this command:
+
+If you need to REPLACE the existing `Role` or `Permission` models you need to keep the
+following things in mind:
+
+- Your `Role` model needs to implement the `Spatie\Permission\Contracts\Role` contract
+- Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
+
+In BOTH cases, whether extending or replacing, you will need to specify your new models in the configuration. To do this you must update the `models.role` and `models.permission` values in the configuration file after publishing the configuration with this command:
 
 ```bash
 php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
 ```
-  
-  And update the `models.role` and `models.permission` values
+ 
 
 ## Cache
 

--- a/README.md
+++ b/README.md
@@ -720,8 +720,8 @@ Two notes about Database Seeding:
 If you need to extend or replace the existing `Role` or `Permission` models you just need to
 keep the following things in mind:
 
-- Your `Role` model needs to implement the `Spatie\Permission\Contracts\Role` contract
-- Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
+- Your `Role` model needs to extend the `Spatie\Permission\Models\Role` model
+- Your `Permission` model needs to extend the `Spatie\Permission\Models\Permission` model
 - You can publish the configuration with this command:
 
 ```bash


### PR DESCRIPTION
Extending a model doesn't work with implementing the contract, but works with extending the model.