### PR TITLE
Add ability to pass guard name to gate methods like can()

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -28,10 +28,14 @@ class PermissionRegistrar
 
     public function registerPermissions(): bool
     {
-        $this->gate->before(function (Authenticatable $user, string $ability) {
+        $this->gate->before(function (Authenticatable $user, string $ability, $guard = null) {
+            if (\is_array($guard)) {
+                $guard = array_first($guard);
+            }
+
             try {
                 if (method_exists($user, 'hasPermissionTo')) {
-                    return $user->hasPermissionTo($ability) ?: null;
+                    return $user->hasPermissionTo($ability, $guard) ?: null;
                 }
             } catch (PermissionDoesNotExist $e) {
             }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -28,7 +28,7 @@ class PermissionRegistrar
 
     public function registerPermissions(): bool
     {
-        $this->gate->before(function (Authenticatable $user, string $ability, $guard = null) {
+        $this->gate->before(function (Authorizable $user, string $ability, $guard = null) {
             if (\is_array($guard)) {
                 $guard = array_first($guard);
             }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -204,6 +204,20 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    public function it_can_approve_and_reject_via_the_gate_when_the_permission_is_not_valid_for_a_specific_guard()
+    {
+        $this->testAdmin->givePermissionTo($this->testAdminPermission);
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->assertFalse($this->testUser->can('admin-permission', 'admin'));
+        $this->assertTrue($this->testUser->can('edit-articles', 'web'));
+
+        $this->assertTrue($this->testAdmin->can('admin-permission', 'admin'));
+        $this->assertTrue($this->testAdmin->can('admin-permission'));
+        $this->assertFalse($this->testAdmin->can('admin-permission', 'web'));
+    }
+
+    /** @test */
     public function it_can_work_with_a_user_that_does_not_have_any_permissions_at_all()
     {
         $user = new User();


### PR DESCRIPTION
Before this, guards passed to gate methods were ignored.
ie:
`can($ability, $guard)`
was treated as just:
`can($ability)`