### PR TITLE
improve speed of findByName and findById on permissions

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -84,7 +84,9 @@ class Permission extends Model implements PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->where('name', $name)->where('guard_name', $guardName)->first();
+        $permission = static::getPermissions()->filter(function($permission) use ($name, $guardName) {
+            return $permission->name === $name && $permission->guard_name === $guardName;
+        })->first();
 
         if (! $permission) {
             throw PermissionDoesNotExist::create($name, $guardName);
@@ -107,7 +109,9 @@ class Permission extends Model implements PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->where('id', $id)->where('guard_name', $guardName)->first();
+        $permission = static::getPermissions()->filter(function($permission) use ($id, $guardName) {
+            return $permission->id === $id && $permission->guard_name === $guardName;
+        })->first();
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -34,7 +34,11 @@ class Permission extends Model implements PermissionContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
-        if (static::getPermissions()->where('name', $attributes['name'])->where('guard_name', $attributes['guard_name'])->first()) {
+        $permission = static::getPermissions()->filter(function ($permission) use($attributes) {
+            return $permission->name === $attributes['name'] && $permission->guard_name === $attributes['guard_name'];
+        })->first();
+
+        if ($permission) {
             throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
         }
 
@@ -132,7 +136,9 @@ class Permission extends Model implements PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->where('name', $name)->where('guard_name', $guardName)->first();
+        $permission = static::getPermissions()->filter(function ($permission) use ($name, $guardName) {
+            return $permission->name === $name && $permission->guard_name === $guardName;
+        })->first();
 
         if (! $permission) {
             return static::create(['name' => $name, 'guard_name' => $guardName]);

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -84,7 +84,7 @@ class Permission extends Model implements PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->filter(function($permission) use ($name, $guardName) {
+        $permission = static::getPermissions()->filter(function ($permission) use ($name, $guardName) {
             return $permission->name === $name && $permission->guard_name === $guardName;
         })->first();
 
@@ -109,7 +109,7 @@ class Permission extends Model implements PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->filter(function($permission) use ($id, $guardName) {
+        $permission = static::getPermissions()->filter(function ($permission) use ($id, $guardName) {
             return $permission->id === $id && $permission->guard_name === $guardName;
         })->first();
 

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -34,7 +34,7 @@ class Permission extends Model implements PermissionContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->filter(function ($permission) use($attributes) {
+        $permission = static::getPermissions()->filter(function ($permission) use ($attributes) {
             return $permission->name === $attributes['name'] && $permission->guard_name === $attributes['guard_name'];
         })->first();
 


### PR DESCRIPTION
This PR addresses issue #550. The `findByName` and `findById` methods were filtering the collection of permissions using the `where` method. Using `filter` on a collection is faster.

All tests still pass. I've also tested the integration with the (private) project I'm currently working on and everything looks good. Tests on my own project indicate a 10-15% performance increase when running these tests:
```php
Auth::loginUsingId(1); // change to active user

for ($i = 0; $i < 1000; ++$i) {
    $time_start = microtime(true);
    auth()->user()->can('my_permission_name'); // change to real permission name
    $time_end = microtime(true);
    $t = $time_end - $time_start;
    $time_by_name[] = $t;
}

for ($i = 0; $i < 1000; ++$i) {
    $time_start = microtime(true);
    auth()->user()->can(42); // change to real permission id
    $time_end = microtime(true);
    $t = $time_end - $time_start;
    $time_by_id[] = $t;
}

dd(array_sum($time_by_name), array_sum($time_by_id));
```

Please let me know if I can help to get this PR merged :)

Barry