### PR TITLE
Update PermissionRegistrar to use Authorizable instead of Authenticatable

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Cache\Repository;
 use Spatie\Permission\Contracts\Permission;
-use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 class PermissionRegistrar
@@ -28,7 +28,7 @@ class PermissionRegistrar
 
     public function registerPermissions(): bool
     {
-        $this->gate->before(function (Authenticatable $user, string $ability) {
+        $this->gate->before(function (Authorizable $user, string $ability) {
             try {
                 if (method_exists($user, 'hasPermissionTo')) {
                     return $user->hasPermissionTo($ability) ?: null;


### PR DESCRIPTION
The package assumes that the model which is being assigned roles/permissions (e.g. User) implements the Authenticatable contract. This is not always the case. Laravel itself adds its authorization method, i.e. can to the Authorizable trait, and not Authenticatable.
This commit changes the type-hinted Authenticatable to Authorizable instead. Closes #694.