### PR TITLE
Support multiple db connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ return [
     ],
 
     /*
+     * Occasionally an app may use separate db connections for storing permission data
+     * for its models. You may specify which connection to use for role / permission
+     * tables as long as your models use the same name in their $connection property.
+     */
+
+    'db_connection' => null,
+
+    /*
      * By default all permissions will be cached for 24 hours unless a permission or
      * role is updated. Then the cache will be flushed immediately.
      */

--- a/config/permission.php
+++ b/config/permission.php
@@ -72,6 +72,14 @@ return [
     ],
 
     /*
+     * Occasionally an app may use separate db connections for storing permission data
+     * for its models. You may specify which connection to use for role / permission
+     * tables as long as your models use the same name in their $connection property.
+     */
+
+    'db_connection' => null,
+
+    /*
      * By default all permissions will be cached for 24 hours unless a permission or
      * role is updated. Then the cache will be flushed immediately.
      */

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -11,25 +11,27 @@ class CreatePermissionTables extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up($connection = null)
     {
+        $connection = $connection ?? config('permission.db_connection');
+
         $tableNames = config('permission.table_names');
 
-        Schema::create($tableNames['permissions'], function (Blueprint $table) {
+        Schema::connection($connection)->create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
         });
 
-        Schema::create($tableNames['roles'], function (Blueprint $table) {
+        Schema::connection($connection)->create($tableNames['roles'], function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
         });
 
-        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames) {
+        Schema::connection($connection)->create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames) {
             $table->unsignedInteger('permission_id');
             $table->morphs('model');
 
@@ -41,7 +43,7 @@ class CreatePermissionTables extends Migration
             $table->primary(['permission_id', 'model_id', 'model_type']);
         });
 
-        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames) {
+        Schema::connection($connection)->create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames) {
             $table->unsignedInteger('role_id');
             $table->morphs('model');
 
@@ -53,7 +55,7 @@ class CreatePermissionTables extends Migration
             $table->primary(['role_id', 'model_id', 'model_type']);
         });
 
-        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
+        Schema::connection($connection)->create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
             $table->unsignedInteger('permission_id');
             $table->unsignedInteger('role_id');
 
@@ -78,14 +80,16 @@ class CreatePermissionTables extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down($connection = null)
     {
+        $connection = $connection ?? config('permission.db_connection');
+
         $tableNames = config('permission.table_names');
 
-        Schema::drop($tableNames['role_has_permissions']);
-        Schema::drop($tableNames['model_has_roles']);
-        Schema::drop($tableNames['model_has_permissions']);
-        Schema::drop($tableNames['roles']);
-        Schema::drop($tableNames['permissions']);
+        Schema::connection($connection)->drop($tableNames['role_has_permissions']);
+        Schema::connection($connection)->drop($tableNames['model_has_roles']);
+        Schema::connection($connection)->drop($tableNames['model_has_permissions']);
+        Schema::connection($connection)->drop($tableNames['roles']);
+        Schema::connection($connection)->drop($tableNames['permissions']);
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -28,6 +28,10 @@ class Permission extends Model implements PermissionContract
         parent::__construct($attributes);
 
         $this->setTable(config('permission.table_names.permissions'));
+
+        if ($connection = config('permission.db_connection')) {
+            $this->setConnection($connection);
+        }
     }
 
     public static function create(array $attributes = [])

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -27,6 +27,10 @@ class Role extends Model implements RoleContract
         parent::__construct($attributes);
 
         $this->setTable(config('permission.table_names.roles'));
+
+        if ($connection = config('permission.db_connection')) {
+            $this->setConnection($connection);
+        }
     }
 
     public static function create(array $attributes = [])

--- a/tests/Admin.php
+++ b/tests/Admin.php
@@ -23,4 +23,14 @@ class Admin extends Model implements AuthorizableContract, AuthenticatableContra
     public $timestamps = false;
 
     protected $table = 'admins';
+
+    // for testing, override the connection lookup
+    public function getConnectionName()
+    {
+        if ($connection = config('permission.db_connection')) {
+            $this->connection = $connection;
+        }
+
+        return $this->connection;
+    }
 }

--- a/tests/DbConnectionsTest.php
+++ b/tests/DbConnectionsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+class DbConnectionsTest extends TestCase
+{
+    protected $first_connection = 'will be detected by tests';
+
+    protected $second_connection = 'second_connection';
+
+    /**
+     * Here we add another connection to the environment setup
+     * And then the master setUp() will seed the database using the new connection, in preparation for these tests.
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // remember the default for use in test assertions
+        $this->first_connection = $app['config']['database.default'];
+
+        // create another connection for testing
+        $app['config']->set('permission.db_connection', $this->second_connection);
+        $app['config']->set('database.connections.'.$this->second_connection, [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'connection2_',
+        ]);
+
+        // pass this preferred connection to rest of setUp()
+        $this->connection = $this->second_connection;
+    }
+
+    /** @test */
+    public function the_testsetup_roles_are_found_in_the_second_connection()
+    {
+        $this->assertDatabaseHas('roles', ['name' => 'testRole'], $this->second_connection);
+        $this->assertDatabaseHas('permissions', ['name' => 'edit-articles'], $this->second_connection);
+    }
+
+    /** @test */
+    public function the_testsetup_roles_are_not_found_in_the_default_connection()
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectExceptionMessage('no such table');
+        $this->assertDatabaseMissing('roles', ['name' => 'testRole'], $this->first_connection);
+        $this->assertDatabaseMissing('permissions', ['name' => 'edit-articles'], $this->first_connection);
+    }
+
+    public function the_test_user_is_found_in_the_second_connection()
+    {
+        $this->assertDatabaseHas('users', ['email' => 'test@user.com'], $this->second_connection);
+    }
+
+    public function the_test_user_is_not_found_in_the_default_connection()
+    {
+        $this->assertDatabaseMissing('users', ['email' => 'test@user.com'], $this->first_connection);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,11 +29,14 @@ abstract class TestCase extends Orchestra
     /** @var \Spatie\Permission\Models\Permission */
     protected $testAdminPermission;
 
+    /** @var string $connection */
+    protected $connection = null;
+
     public function setUp()
     {
         parent::setUp();
 
-        $this->setUpDatabase($this->app);
+        $this->setUpDatabase($this->app, $this->connection);
 
         $this->testUser = User::first();
         $this->testUserRole = app(Role::class)->find(1);
@@ -84,23 +87,24 @@ abstract class TestCase extends Orchestra
      * Set up the database.
      *
      * @param \Illuminate\Foundation\Application $app
+     * @param string $connection
      */
-    protected function setUpDatabase($app)
+    protected function setUpDatabase($app, $connection = null)
     {
-        $app['db']->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+        $app['db']->connection($connection)->getSchemaBuilder()->create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->softDeletes();
         });
 
-        $app['db']->connection()->getSchemaBuilder()->create('admins', function (Blueprint $table) {
+        $app['db']->connection($connection)->getSchemaBuilder()->create('admins', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
         });
 
         include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
 
-        (new \CreatePermissionTables())->up();
+        (new \CreatePermissionTables())->up($connection);
 
         User::create(['email' => 'test@user.com']);
         Admin::create(['email' => 'admin@user.com']);

--- a/tests/User.php
+++ b/tests/User.php
@@ -23,4 +23,14 @@ class User extends Model implements AuthorizableContract, AuthenticatableContrac
     public $timestamps = false;
 
     protected $table = 'users';
+
+    // for testing, override the connection lookup
+    public function getConnectionName()
+    {
+        if ($connection = config('permission.db_connection')) {
+            $this->connection = $connection;
+        }
+
+        return $this->connection;
+    }
 }


### PR DESCRIPTION
To support storing the role/permission data and its associated models on a specific database connection, set the config `db_connection` (default is null) to the connection-name of a specific connection defined in your `config/database.php` connections array. ALL associated models using roles/permissions MUST have their `$connection` property set to the same name.

Closes #697