### PR TITLE
Added Events firing when assigning roles or permissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,9 @@
         "illuminate/database": "~5.4.0|~5.5.0|~5.6.0"
     },
     "require-dev": {
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.3.0|~3.4.2|^3.5.0",
-        "phpunit/phpunit" : "^5.7|6.2|^7.0"
+        "phpunit/phpunit": "^5.7|6.2|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/permission.php
+++ b/config/permission.php
@@ -85,4 +85,8 @@ return [
      */
 
     'display_permission_in_exception' => false,
+    /*
+     * If set to false Custom Events will not be fired when roles/permission is assigned
+     */
+    'events_enabled' => true,
 ];

--- a/src/Events/PermissionAssigned.php
+++ b/src/Events/PermissionAssigned.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PermissionAssigned
+{
+    use SerializesModels;
+
+    /**
+     * @var Collection
+     */
+    public $permissions;
+    /**
+     * @var Model
+     */
+    public $target;
+
+    public function __construct(Collection $permissions, Model $target)
+    {
+        $this->permissions = $permissions;
+        $this->target = $target;
+    }
+
+}

--- a/src/Events/PermissionRevoked.php
+++ b/src/Events/PermissionRevoked.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PermissionRevoked
+{
+    use SerializesModels;
+
+    /**
+     * @var Collection
+     */
+    public $permissions;
+    /**
+     * @var Model
+     */
+    public $target;
+
+    public function __construct(Collection $permissions, Model $target)
+    {
+        $this->permissions = $permissions;
+        $this->target = $target;
+    }
+
+}

--- a/src/Events/PermissionSynched.php
+++ b/src/Events/PermissionSynched.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class PermissionSynched
+{
+    use SerializesModels;
+
+    /**
+     * @var Collection
+     */
+    public $permissions_assigned;
+    /**
+     * @var Collection
+     */
+    public $permissions_revoked;
+    /**
+     * @var Collection
+     */
+    public $permissions_added;
+    /**
+     * @var Model
+     */
+    public $target;
+
+    public function __construct(Collection $permissions_revoked, Collection $permissions_added, Collection $permissions_assigned, Model $target)
+    {
+        $this->permissions_revoked = $permissions_revoked;
+        $this->permissions_added = $permissions_added;
+        $this->permissions_assigned = $permissions_assigned;
+        $this->target = $target;
+    }
+
+}

--- a/src/Events/RoleAssigned.php
+++ b/src/Events/RoleAssigned.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class RoleAssigned
+{
+    use SerializesModels;
+
+    /**
+     * @var Collection
+     */
+    public $roles;
+    /**
+     * @var Model
+     */
+    public $target;
+
+    public function __construct(Collection $roles, Model $target)
+    {
+        $this->roles = $roles;
+        $this->target = $target;
+    }
+
+}

--- a/src/Events/RoleRevoked.php
+++ b/src/Events/RoleRevoked.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class RoleRevoked
+{
+    use SerializesModels;
+
+    /**
+     * @var Collection
+     */
+    public $roles;
+    /**
+     * @var Model
+     */
+    public $target;
+
+    public function __construct(Collection $roles, Model $target)
+    {
+        $this->roles = $roles;
+        $this->target = $target;
+    }
+
+}

--- a/src/Events/RoleSynched.php
+++ b/src/Events/RoleSynched.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class RoleSynched
+{
+    use SerializesModels;
+
+    /**
+     * @var Collection
+     */
+    public $roles_assigned;
+    /**
+     * @var Collection
+     */
+    public $roles_revoked;
+    /**
+     * @var Collection
+     */
+    public $roles_added;
+    /**
+     * @var Model
+     */
+    public $target;
+
+    public function __construct(Collection $roles_revoked, Collection $roles_added, Collection $roles_assigned, Model $target)
+    {
+        $this->roles_revoked = $roles_revoked;
+        $this->roles_added = $roles_added;
+        $this->roles_assigned = $roles_assigned;
+        $this->target = $target;
+    }
+
+}

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright (c) Padosoft.com 2018.
+ */
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Support\Facades\Event;
+use Spatie\Permission\Events\PermissionRevoked;
+use Spatie\Permission\Events\PermissionSynched;
+use Spatie\Permission\Events\RoleAssigned;
+use Spatie\Permission\Events\RoleRevoked;
+use Spatie\Permission\Events\RoleSynched;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Events\PermissionAssigned;
+
+class EventTest extends TestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+        Permission::create(['name' => 'other-permission']);
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_permission_assigned_to_role()
+    {
+        Event::fake();
+
+        $this->testUserRole->givePermissionTo('other-permission');
+        $role = $this->testUserRole;
+        Event::assertDispatched(PermissionAssigned::class, function ($event) use ($role) {
+            return count($event->permissions) === 1 && $event->target == $role;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_role_assigned_to_permission()
+    {
+        Event::fake();
+        $role = $this->testUserRole;
+        $perm = Permission::create(['name' => 'other-permission2']);
+        $perm->assignRole($role);
+
+        Event::assertDispatched(PermissionAssigned::class, function ($event) use ($role) {
+            return count($event->permissions) === 1 && $event->target == $role;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_role_synched_to_permission()
+    {
+        Event::fake();
+        $role = $this->testUserRole;
+        $role2 = app(Role::class)->findByName('testRole2');
+        $perm = Permission::create(['name' => 'other-permission2']);
+        $perm->disablePermissionEvents();
+        $perm = $perm->syncRoles('testRole');
+        Event::assertNotDispatched(PermissionAssigned::class);
+        $perm->enablePermissionEvents();
+        $perm = $perm->syncRoles('testRole2');
+        Event::assertDispatched(PermissionAssigned::class, function ($event) use ($role2) {
+            return count($event->permissions) === 1 && $event->target->id == $role2->id;
+        });
+        Event::assertDispatched(PermissionRevoked::class, function ($event) use ($role) {
+            return count($event->permissions) === 1 && $event->target->id == $role->id;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_permission_synched_to_role()
+    {
+        Event::fake();
+
+        $this->testUserRole->syncPermissions('other-permission', 'edit-articles');
+        $role = $this->testUserRole;
+        Event::assertDispatched(PermissionSynched::class, function ($event) use ($role) {
+            return count($event->permissions_revoked) === 0 && count($event->permissions_added) === 2 && count($event->permissions_assigned) === 2 && $event->target == $role;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_permission_assigned_to_user()
+    {
+        Event::fake();
+
+        $this->testUser->givePermissionTo('other-permission');
+        $user = $this->testUser;
+        Event::assertDispatched(PermissionAssigned::class, function ($event) use ($user) {
+            return count($event->permissions) === 1 && $event->target == $user;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_permission_synched_to_user()
+    {
+        Event::fake();
+
+        $this->testUser->syncPermissions('other-permission', 'edit-articles');
+        $user = $this->testUser;
+        Event::assertDispatched(PermissionSynched::class, function ($event) use ($user) {
+            return count($event->permissions_revoked) === 0 && count($event->permissions_added) === 2 && count($event->permissions_assigned) === 2 && $event->target == $user;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_permission_revoked_to_role()
+    {
+        Event::fake();
+
+        $this->testUserRole->revokePermissionTo('edit-articles');
+        $role = $this->testUserRole;
+        Event::assertDispatched(PermissionRevoked::class, function ($event) use ($role) {
+            return count($event->permissions) === 1 && $event->target == $role;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_role_revoked_from_role()
+    {
+        Event::fake();
+        $role = $this->testUserRole;
+        $this->testUserPermission->removeRole($role);
+
+        Event::assertDispatched(PermissionRevoked::class, function ($event) use ($role) {
+            return count($event->permissions) === 1 && $event->target == $role;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_permission_revoked_to_user()
+    {
+        Event::fake();
+
+        $this->testUser->revokePermissionTo('edit-articles');
+        $user = $this->testUser;
+        Event::assertDispatched(PermissionRevoked::class, function ($event) use ($user) {
+            return count($event->permissions) === 1 && $event->target == $user;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_role_assigned_to_user()
+    {
+        Event::fake();
+
+        $this->testUser->assignRole('testRole');
+        $user = $this->testUser;
+        Event::assertDispatched(RoleAssigned::class, function ($event) use ($user) {
+            return count($event->roles) === 1 && $event->target == $user;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_roles_synched_to_user()
+    {
+        Event::fake();
+
+        $this->testUser->syncRoles('testRole', 'testRole2');
+        $user = $this->testUser;
+        Event::assertNotDispatched(RoleAssigned::class);
+        Event::assertDispatched(RoleSynched::class, function ($event) use ($user) {
+            return count($event->roles_revoked) === 0 && count($event->roles_added) === 2 && count($event->roles_assigned) === 2 && $event->target == $user;
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_on_role_revoked_to_user()
+    {
+        Event::fake();
+
+        $this->testUser->removeRole('testRole');
+        $user = $this->testUser;
+        Event::assertDispatched(RoleRevoked::class, function ($event) use ($user) {
+            return count($event->roles) === 1 && $event->target == $user;
+        });
+    }
+}


### PR DESCRIPTION
I was using this package to manage roles and permissions on a project.
However, I needed to keep a log of the permissions and roles that were assigned or revoked to users.
I saw that it was not present so I added support for these events. I have not added the events on the creation, modification and deletion because for these it is sufficient to create an observer on Role and Permission models.
In addition, I also managed the activation of this feature via config.
Probably the implementation is far from perfect but I hope you can find it useful too to increase the potential of this already very interesting package.

Best Regards,
Leonardo Padovani.