### PR TITLE
Replacing static Permission::class and Role::class with dynamic value

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -138,12 +138,14 @@ class Role extends Model implements RoleContract
      */
     public function hasPermissionTo($permission): bool
     {
+        $permissionClass = $this->getPermissionClass();
+
         if (is_string($permission)) {
-            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findByName($permission, $this->getDefaultGuardName());
+            $permission = $permissionClass->findByName($permission, $this->getDefaultGuardName());
         }
 
         if (is_int($permission)) {
-            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findById($permission, $this->getDefaultGuardName());
+            $permission = $permissionClass->findById($permission, $this->getDefaultGuardName());
         }
 
         if (! $this->getGuardNames()->contains($permission->guard_name)) {

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Spatie\Permission\Guard;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -138,11 +139,11 @@ class Role extends Model implements RoleContract
     public function hasPermissionTo($permission): bool
     {
         if (is_string($permission)) {
-            $permission = app(config('permission.models.permission'))->findByName($permission, $this->getDefaultGuardName());
+            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findByName($permission, $this->getDefaultGuardName());
         }
 
         if (is_int($permission)) {
-            $permission = app(config('permission.models.permission'))->findById($permission, $this->getDefaultGuardName());
+            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findById($permission, $this->getDefaultGuardName());
         }
 
         if (! $this->getGuardNames()->contains($permission->guard_name)) {

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,7 +4,6 @@ namespace Spatie\Permission\Models;
 
 use Spatie\Permission\Guard;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -138,11 +138,11 @@ class Role extends Model implements RoleContract
     public function hasPermissionTo($permission): bool
     {
         if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
+            $permission = app(config('permission.models.permission'))->findByName($permission, $this->getDefaultGuardName());
         }
 
         if (is_int($permission)) {
-            $permission = app(Permission::class)->findById($permission, $this->getDefaultGuardName());
+            $permission = app(config('permission.models.permission'))->findById($permission, $this->getDefaultGuardName());
         }
 
         if (! $this->getGuardNames()->contains($permission->guard_name)) {

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -55,8 +55,10 @@ class PermissionRegistrar
 
     public function getPermissions(): Collection
     {
-        return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () {
-            return $this->getPermissionClass()->with('roles')->get();
+        $permissionClass = $this->getPermissionClass();
+
+        return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () use ($permissionClass) {
+            return $permissionClass->with('roles')->get();
         });
     }
 

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -48,7 +48,7 @@ class PermissionRegistrar
     public function getPermissions(): Collection
     {
         return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () {
-            return app(Permission::class)->with('roles')->get();
+            return app(config('permission.models.permission'))->with('roles')->get();
         });
     }
 }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -20,10 +20,18 @@ class PermissionRegistrar
     /** @var string */
     protected $cacheKey = 'spatie.permission.cache';
 
+    /** @var string */
+    protected $permissionClass;
+
+    /** @var string */
+    protected $roleClass;
+
     public function __construct(Gate $gate, Repository $cache)
     {
         $this->gate = $gate;
         $this->cache = $cache;
+        $this->permissionClass = config('permission.models.permission');
+        $this->roleClass = config('permission.models.role');
     }
 
     public function registerPermissions(): bool
@@ -48,7 +56,17 @@ class PermissionRegistrar
     public function getPermissions(): Collection
     {
         return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () {
-            return app(config('permission.models.permission'))->with('roles')->get();
+            return app(PermissionRegistrar::class)->getPermissionClass()->with('roles')->get();
         });
+    }
+
+    public function getPermissionClass()
+    {
+        return app($this->permissionClass);
+    }
+
+    public function getRoleClass()
+    {
+        return app($this->roleClass);
     }
 }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -56,7 +56,7 @@ class PermissionRegistrar
     public function getPermissions(): Collection
     {
         return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () {
-            return app(PermissionRegistrar::class)->getPermissionClass()->with('roles')->get();
+            return $this->getPermissionClass()->with('roles')->get();
         });
     }
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -91,7 +91,7 @@ trait HasPermissions
                 return $permission;
             }
 
-            return app(config('permission.models.permission'))->findByName($permission, $this->getDefaultGuardName());
+            return app(PermissionRegistrar::class)->getPermissionClass()->findByName($permission, $this->getDefaultGuardName());
         }, $permissions);
     }
 
@@ -106,14 +106,14 @@ trait HasPermissions
     public function hasPermissionTo($permission, $guardName = null): bool
     {
         if (is_string($permission)) {
-            $permission = app(config('permission.models.permission'))->findByName(
+            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findByName(
                 $permission,
                 $guardName ?? $this->getDefaultGuardName()
             );
         }
 
         if (is_int($permission)) {
-            $permission = app(config('permission.models.permission'))->findById($permission, $this->getDefaultGuardName());
+            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findById($permission, $this->getDefaultGuardName());
         }
 
         return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
@@ -163,14 +163,14 @@ trait HasPermissions
     public function hasDirectPermission($permission): bool
     {
         if (is_string($permission)) {
-            $permission = app(config('permission.models.permission'))->findByName($permission, $this->getDefaultGuardName());
+            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findByName($permission, $this->getDefaultGuardName());
             if (! $permission) {
                 return false;
             }
         }
 
         if (is_int($permission)) {
-            $permission = app(config('permission.models.permission'))->findById($permission, $this->getDefaultGuardName());
+            $permission = app(PermissionRegistrar::class)->getPermissionClass()->findById($permission, $this->getDefaultGuardName());
             if (! $permission) {
                 return false;
             }
@@ -265,15 +265,15 @@ trait HasPermissions
     protected function getStoredPermission($permissions)
     {
         if (is_numeric($permissions)) {
-            return app(config('permission.models.permission'))->findById($permissions, $this->getDefaultGuardName());
+            return app(PermissionRegistrar::class)->getPermissionClass()->findById($permissions, $this->getDefaultGuardName());
         }
 
         if (is_string($permissions)) {
-            return app(config('permission.models.permission'))->findByName($permissions, $this->getDefaultGuardName());
+            return app(PermissionRegistrar::class)->getPermissionClass()->findByName($permissions, $this->getDefaultGuardName());
         }
 
         if (is_array($permissions)) {
-            return app(config('permission.models.permission'))
+            return app(PermissionRegistrar::class)->getPermissionClass()
                 ->whereIn('name', $permissions)
                 ->whereIn('guard_name', $this->getGuardNames())
                 ->get();

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -27,8 +27,7 @@ trait HasPermissions
 
     public function getPermissionClass()
     {
-        if(!isset($this->permissionClass))
-        {
+        if (! isset($this->permissionClass)) {
             $this->permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
         }
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -91,7 +91,7 @@ trait HasPermissions
                 return $permission;
             }
 
-            return app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
+            return app(config('permission.models.permission'))->findByName($permission, $this->getDefaultGuardName());
         }, $permissions);
     }
 
@@ -106,14 +106,14 @@ trait HasPermissions
     public function hasPermissionTo($permission, $guardName = null): bool
     {
         if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName(
+            $permission = app(config('permission.models.permission'))->findByName(
                 $permission,
                 $guardName ?? $this->getDefaultGuardName()
             );
         }
 
         if (is_int($permission)) {
-            $permission = app(Permission::class)->findById($permission, $this->getDefaultGuardName());
+            $permission = app(config('permission.models.permission'))->findById($permission, $this->getDefaultGuardName());
         }
 
         return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
@@ -163,14 +163,14 @@ trait HasPermissions
     public function hasDirectPermission($permission): bool
     {
         if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
+            $permission = app(config('permission.models.permission'))->findByName($permission, $this->getDefaultGuardName());
             if (! $permission) {
                 return false;
             }
         }
 
         if (is_int($permission)) {
-            $permission = app(Permission::class)->findById($permission, $this->getDefaultGuardName());
+            $permission = app(config('permission.models.permission'))->findById($permission, $this->getDefaultGuardName());
             if (! $permission) {
                 return false;
             }
@@ -265,15 +265,15 @@ trait HasPermissions
     protected function getStoredPermission($permissions)
     {
         if (is_numeric($permissions)) {
-            return app(Permission::class)->findById($permissions, $this->getDefaultGuardName());
+            return app(config('permission.models.permission'))->findById($permissions, $this->getDefaultGuardName());
         }
 
         if (is_string($permissions)) {
-            return app(Permission::class)->findByName($permissions, $this->getDefaultGuardName());
+            return app(config('permission.models.permission'))->findByName($permissions, $this->getDefaultGuardName());
         }
 
         if (is_array($permissions)) {
-            return app(Permission::class)
+            return app(config('permission.models.permission'))
                 ->whereIn('name', $permissions)
                 ->whereIn('guard_name', $this->getGuardNames())
                 ->get();

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -291,7 +291,7 @@ trait HasPermissions
         }
 
         if (is_array($permissions)) {
-            return app(PermissionRegistrar::class)->getPermissionClass()
+            return $permissionClass
                 ->whereIn('name', $permissions)
                 ->whereIn('guard_name', $this->getGuardNames())
                 ->get();

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Spatie\Permission\PermissionRegistrar;
 
 trait HasRoles
 {
@@ -59,7 +60,7 @@ trait HasRoles
                 return $role;
             }
 
-            return app(config('permission.models.role'))->findByName($role, $this->getDefaultGuardName());
+            return app(PermissionRegistrar::class)->getRoleClass()->findByName($role, $this->getDefaultGuardName());
         }, $roles);
 
         return $query->whereHas('roles', function ($query) use ($roles) {
@@ -211,11 +212,11 @@ trait HasRoles
     protected function getStoredRole($role): Role
     {
         if (is_numeric($role)) {
-            return app(config('permission.models.role'))->findById($role, $this->getDefaultGuardName());
+            return app(PermissionRegistrar::class)->getRoleClass()->findById($role, $this->getDefaultGuardName());
         }
 
         if (is_string($role)) {
-            return app(config('permission.models.role'))->findByName($role, $this->getDefaultGuardName());
+            return app(PermissionRegistrar::class)->getRoleClass()->findByName($role, $this->getDefaultGuardName());
         }
 
         return $role;

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -5,8 +5,8 @@ namespace Spatie\Permission\Traits;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Spatie\Permission\PermissionRegistrar;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 trait HasRoles
 {
@@ -27,8 +27,7 @@ trait HasRoles
 
     public function getRoleClass()
     {
-        if(!isset($this->roleClass))
-        {
+        if (! isset($this->roleClass)) {
             $this->roleClass = app(PermissionRegistrar::class)->getRoleClass();
         }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -12,6 +12,8 @@ trait HasRoles
 {
     use HasPermissions;
 
+    private $roleClass;
+
     public static function bootHasRoles()
     {
         static::deleting(function ($model) {
@@ -21,6 +23,16 @@ trait HasRoles
 
             $model->roles()->detach();
         });
+    }
+
+    public function getRoleClass()
+    {
+        if(!isset($this->roleClass))
+        {
+            $this->roleClass = app(PermissionRegistrar::class)->getRoleClass();
+        }
+
+        return $this->roleClass;
     }
 
     /**
@@ -60,7 +72,7 @@ trait HasRoles
                 return $role;
             }
 
-            return app(PermissionRegistrar::class)->getRoleClass()->findByName($role, $this->getDefaultGuardName());
+            return $this->getRoleClass()->findByName($role, $this->getDefaultGuardName());
         }, $roles);
 
         return $query->whereHas('roles', function ($query) use ($roles) {
@@ -211,12 +223,14 @@ trait HasRoles
 
     protected function getStoredRole($role): Role
     {
+        $roleClass = $this->getRoleClass();
+
         if (is_numeric($role)) {
-            return app(PermissionRegistrar::class)->getRoleClass()->findById($role, $this->getDefaultGuardName());
+            return $roleClass->findById($role, $this->getDefaultGuardName());
         }
 
         if (is_string($role)) {
-            return app(PermissionRegistrar::class)->getRoleClass()->findByName($role, $this->getDefaultGuardName());
+            return $roleClass->findByName($role, $this->getDefaultGuardName());
         }
 
         return $role;

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -59,7 +59,7 @@ trait HasRoles
                 return $role;
             }
 
-            return app(Role::class)->findByName($role, $this->getDefaultGuardName());
+            return app(config('permission.models.role'))->findByName($role, $this->getDefaultGuardName());
         }, $roles);
 
         return $query->whereHas('roles', function ($query) use ($roles) {
@@ -211,11 +211,11 @@ trait HasRoles
     protected function getStoredRole($role): Role
     {
         if (is_numeric($role)) {
-            return app(Role::class)->findById($role, $this->getDefaultGuardName());
+            return app(config('permission.models.role'))->findById($role, $this->getDefaultGuardName());
         }
 
         if (is_string($role)) {
-            return app(Role::class)->findByName($role, $this->getDefaultGuardName());
+            return app(config('permission.models.role'))->findByName($role, $this->getDefaultGuardName());
         }
 
         return $role;


### PR DESCRIPTION
Hello,

i'm proposing this change, 
which remove all Permission::class and Role::class and using the classes defined in the config instead,
to prevent the overriding of user preferences and the fallback to the default class that appen systematically  when using custom models.

now, with this change, if you override a method, the default one from the default model will not be called anymore, your custom method will be called every time.

tell me what you think.

the main purpose is to be able to modify the logic with heritage (adding wildcard implementation in my case), without beeing forced to modify the package core code.

PS: if you think wildcard capabilities is something useful for this package, i can try to implement it in another PR if you want.

thanks.

```
PHPUnit 6.2.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.0alpha3
Configuration: /var/www/laravel-permission/phpunit.xml.dist

...............................................................  63 / 127 ( 49%)
............................................................... 126 / 127 ( 99%)
.                                                               127 / 127 (100%)

Time: 1.79 seconds, Memory: 26.00MB

OK (127 tests, 223 assertions)

```