### PR TITLE
 Fixed HasRoles::hasRole() function.  is_array does not work to Illuminate\Support\Collection

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -142,7 +142,7 @@ trait HasRoles
             return $this->roles->contains('id', $roles->id);
         }
 
-        if (is_array($roles)) {
+        if (is_array($roles) || is_a($a, Illuminate\Support\Collection::class)) {
             foreach ($roles as $role) {
                 if ($this->hasRole($role)) {
                     return true;

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -142,7 +142,7 @@ trait HasRoles
             return $this->roles->contains('id', $roles->id);
         }
 
-        if (is_array($roles) || is_a($a, Illuminate\Support\Collection::class)) {
+        if (is_array($roles) || is_a($roles, Illuminate\Support\Collection::class)) {
             foreach ($roles as $role) {
                 if ($this->hasRole($role)) {
                     return true;


### PR DESCRIPTION
is_array does not work to Illuminate\Support\Collection
It needs a proper type detection.

On Laravel 5.5

```
   $collection = new Illuminate\Support\Collection([11, 33, 55]);
   var_dump(is_array($collection);
```

It outputs false. So is_array should not apply to Illuminate\Support\Collection object.