### PR TITLE
Modify hasPermissionTo & hasDirectPermission to return boolean

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -33,7 +33,7 @@ class Permission extends Model implements PermissionContract
     public static function create(array $attributes = [])
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
-        
+
         $permission = static::findByNameOrId($attributes['name'], $attributes['guard_name']);
 
         if ($permission) {
@@ -157,7 +157,7 @@ class Permission extends Model implements PermissionContract
     }
     
     /**
-     * Filters permissions by a given (key , value) and guardName
+     * Filters permissions by a given (key , value) and guardName .
      *
      * @param string $key
      * @param string|int $value

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -162,7 +162,7 @@ class Permission extends Model implements PermissionContract
      * @param string $key
      * @param string|int $value
      * @param string $guardName
-     * 
+     *
      * @return \Illuminate\Support\Collection
      */
     protected static function filterPermissionsBy(string $key, $value, string $guardName)

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -155,7 +155,7 @@ class Permission extends Model implements PermissionContract
 
         return static::filterPermissionsBy('id', $permission, $guardName)->first();
     }
-    
+
     /**
      * Filters permissions by a given (key , value) and guardName .
      *

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -105,20 +105,14 @@ trait HasPermissions
      */
     public function hasPermissionTo($permission, $guardName = null): bool
     {
-        if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName(
-                $permission,
-                $guardName ?? $this->getDefaultGuardName()
-            );
+        if (!is_object($permission)) {
+            $permission = app(Permission::class)->findByNameOrId($permission, $guardName ?? $this->getDefaultGuardName());
         }
 
-        if (is_int($permission)) {
-            $permission = app(Permission::class)->findById(
-                $permission,
-                $guardName ?? $this->getDefaultGuardName()
-            );
+        if (! $permission) {
+            return false;
         }
-
+        
         return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
     }
 
@@ -187,18 +181,12 @@ trait HasPermissions
      */
     public function hasDirectPermission($permission): bool
     {
-        if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
-            if (! $permission) {
-                return false;
-            }
+        if (!is_object($permission)) {
+            $permission = app(Permission::class)->findByNameOrId($permission, $guardName ?? $this->getDefaultGuardName());
         }
-
-        if (is_int($permission)) {
-            $permission = app(Permission::class)->findById($permission, $this->getDefaultGuardName());
-            if (! $permission) {
-                return false;
-            }
+        
+        if (! $permission) {
+            return false;
         }
 
         return $this->permissions->contains('id', $permission->id);

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -112,7 +112,7 @@ trait HasPermissions
         if (! $permission) {
             return false;
         }
-        
+
         return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
     }
 
@@ -184,7 +184,7 @@ trait HasPermissions
         if (! is_object($permission)) {
             $permission = app(Permission::class)->findByNameOrId($permission, $guardName ?? $this->getDefaultGuardName());
         }
-        
+
         if (! $permission) {
             return false;
         }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -105,7 +105,7 @@ trait HasPermissions
      */
     public function hasPermissionTo($permission, $guardName = null): bool
     {
-        if (!is_object($permission)) {
+        if (! is_object($permission)) {
             $permission = app(Permission::class)->findByNameOrId($permission, $guardName ?? $this->getDefaultGuardName());
         }
 
@@ -181,7 +181,7 @@ trait HasPermissions
      */
     public function hasDirectPermission($permission): bool
     {
-        if (!is_object($permission)) {
+        if (! is_object($permission)) {
             $permission = app(Permission::class)->findByNameOrId($permission, $guardName ?? $this->getDefaultGuardName());
         }
         

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -182,7 +182,7 @@ trait HasPermissions
     public function hasDirectPermission($permission): bool
     {
         if (! is_object($permission)) {
-            $permission = app(Permission::class)->findByNameOrId($permission, $guardName ?? $this->getDefaultGuardName());
+            $permission = app(Permission::class)->findByNameOrId($permission, $this->getDefaultGuardName());
         }
 
         if (! $permission) {

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -188,19 +188,15 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_exception_when_the_permission_does_not_exist()
+    public function it_returns_false_when_the_permission_does_not_exist()
     {
-        $this->expectException(PermissionDoesNotExist::class);
-
-        $this->testUser->hasPermissionTo('does-not-exist');
+        $this->assertFalse($this->testUser->hasPermissionTo('does-not-exist'));
     }
 
     /** @test */
-    public function it_throws_an_exception_when_the_permission_does_not_exist_for_this_guard()
+    public function it_returns_false_when_the_permission_does_not_exist_for_this_guard()
     {
-        $this->expectException(PermissionDoesNotExist::class);
-
-        $this->testUser->hasPermissionTo('admin-permission');
+        $this->assertFalse($this->testUser->hasPermissionTo('admin-permission'));
     }
 
     /** @test */


### PR DESCRIPTION
this **PR** , resolves #802 .

i extracted the filtering logic in **Permission model** , to a method called **filterPermissionsBy** , and in **HasPermissions Trait** , i extracted the logic of checking wither the permission is **boolean** or **string** to a public method in **Permission model** called **findByNameOrId** .

with these extractions i removed some of duplicated logic like this :

```php
static::getPermissions()->filter(function ($permission) use ($name, $guardName) {
            return $permission->name === $name && $permission->guard_name === $guardName;	
})->first();
```
one last thing , i think this PR **will cause a breaking changes** , for example if someone was doing this , then this code will **never throws an exception** :
```php

try
{
   $user->hasPermissionTo('some permission')
}
catch(Exception $e)
{
   Permission::create(['name' => 'some permission']);
}
```