### PR TITLE
Make duplicate role assignment not throw an exception

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -95,9 +95,10 @@ trait HasRoles
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
             })
+            ->map->id
             ->all();
 
-        $this->roles()->saveMany($roles);
+        $this->roles()->sync($roles, false);
 
         $this->forgetCachedPermissions();
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -79,6 +79,26 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_remove_already_associated_roles_when_assigning_new_roles()
+    {
+        $this->testUser->assignRole($this->testUserRole->id);
+
+        $this->testUser->assignRole('testRole2');
+
+        $this->assertTrue($this->testUser->fresh()->hasRole('testRole'));
+    }
+
+    /** @test */
+    public function it_does_not_throw_an_exception_when_assigning_a_role_that_is_already_assigned()
+    {
+        $this->testUser->assignRole($this->testUserRole->id);
+
+        $this->testUser->assignRole($this->testUserRole->id);
+
+        $this->assertTrue($this->testUser->fresh()->hasRole('testRole'));
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_assigning_a_role_that_does_not_exist()
     {
         $this->expectException(RoleDoesNotExist::class);


### PR DESCRIPTION
Closes https://github.com/spatie/laravel-permission/issues/808

Assigning roles now uses `sync` instead of `saveMany` with `detaching=false`. This way when assigning roles, non-existing roles will be added (hence, no SQL Exception) without affecting already assigned roles.
