### PR TITLE
Make assigning the same permission twice not throw an exception

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -246,9 +246,10 @@ trait HasPermissions
             ->each(function ($permission) {
                 $this->ensureModelSharesGuard($permission);
             })
+            ->map->id
             ->all();
 
-        $this->permissions()->saveMany($permissions);
+        $this->permissions()->sync($permissions, false);
 
         $this->forgetCachedPermissions();
 

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -405,4 +405,24 @@ class HasPermissionsTest extends TestCase
 
         $this->assertFalse($this->testUser->hasDirectPermission('edit-news'));
     }
+
+    /** @test */
+    public function it_does_not_remove_already_associated_permissions_when_assigning_new_permissions()
+    {
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->assertTrue($this->testUser->fresh()->hasDirectPermission('edit-news'));
+    }
+
+    /** @test */
+    public function it_does_not_throw_an_exception_when_assigning_a_permission_that_is_already_assigned()
+    {
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->assertTrue($this->testUser->fresh()->hasDirectPermission('edit-news'));
+    }
 }


### PR DESCRIPTION
This builds on #830 by @elghobaty to do the same with permissions.