### PR TITLE
CLI create-role command idempotently creates role & permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ $permissions = $user->getDirectPermissions();
 $permissions = $user->getPermissionsViaRoles();
 $permissions = $user->getAllPermissions();
 
-// get a collection of all defined roles
+// get the names of the user's roles
 $roles = $user->getRoleNames(); // Returns a collection
 ```
 
@@ -705,7 +705,7 @@ php artisan permission:create-role writer
 php artisan permission:create-permission "edit articles"
 ```
 
-When creating permissions and roles for specific guards you can specify the guard names as a second argument:
+When creating permissions/roles for specific guards you can specify the guard names as a second argument:
 
 ```bash
 php artisan permission:create-role writer web
@@ -714,6 +714,13 @@ php artisan permission:create-role writer web
 ```bash
 php artisan permission:create-permission "edit articles" web
 ```
+
+When creating roles you can also create and link permissions at the same time:
+
+```bash
+php artisan permission:create-role writer web "create articles|edit articles"
+```
+
 
 ## Unit Testing
 

--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -4,12 +4,14 @@ namespace Spatie\Permission\Commands;
 
 use Illuminate\Console\Command;
 use Spatie\Permission\Contracts\Role as RoleContract;
+use Spatie\Permission\Contracts\Permission as PermissionContract;
 
 class CreateRole extends Command
 {
     protected $signature = 'permission:create-role
         {name : The name of the role}
-        {guard? : The name of the guard}';
+        {guard? : The name of the guard}
+        {permissions? : A list of permissions to assign to the role, separated by | }';
 
     protected $description = 'Create a role';
 
@@ -17,11 +19,25 @@ class CreateRole extends Command
     {
         $roleClass = app(RoleContract::class);
 
-        $role = $roleClass::create([
-            'name' => $this->argument('name'),
-            'guard_name' => $this->argument('guard'),
-        ]);
+        $role = $roleClass::findOrCreate($this->argument('name'), $this->argument('guard'));
+
+        $role->givePermissionTo($this->makePermissions($this->argument('permissions')));
 
         $this->info("Role `{$role->name}` created");
+    }
+
+    protected function makePermissions($string = null)
+    {
+        $permissionClass = app(PermissionContract::class);
+
+        $permissions = explode('|', $string);
+
+        $models = [];
+
+        foreach ($permissions as $permission) {
+            $models[] = $permissionClass::findOrCreate(trim($permission), $this->argument('guard'));
+        }
+
+        return collect($models);
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -141,7 +141,7 @@ class Permission extends Model implements PermissionContract
         })->first();
 
         if (! $permission) {
-            return static::create(['name' => $name, 'guard_name' => $guardName]);
+            return static::query()->create(['name' => $name, 'guard_name' => $guardName]);
         }
 
         return $permission;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -120,7 +120,7 @@ class Role extends Model implements RoleContract
         $role = static::where('name', $name)->where('guard_name', $guardName)->first();
 
         if (! $role) {
-            return static::create(['name' => $name, 'guard_name' => $guardName]);
+            return static::query()->create(['name' => $name, 'guard_name' => $guardName]);
         }
 
         return $role;

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Permission\Test;
 
-use Artisan;
 use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\Models\Permission;
 
 class CommandTest extends TestCase
@@ -48,5 +48,19 @@ class CommandTest extends TestCase
         $this->assertCount(1, Permission::where('name', 'new-permission')
             ->where('guard_name', 'api')
             ->get());
+    }
+
+    /** @test */
+    public function it_can_create_a_role_and_permissions_at_same_time()
+    {
+        Artisan::call('permission:create-role', [
+            'name' => 'new-role',
+            'permissions' => 'first permission | second permission',
+        ]);
+
+        $role = Role::where('name', 'new-role')->first();
+
+        $this->assertTrue($role->hasPermissionTo('first permission'));
+        $this->assertTrue($role->hasPermissionTo('second permission'));
     }
 }


### PR DESCRIPTION
Pass a `|`-delimited string of permissions to the `permission:create-role` command and it will link them to the role after creating any that don't already exist.