### PR TITLE
Adds ability to pass in id's or mixed values to role scope.

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -71,7 +71,9 @@ trait HasRoles
                 return $role;
             }
 
-            return $this->getRoleClass()->findByName($role, $this->getDefaultGuardName());
+            $method = is_numeric($role) ? 'findById' : 'findByName';
+
+            return $this->getRoleClass()->{$method}($role, $this->getDefaultGuardName());
         }, $roles);
 
         return $query->whereHas('roles', function ($query) use ($roles) {

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -243,10 +243,30 @@ class HasRolesTest extends TestCase
         $user2->assignRole('testRole2');
 
         $scopedUsers1 = User::role([$this->testUserRole])->get();
+
         $scopedUsers2 = User::role(['testRole', 'testRole2'])->get();
 
         $this->assertEquals($scopedUsers1->count(), 1);
         $this->assertEquals($scopedUsers2->count(), 2);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_an_array_of_ids_and_names()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+
+        $user1->assignRole($this->testUserRole);
+
+        $user2->assignRole('testRole2');
+
+        $roleName = $this->testUserRole->name;
+
+        $otherRoleId = app(Role::class)->find(2)->id;
+
+        $scopedUsers = User::role([$roleName, $otherRoleId])->get();
+
+        $this->assertEquals($scopedUsers->count(), 2);
     }
 
     /** @test */


### PR DESCRIPTION
Currently you can use the scopeRole to query by role names:

```php
 // Returns only users with the roles 'writer,editor,...
$users = User::role(['writer', 'editor', ...])->get();'

```


However it be useful in some scenarios to be able to use the scope to query by id's 

```php
// Returns only users with the roles with the given id's
$users = User::role([1,4,6, ...])->get(); 

```

This pull request adds that ability by checking whether the role being mapped over in the scopeRole method is numeric or not then calls either `findById` or `findByName` :

```php

 $method = is_numeric($role) ? 'findById' : 'findByName';

```

Might be a trivial use case, but this would also allow you to call by mixed values

```php
User::role([1, $role, 'writer'])->get();
```