### PR TITLE
Add role & permission middleware helper functions to Route class

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -35,7 +35,9 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerModelBindings();
 
-        $this->registerMacroHelpers();
+        if (app()->version() > '5.4') {
+            $this->registerMacroHelpers();
+        }
 
         $permissionLoader->registerPermissions();
     }
@@ -49,9 +51,7 @@ class PermissionServiceProvider extends ServiceProvider
             );
         }
 
-        if (app()->version() > '5.4') {
-            $this->registerBladeExtensions();
-        }
+        $this->registerBladeExtensions();
     }
 
     protected function registerModelBindings()

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -120,7 +120,7 @@ class PermissionServiceProvider extends ServiceProvider
     protected function registerMacroHelpers()
     {
         Route::macro('role', function ($roles = []) {
-            if (!is_array($roles)) {
+            if (! is_array($roles)) {
                 $roles = [$roles];
             }
 
@@ -132,7 +132,7 @@ class PermissionServiceProvider extends ServiceProvider
         });
 
         Route::macro('permission', function ($permissions = []) {
-            if (!is_array($permissions)) {
+            if (! is_array($permissions)) {
                 $permissions = [$permissions];
             }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -35,7 +35,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerModelBindings();
 
-        if (app()->version() > '5.4') {
+        if (app()->version() >= '5.5') {
             $this->registerMacroHelpers();
         }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission;
 
+use Illuminate\Routing\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\Permission\Contracts\Role as RoleContract;
@@ -34,6 +35,8 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerModelBindings();
 
+        $this->registerMacroHelpers();
+
         $permissionLoader->registerPermissions();
     }
 
@@ -46,7 +49,9 @@ class PermissionServiceProvider extends ServiceProvider
             );
         }
 
-        $this->registerBladeExtensions();
+        if (app()->version() > '5.4') {
+            $this->registerBladeExtensions();
+        }
     }
 
     protected function registerModelBindings()
@@ -109,6 +114,33 @@ class PermissionServiceProvider extends ServiceProvider
             $bladeCompiler->directive('endunlessrole', function () {
                 return '<?php endif; ?>';
             });
+        });
+    }
+
+    protected function registerMacroHelpers()
+    {
+        Route::macro('role', function ($roles = []) {
+            if (!is_array($roles)) {
+                $roles = [$roles];
+            }
+
+            $roles = implode('|', $roles);
+
+            $this->middleware("role:$roles");
+
+            return $this;
+        });
+
+        Route::macro('permission', function ($permissions = []) {
+            if (!is_array($permissions)) {
+                $permissions = [$permissions];
+            }
+
+            $permissions = implode('|', $permissions);
+
+            $this->middleware("permission:$permissions");
+
+            return $this;
         });
     }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -43,7 +43,7 @@ class RouteTest extends TestCase
         $this->assertEquals(
             [
                 'role:superadmin|admin',
-                'permission:create user|edit user'
+                'permission:create user|edit user',
             ],
             $this->getLastRouteMiddlewareFromRouter($router)
         );

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -6,6 +6,17 @@ use Illuminate\Http\Response;
 
 class RouteTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (! $this->isVersionAvailable()) {
+            $this->markTestSkipped(
+                'This feature available for Laravel 5.5 and higher'
+            );
+        }
+    }
+
     /** @test */
     public function test_role_function()
     {
@@ -47,6 +58,11 @@ class RouteTest extends TestCase
             ],
             $this->getLastRouteMiddlewareFromRouter($router)
         );
+    }
+
+    protected function isVersionAvailable()
+    {
+        return app()->version() >= '5.5';
     }
 
     protected function getLastRouteMiddlewareFromRouter($router)

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Http\Response;
+
+class RouteTest extends TestCase
+{
+    /** @test */
+    public function test_role_function()
+    {
+        $router = $this->getRouter();
+
+        $router->get('role-test', $this->getRouteResponse())
+                ->name('role.test')
+                ->role('superadmin');
+
+        $this->assertEquals(['role:superadmin'], $this->getLastRouteMiddlewareFromRouter($router));
+    }
+
+    /** @test */
+    public function test_permission_function()
+    {
+        $router = $this->getRouter();
+
+        $router->get('permission-test', $this->getRouteResponse())
+                ->name('permission.test')
+                ->permission(['edit articles', 'save articles']);
+
+        $this->assertEquals(['permission:edit articles|save articles'], $this->getLastRouteMiddlewareFromRouter($router));
+    }
+
+    /** @test */
+    public function test_role_and_permission_function_together()
+    {
+        $router = $this->getRouter();
+
+        $router->get('role-permission-test', $this->getRouteResponse())
+                ->name('role-permission.test')
+                ->role('superadmin|admin')
+                ->permission('create user|edit user');
+
+        $this->assertEquals(
+            [
+                'role:superadmin|admin',
+                'permission:create user|edit user'
+            ],
+            $this->getLastRouteMiddlewareFromRouter($router)
+        );
+    }
+
+    protected function getLastRouteMiddlewareFromRouter($router)
+    {
+        return last($router->getRoutes()->get())->middleware();
+    }
+
+    protected function getRouter()
+    {
+        return app('router');
+    }
+
+    protected function getRouteResponse()
+    {
+        return function () {
+            return (new Response())->setContent('<html></html>');
+        };
+    }
+}


### PR DESCRIPTION
Added `role` and `permission` middleware helper functions to `Route` class from Laravel 5.5 and higher

Example:
```php
Route::get('users', 'UserController@index')->role('superadmin');
```

```php
Route::get('users', 'UserController@index')->permission('show users list');
```

```php
Route::get('admin/users', 'UserController@index')->role(['superadmin', 'admin']->permission(['show users list', 'another permission']);
```