### PR TITLE
Add role_or_permission middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ You can use all of the blade directives listed in [using blade directives](#usin
 
 ## Using a middleware
 
-This package comes with `RoleMiddleware`, `PermissionMiddleware` nad `RoleOrPermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
+This package comes with `RoleMiddleware`, `PermissionMiddleware` and `RoleOrPermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
 
 ```php
 protected $routeMiddleware = [

--- a/README.md
+++ b/README.md
@@ -671,11 +671,11 @@ Route::group(['middleware' => ['role:super-admin','permission:publish articles']
     //
 });
 
-Route::group(['middleware' => ['role_or_permission:super-admin]], function () {
+Route::group(['middleware' => ['role_or_permission:super-admin']], function () {
     //
 });
 
-Route::group(['middleware' => ['role_or_permission:publish articles]], function () {
+Route::group(['middleware' => ['role_or_permission:publish articles']], function () {
     //
 });
 ```

--- a/README.md
+++ b/README.md
@@ -645,13 +645,14 @@ You can use all of the blade directives listed in [using blade directives](#usin
 
 ## Using a middleware
 
-This package comes with `RoleMiddleware` and `PermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
+This package comes with `RoleMiddleware`, `PermissionMiddleware` nad `RoleOrPermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
 
 ```php
 protected $routeMiddleware = [
     // ...
     'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
     'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+    'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
 ];
 ```
 
@@ -669,6 +670,14 @@ Route::group(['middleware' => ['permission:publish articles']], function () {
 Route::group(['middleware' => ['role:super-admin','permission:publish articles']], function () {
     //
 });
+
+Route::group(['middleware' => ['role_or_permission:super-admin]], function () {
+    //
+});
+
+Route::group(['middleware' => ['role_or_permission:publish articles]], function () {
+    //
+});
 ```
 
 Alternatively, you can separate multiple roles or permission with a `|` (pipe) character:
@@ -681,6 +690,10 @@ Route::group(['middleware' => ['role:super-admin|writer']], function () {
 Route::group(['middleware' => ['permission:publish articles|edit articles']], function () {
     //
 });
+
+Route::group(['middleware' => ['role_or_permission:super-admin|edit articles']], function () {
+    //
+});
 ```
 
 You can protect your controllers similarly, by setting desired middleware in the constructor:
@@ -689,6 +702,13 @@ You can protect your controllers similarly, by setting desired middleware in the
 public function __construct()
 {
     $this->middleware(['role:super-admin','permission:publish articles|edit articles']);
+}
+```
+
+```php
+public function __construct()
+{
+    $this->middleware(['role_or_permission:super-admin|edit articles']);
 }
 ```
 
@@ -704,7 +724,6 @@ public function render($request, Exception $exception)
 
     return parent::render($request, $exception);
 }
-
 ```
 
 ## Using artisan commands

--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -40,6 +40,21 @@ class UnauthorizedException extends HttpException
         return $exception;
     }
 
+    public static function forRolesOrPermissions(array $rolesOrPermissions): self
+    {
+        $message = 'User does not have any of the necessary access rights.';
+
+        if (config('permission.display_permission_in_exception') && config('permission.display_role_in_exception')) {
+            $permStr = implode(', ', $rolesOrPermissions);
+            $message = 'User does not have the right permissions. Necessary permissions are '.$permStr;
+        }
+
+        $exception = new static(403, $message, null, []);
+        $exception->requiredPermissions = $rolesOrPermissions;
+
+        return $exception;
+    }
+
     public static function notLoggedIn(): self
     {
         return new static(403, 'User is not logged in.', null, []);

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -4,8 +4,8 @@ namespace Spatie\Permission\Middlewares;
 
 use Closure;
 use Illuminate\Support\Facades\Auth;
-use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 class RoleOrPermissionMiddleware
 {
@@ -23,7 +23,8 @@ class RoleOrPermissionMiddleware
             if (! Auth::user()->hasAnyRole($rolesOrPermissions) || ! Auth::user()->hasAnyPermission($rolesOrPermissions)) {
                 throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
             }
-        } catch (PermissionDoesNotExist $exception) {}
+        } catch (PermissionDoesNotExist $exception) {
+        }
 
         return $next($request);
     }

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Permission\Middlewares;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+
+class RoleOrPermissionMiddleware
+{
+    public function handle($request, Closure $next, $roleOrPermission)
+    {
+        if (Auth::guest()) {
+            throw UnauthorizedException::notLoggedIn();
+        }
+
+        $rolesOrPermissions = is_array($roleOrPermission)
+            ? $roleOrPermission
+            : explode('|', $roleOrPermission);
+
+        try {
+            if (! Auth::user()->hasAnyRole($rolesOrPermissions) || ! Auth::user()->hasAnyPermission($rolesOrPermissions)) {
+                throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
+            }
+        } catch (PermissionDoesNotExist $exception) {}
+
+        return $next($request);
+    }
+}

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -23,7 +23,7 @@ class MiddlewareTest extends TestCase
         $this->roleMiddleware = new RoleMiddleware($this->app);
 
         $this->permissionMiddleware = new PermissionMiddleware($this->app);
-        
+
         $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware($this->app);
     }
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -8,11 +8,13 @@ use Illuminate\Support\Facades\Auth;
 use Spatie\Permission\Middlewares\RoleMiddleware;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middlewares\PermissionMiddleware;
+use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;
 
 class MiddlewareTest extends TestCase
 {
     protected $roleMiddleware;
     protected $permissionMiddleware;
+    protected $roleOrPermissionMiddleware;
 
     public function setUp()
     {
@@ -21,6 +23,8 @@ class MiddlewareTest extends TestCase
         $this->roleMiddleware = new RoleMiddleware($this->app);
 
         $this->permissionMiddleware = new PermissionMiddleware($this->app);
+        
+        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware($this->app);
     }
 
     /** @test */
@@ -160,6 +164,46 @@ class MiddlewareTest extends TestCase
             $this->runMiddleware(
                 $this->permissionMiddleware, 'edit-articles|edit-news'
             ), 403);
+    }
+
+    /** @test */
+    public function a_user_can_access_a_route_protected_by_permission_or_role_middleware_if_has_this_permission_or_role()
+    {
+        Auth::login($this->testUser);
+
+        $this->testUser->assignRole('testRole');
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),
+            200
+        );
+
+        $this->testUser->removeRole('testRole');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),
+            200
+        );
+
+        $this->testUser->revokePermissionTo('edit-articles');
+        $this->testUser->assignRole('testRole');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),
+            200
+        );
+    }
+
+    /** @test */
+    public function a_user_can_not_access_a_route_protected_by_permission_or_role_middleware_if_have_not_this_permission_and_role()
+    {
+        Auth::login($this->testUser);
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),
+            403
+        );
     }
 
     /** @test */


### PR DESCRIPTION
Hi guys! Nice package you've got here.

This PR adds a new middleware to support the verification that a user has either a role OR a given permission. It's most useful for including a verification of a high access level user and lower access level users, without having to add any specific permissions to the high access level user.

Take, for example, the following:

```php
public function __construct()
{
    $this->middleware('role_or_permission:super-admin|edit-news');
}
``` 

This expression would pass if the user has either the role `super-admin` or the permission `edit-news` (whatever the role has that permission).

Wish you all a good day, 
José Postiga