### PR TITLE
Avoid unnecessary queries of user roles when fetching all permissions

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -233,7 +233,7 @@ trait HasPermissions
      */
     public function getPermissionsViaRoles(): Collection
     {
-        return $this->load('roles', 'roles.permissions')
+        return $this->loadMissing('roles', 'roles.permissions')
             ->roles->flatMap(function ($role) {
                 return $role->permissions;
             })->sort()->values();

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -245,7 +245,9 @@ trait HasPermissions
     public function getAllPermissions(): Collection
     {
         return $this->permissions
-            ->merge($this->getPermissionsViaRoles())
+            ->when($this->roles, function ($collection) {
+                return $collection->merge($this->getPermissionsViaRoles());
+            })
             ->sort()
             ->values();
     }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -244,12 +244,13 @@ trait HasPermissions
      */
     public function getAllPermissions(): Collection
     {
-        return $this->permissions
-            ->when($this->roles, function ($collection) {
-                return $collection->merge($this->getPermissionsViaRoles());
-            })
-            ->sort()
-            ->values();
+        $permissions = $this->permissions;
+
+        if ($this->roles) {
+            $permissions = $permissions->merge($this->getPermissionsViaRoles());
+        }
+
+        return $permissions->sort()->values();
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -233,7 +233,7 @@ trait HasPermissions
      */
     public function getPermissionsViaRoles(): Collection
     {
-        return $this->loadMissing('roles', 'roles.permissions')
+        return $this->load('roles', 'roles.permissions')
             ->roles->flatMap(function ($role) {
                 return $role->permissions;
             })->sort()->values();


### PR DESCRIPTION
Hi, everyone!

This PR addresses #886 by adding a condition to only call `getPermissionsViaRoles()`, via `getAllPermisisons()`, when a `User` has roles.