### PR TITLE
Refresh model roles after assigning a role

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -116,6 +116,7 @@ trait HasRoles
 
         if ($model->exists) {
             $this->roles()->sync($roles, false);
+            $model->load('roles');
         } else {
             $class = \get_class($model);
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -126,7 +126,7 @@ class CacheTest extends TestCase
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
 
-        $this->assertQueryCount(self::QUERIES_PER_CACHE_PROVISION + 2); // + 2 for getting the User's relations
+        $this->assertQueryCount(self::QUERIES_PER_CACHE_PROVISION + 1); // + 1 for getting the User's relations
         $this->resetQueryCount();
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -17,6 +17,8 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_and_remove_a_role()
     {
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+
         $this->testUser->assignRole('testRole');
 
         $this->assertTrue($this->testUser->hasRole('testRole'));


### PR DESCRIPTION
Fixes #914 

There is some side effect with tests. 
`it_can_assign_and_remove_a_role` will pass if there is no assert in the beginning and fail with it (in original code). 