### PR TITLE
Avoid empty permission creation

### DIFF
--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -30,14 +30,18 @@ class CreateRole extends Command
     {
         $permissionClass = app(PermissionContract::class);
 
-        $permissions = explode('|', $string);
+        if ($string) {
+            $permissions = explode('|', $string);
 
-        $models = [];
+            $models = [];
 
-        foreach ($permissions as $permission) {
-            $models[] = $permissionClass::findOrCreate(trim($permission), $this->argument('guard'));
+            foreach ($permissions as $permission) {
+                $models[] = $permissionClass::findOrCreate(trim($permission), $this->argument('guard'));
+            }
+
+            return collect($models);
+        } else {
+            return null;
         }
-
-        return collect($models);
     }
 }

--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -28,7 +28,7 @@ class CreateRole extends Command
 
     protected function makePermissions($string = null)
     {
-        if (null === string) {
+        if (empty($string)) {
             return;
         }
 

--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -28,20 +28,20 @@ class CreateRole extends Command
 
     protected function makePermissions($string = null)
     {
+        if (null === string) {
+            return;
+        }
+
         $permissionClass = app(PermissionContract::class);
 
-        if ($string) {
-            $permissions = explode('|', $string);
+        $permissions = explode('|', $string);
 
-            $models = [];
+        $models = [];
 
-            foreach ($permissions as $permission) {
-                $models[] = $permissionClass::findOrCreate(trim($permission), $this->argument('guard'));
-            }
-
-            return collect($models);
-        } else {
-            return null;
+        foreach ($permissions as $permission) {
+            $models[] = $permissionClass::findOrCreate(trim($permission), $this->argument('guard'));
         }
+
+        return collect($models);
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -14,6 +14,7 @@ class CommandTest extends TestCase
         Artisan::call('permission:create-role', ['name' => 'new-role']);
 
         $this->assertCount(1, Role::where('name', 'new-role')->get());
+        $this->assertCount(0, Role::where('name', 'new-role')->first()->permissions);
     }
 
     /** @test */


### PR DESCRIPTION
Null permissions string resulted in the creation of an empty permission
associated to the new created role.
New line added to the CommandTest file to test the correction.