### PR TITLE
Fix operator used on RoleOrPermissionMiddleware

### DIFF
--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -5,7 +5,6 @@ namespace Spatie\Permission\Middlewares;
 use Closure;
 use Illuminate\Support\Facades\Auth;
 use Spatie\Permission\Exceptions\UnauthorizedException;
-use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 class RoleOrPermissionMiddleware
 {

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -19,11 +19,8 @@ class RoleOrPermissionMiddleware
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        try {
-            if (! Auth::user()->hasAnyRole($rolesOrPermissions) || ! Auth::user()->hasAnyPermission($rolesOrPermissions)) {
-                throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
-            }
-        } catch (PermissionDoesNotExist $exception) {
+        if (! Auth::user()->hasAnyRole($rolesOrPermissions) && ! Auth::user()->hasAnyPermission($rolesOrPermissions)) {
+            throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 
         return $next($request);

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -141,6 +141,23 @@ trait HasPermissions
     }
 
     /**
+     * An alias to hasPermissionTo(), but avoids throwing an exception.
+     *
+     * @param string|int|\Spatie\Permission\Contracts\Permission $permission
+     * @param string|null $guardName
+     *
+     * @return bool
+     */
+    public function checkPermissionTo($permission, $guardName = null): bool
+    {
+        try {
+            return $this->hasPermissionTo($permission, $guardName);
+        } catch (PermissionDoesNotExist $e) {
+            return false;
+        }
+    }
+
+    /**
      * Determine if the model has any of the given permissions.
      *
      * @param array ...$permissions
@@ -154,7 +171,7 @@ trait HasPermissions
         }
 
         foreach ($permissions as $permission) {
-            if ($this->hasPermissionTo($permission)) {
+            if ($this->checkPermissionTo($permission)) {
                 return true;
             }
         }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -175,7 +175,7 @@ class MiddlewareTest extends TestCase
         $this->testUser->givePermissionTo('edit-articles');
 
         $this->assertEquals(
-            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-news|edit-articles'),
             200
         );
 
@@ -203,6 +203,11 @@ class MiddlewareTest extends TestCase
 
         $this->assertEquals(
             $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),
+            403
+        );
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'missingRole|missingPermission'),
             403
         );
     }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -180,6 +180,7 @@ class MiddlewareTest extends TestCase
         );
 
         $this->testUser->removeRole('testRole');
+        $this->refreshTestUser();
 
         $this->assertEquals(
             $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),


### PR DESCRIPTION
This PR fixes the logic operation inside the `RoleOrPermissionMiddleware`, where a `||` is used, instead of a `&&`.

It also adds an alias for `hasPermissionTo()`, `checkPermissionTo`, which catches any `PermissionDoesNotExist` exception and returning `false`, ensuring the return value to always be a boolean.