### PR TITLE
Auto-reload role/permission relations on assign/remove & give/revoke

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -297,12 +297,14 @@ trait HasPermissions
 
         if ($model->exists) {
             $this->permissions()->sync($permissions, false);
+            $model->load('permissions');
         } else {
             $class = \get_class($model);
 
             $class::saved(
                 function ($model) use ($permissions) {
                     $model->permissions()->sync($permissions, false);
+                    $model->load('permissions');
                 });
         }
 
@@ -337,6 +339,8 @@ trait HasPermissions
         $this->permissions()->detach($this->getStoredPermission($permission));
 
         $this->forgetCachedPermissions();
+
+        $this->load('permissions');
 
         return $this;
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -139,6 +139,8 @@ trait HasRoles
     public function removeRole($role)
     {
         $this->roles()->detach($this->getStoredRole($role));
+
+        $this->load('roles');
     }
 
     /**

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -214,8 +214,6 @@ class BladeTest extends TestCase
 
         $user->assignRole('writer');
 
-        $this->refreshTestUser();
-
         auth()->setUser($user);
 
         $this->assertEquals('does have all of the given roles', $this->renderView('hasAllRoles', compact('roles')));
@@ -232,8 +230,6 @@ class BladeTest extends TestCase
 
         $admin->assignRole('moderator');
 
-        $this->refreshTestAdmin();
-
         auth('admin')->setUser($admin);
 
         $this->assertEquals('does have all of the given roles', $this->renderView('guardHasAllRoles', compact('roles', 'guard')));
@@ -248,8 +244,6 @@ class BladeTest extends TestCase
 
         $admin->assignRole('moderator');
 
-        $this->refreshTestAdmin();
-
         auth('admin')->setUser($admin);
 
         $this->assertEquals('does have all of the given roles', $this->renderView('guardHasAllRolesPipe', compact('guard')));
@@ -263,8 +257,6 @@ class BladeTest extends TestCase
 
         $user->assignRole('writer');
 
-        $this->refreshTestUser();
-
         auth()->setUser($user);
 
         $this->assertEquals('does not have all of the given roles', $this->renderView('guardHasAllRolesPipe', compact('guard')));
@@ -274,8 +266,6 @@ class BladeTest extends TestCase
     {
         $this->testUser->assignRole('writer');
 
-        $this->refreshTestUser();
-
         return $this->testUser;
     }
 
@@ -283,16 +273,12 @@ class BladeTest extends TestCase
     {
         $this->testUser->assignRole('member');
 
-        $this->refreshTestUser();
-
         return $this->testUser;
     }
 
     protected function getSuperAdmin()
     {
         $this->testAdmin->assignRole('super-admin');
-
-        $this->refreshTestAdmin();
 
         return $this->testAdmin;
     }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -14,8 +14,6 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
 
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasPermissionTo($this->testUserPermission));
     }
 
@@ -44,13 +42,9 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
 
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasPermissionTo($this->testUserPermission));
 
         $this->testUser->revokePermissionTo($this->testUserPermission);
-
-        $this->refreshTestUser();
 
         $this->assertFalse($this->testUser->hasPermissionTo($this->testUserPermission));
     }
@@ -254,13 +248,9 @@ class HasPermissionsTest extends TestCase
 
         $this->testUser->givePermissionTo('edit-articles');
 
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasAnyPermission('edit-news', 'edit-articles'));
 
         $this->testUser->givePermissionTo('edit-news');
-
-        $this->refreshTestUser();
 
         $this->testUser->revokePermissionTo($this->testUserPermission);
 
@@ -274,13 +264,9 @@ class HasPermissionsTest extends TestCase
 
         $this->testUser->givePermissionTo('edit-articles');
 
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasAnyPermission(['edit-news', 'edit-articles']));
 
         $this->testUser->givePermissionTo('edit-news');
-
-        $this->refreshTestUser();
 
         $this->testUser->revokePermissionTo($this->testUserPermission);
 
@@ -302,13 +288,9 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo('edit-articles', 'edit-news');
 
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasAllPermissions('edit-articles', 'edit-news'));
 
         $this->testUser->revokePermissionTo('edit-articles');
-
-        $this->refreshTestUser();
 
         $this->assertFalse($this->testUser->hasAllPermissions('edit-articles', 'edit-news'));
     }
@@ -320,13 +302,9 @@ class HasPermissionsTest extends TestCase
 
         $this->testUser->revokePermissionTo('edit-articles');
 
-        $this->refreshTestUser();
-
         $this->assertFalse($this->testUser->hasAllPermissions(['edit-news', 'edit-articles']));
 
         $this->testUser->givePermissionTo('edit-news');
-
-        $this->refreshTestUser();
 
         $this->testUser->revokePermissionTo($this->testUserPermission);
 
@@ -347,8 +325,6 @@ class HasPermissionsTest extends TestCase
     public function it_can_determine_that_user_has_direct_permission()
     {
         $this->testUser->givePermissionTo('edit-articles');
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
         $this->assertEquals(
             collect(['edit-articles']),
@@ -356,12 +332,10 @@ class HasPermissionsTest extends TestCase
         );
 
         $this->testUser->revokePermissionTo('edit-articles');
-        $this->refreshTestUser();
         $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
 
         $this->testUser->assignRole('testRole');
         $this->testUserRole->givePermissionTo('edit-articles');
-        $this->refreshTestUser();
         $this->assertFalse($this->testUser->hasDirectPermission('edit-articles'));
     }
 
@@ -472,6 +446,7 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($user->hasPermissionTo('edit-articles'));
 
         $user->syncPermissions('edit-articles');
+        $this->assertTrue($user->hasPermissionTo('edit-articles'));
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-articles'));
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -25,8 +25,6 @@ class HasRolesTest extends TestCase
 
         $this->testUser->removeRole('testRole');
 
-        $this->refreshTestUser();
-
         $this->assertFalse($this->testUser->hasRole('testRole'));
     }
 
@@ -38,8 +36,6 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUserPermission->hasRole('testRole'));
 
         $this->testUserPermission->removeRole('testRole');
-
-        $this->refreshTestUserPermission();
 
         $this->assertFalse($this->testUserPermission->hasRole('testRole'));
     }
@@ -336,8 +332,6 @@ class HasRolesTest extends TestCase
 
         $this->testUser->assignRole($this->testUserRole);
 
-        $this->refreshTestUser();
-
         $this->assertTrue($this->testUser->hasRole($roleModel->all()));
 
         $this->assertTrue($this->testUser->hasAnyRole($roleModel->all()));
@@ -370,13 +364,9 @@ class HasRolesTest extends TestCase
 
         $this->testUser->assignRole($this->testUserRole);
 
-        $this->refreshTestUser();
-
         $this->assertFalse($this->testUser->hasAllRoles(['testRole', 'second role']));
 
         $this->testUser->assignRole('second role');
-
-        $this->refreshTestUser();
 
         $this->assertTrue($this->testUser->hasAllRoles(['testRole', 'second role']));
     }
@@ -389,8 +379,6 @@ class HasRolesTest extends TestCase
         $this->assertFalse($this->testUser->hasRole($this->testAdminRole));
 
         $this->testUser->assignRole('testRole');
-
-        $this->refreshTestUser();
 
         $this->assertTrue($this->testUser->hasAnyRole(['testRole', 'testAdminRole']));
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -180,7 +180,6 @@ class MiddlewareTest extends TestCase
         );
 
         $this->testUser->removeRole('testRole');
-        $this->refreshTestUser();
 
         $this->assertEquals(
             $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|edit-articles'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -122,28 +122,4 @@ abstract class TestCase extends Orchestra
     {
         app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
-
-    /**
-     * Refresh the testUser.
-     */
-    public function refreshTestUser()
-    {
-        $this->testUser = $this->testUser->fresh();
-    }
-
-    /**
-     * Refresh the testAdmin.
-     */
-    public function refreshTestAdmin()
-    {
-        $this->testAdmin = $this->testAdmin->fresh();
-    }
-
-    /**
-     * Refresh the testUserPermission.
-     */
-    public function refreshTestUserPermission()
-    {
-        $this->testUserPermission = $this->testUserPermission->fresh();
-    }
 }


### PR DESCRIPTION
This continues where #916 left off, adding the refresh to not just the Assign method, but also the Remove method on roles, and to both give/revoke on permissions.

This means there's no longer a need to call `->fresh()` on the model if the only reason is to reload the role/permission relations. (That said, you may want to call it for other reasons.)