### PR TITLE
Add model/permissions caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 vendor
 tests/temp
+.idea

--- a/README.md
+++ b/README.md
@@ -177,13 +177,18 @@ return [
         'role_has_permissions' => 'role_has_permissions',
     ],
 
-    /*
-     * By default all permissions will be cached for 24 hours unless a permission or
-     * role is updated. Then the cache will be flushed immediately.
-     */
+    'column_names' => [
 
-    'cache_expiration_time' => 60 * 24,
-    
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+        'model_morph_key' => 'model_id',
+    ],
+
     /*
      * When set to true, the required permission/role names are added to the exception
      * message. This could be considered an information leak in some contexts, so
@@ -191,6 +196,33 @@ return [
      */
 
     'display_permission_in_exception' => false,
+
+    'cache' => [
+
+        /*
+         * By default all permissions will be cached for 24 hours unless a permission or
+         * role is updated. Then the cache will be flushed immediately.
+         */
+
+        'expiration_time' => 60 * 24,
+
+        /*
+         * The key to use when tagging and prefixing entries in the cache.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * When checking for a permission against a model by passing a Permission
+         * instance to the check, this key determines what attribute on the
+         * Permissions model is used to cache against.
+         *
+         * Ideally, this should match your preferred way of checking permissions, eg:
+         * `$user->can('view-posts')` would be 'name'.
+         */
+
+        'model_key' => 'name',
+    ],
 ];
 ```
 

--- a/config/permission.php
+++ b/config/permission.php
@@ -72,17 +72,37 @@ return [
     ],
 
     /*
-     * By default all permissions will be cached for 24 hours unless a permission or
-     * role is updated. Then the cache will be flushed immediately.
-     */
-
-    'cache_expiration_time' => 60 * 24,
-
-    /*
      * When set to true, the required permission/role names are added to the exception
      * message. This could be considered an information leak in some contexts, so
      * the default setting is false here for optimum safety.
      */
 
     'display_permission_in_exception' => false,
+
+    'cache' => [
+
+        /*
+         * By default all permissions will be cached for 24 hours unless a permission or
+         * role is updated. Then the cache will be flushed immediately.
+         */
+
+        'expiration_time' => 60 * 24,
+
+        /*
+         * The key to use when tagging and prefixing entries in the cache.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * When checking for a permission against a model by passing a Permission
+         * instance to the check, this key determines what attribute on the
+         * Permissions model is used to cache against.
+         *
+         * Ideally, this should match your preferred way of checking permissions, eg:
+         * `$user->can('view-posts')` would be 'name'.
+         */
+
+        'model_key' => 'name',
+    ],
 ];

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -34,9 +34,7 @@ class Permission extends Model implements PermissionContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions()->filter(function ($permission) use ($attributes) {
-            return $permission->name === $attributes['name'] && $permission->guard_name === $attributes['guard_name'];
-        })->first();
+        $permission = static::getPermissions(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']])->first();
 
         if ($permission) {
             throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
@@ -87,11 +85,7 @@ class Permission extends Model implements PermissionContract
     public static function findByName(string $name, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-
-        $permission = static::getPermissions()->filter(function ($permission) use ($name, $guardName) {
-            return $permission->name === $name && $permission->guard_name === $guardName;
-        })->first();
-
+        $permission = static::getPermissions(['name' => $name, 'guard_name' => $guardName])->first();
         if (! $permission) {
             throw PermissionDoesNotExist::create($name, $guardName);
         }
@@ -112,10 +106,7 @@ class Permission extends Model implements PermissionContract
     public static function findById(int $id, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-
-        $permission = static::getPermissions()->filter(function ($permission) use ($id, $guardName) {
-            return $permission->id === $id && $permission->guard_name === $guardName;
-        })->first();
+        $permission = static::getPermissions(['id' => $id, 'guard_name' => $guardName])->first();
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);
@@ -135,10 +126,7 @@ class Permission extends Model implements PermissionContract
     public static function findOrCreate(string $name, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-
-        $permission = static::getPermissions()->filter(function ($permission) use ($name, $guardName) {
-            return $permission->name === $name && $permission->guard_name === $guardName;
-        })->first();
+        $permission = static::getPermissions(['name' => $name, 'guard_name' => $guardName])->first();
 
         if (! $permission) {
             return static::create(['name' => $name, 'guard_name' => $guardName]);
@@ -150,8 +138,8 @@ class Permission extends Model implements PermissionContract
     /**
      * Get the current cached permissions.
      */
-    protected static function getPermissions(): Collection
+    protected static function getPermissions($params = null): Collection
     {
-        return app(PermissionRegistrar::class)->getPermissions();
+        return app(PermissionRegistrar::class)->getPermissions($params);
     }
 }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission;
 
 use Illuminate\Support\Collection;
+use Spatie\Permission\Contracts\Role;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Cache\Repository;
 use Spatie\Permission\Contracts\Permission;
@@ -18,14 +19,49 @@ class PermissionRegistrar
     protected $cache;
 
     /** @var string */
-    protected $cacheKey = 'spatie.permission.cache';
+    protected $permissionClass;
 
+    /** @var string */
+    protected $roleClass;
+
+    /** @var int */
+    public static $cacheExpirationTime;
+
+    /** @var string */
+    public static $cacheKey;
+
+    /** @var string */
+    public static $cacheModelKey;
+
+    /** @var bool */
+    public static $cacheIsTaggable = false;
+
+    /**
+     * PermissionRegistrar constructor.
+     *
+     * @param \Illuminate\Contracts\Auth\Access\Gate $gate
+     * @param \Illuminate\Contracts\Cache\Repository $cache
+     */
     public function __construct(Gate $gate, Repository $cache)
     {
         $this->gate = $gate;
-        $this->cache = $cache;
+        $this->permissionClass = config('permission.models.permission');
+        $this->roleClass = config('permission.models.role');
+
+        self::$cacheExpirationTime = config('permission.cache.expiration_time',
+            config('permission.cache_expiration_time'));
+        self::$cacheKey = config('permission.cache.key');
+        self::$cacheModelKey = config('permission.cache.model_key');
+        self::$cacheIsTaggable = ($cache->getStore() instanceof \Illuminate\Cache\TaggableStore);
+
+        $this->cache = self::$cacheIsTaggable ? $cache->tags(self::$cacheKey) : $cache;
     }
 
+    /**
+     * Register the permission check method on the gate.
+     *
+     * @return bool
+     */
     public function registerPermissions(): bool
     {
         $this->gate->before(function (Authorizable $user, string $ability) {
@@ -40,19 +76,75 @@ class PermissionRegistrar
         return true;
     }
 
+    /**
+     * Flush the cache.
+     */
     public function forgetCachedPermissions()
     {
-        $this->cache->tags($this->cacheKey)->flush();
+        self::$cacheIsTaggable ? $this->cache->flush() : $this->cache->forget(self::$cacheKey);
     }
 
-    public function getPermissions($params = null): Collection
+    /**
+     * Get the permissions based on the passed params.
+     *
+     * @param array $params
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getPermissions(array $params = []): Collection
     {
-        return $this->cache->tags($this->cacheKey)->remember($this->cacheKey.($params ? '.'.implode('.', array_values($params)) : ''), config('permission.cache_expiration_time'), function () use ($params) {
-            if ($params) {
-                return app(Permission::class)->where($params)->with('roles')->get();
-            } else {
-                return app(Permission::class)->with('roles')->get();
+        $permissions = $this->cache->remember($this->getKey($params), self::$cacheExpirationTime,
+            function () use ($params) {
+                return $this->getPermissionClass()
+                    ->when(($params && self::$cacheIsTaggable), function ($query) use ($params) {
+                        return $query->where($params);
+                    })
+                    ->with('roles')
+                    ->get();
+            });
+
+        if (! self::$cacheIsTaggable) {
+            foreach ($params as $attr => $value) {
+                $permissions = $permissions->where($attr, $value);
             }
-        });
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * Get the key for caching.
+     *
+     * @param $params
+     *
+     * @return string
+     */
+    public function getKey(array $params): string
+    {
+        if ($params && self::$cacheIsTaggable) {
+            return self::$cacheKey.'.'.implode('.', array_values($params));
+        }
+
+        return self::$cacheKey;
+    }
+
+    /**
+     * Get an instance of the permission class.
+     *
+     * @return \Spatie\Permission\Contracts\Permission
+     */
+    public function getPermissionClass(): Permission
+    {
+        return app($this->permissionClass);
+    }
+
+    /**
+     * Get an instance of the role class.
+     *
+     * @return \Spatie\Permission\Contracts\Role
+     */
+    public function getRoleClass(): Role
+    {
+        return app($this->roleClass);
     }
 }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -42,13 +42,17 @@ class PermissionRegistrar
 
     public function forgetCachedPermissions()
     {
-        $this->cache->forget($this->cacheKey);
+        $this->cache->tags($this->cacheKey)->flush();
     }
 
-    public function getPermissions(): Collection
+    public function getPermissions($params = null): Collection
     {
-        return $this->cache->remember($this->cacheKey, config('permission.cache_expiration_time'), function () {
-            return app(Permission::class)->with('roles')->get();
+        return $this->cache->tags($this->cacheKey)->remember($this->cacheKey.($params ? '.'.implode('.', array_values($params)) : ''), config('permission.cache_expiration_time'), function () use ($params) {
+            if ($params) {
+                return app(Permission::class)->where($params)->with('roles')->get();
+            } else {
+                return app(Permission::class)->with('roles')->get();
+            }
         });
     }
 }

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -35,6 +35,10 @@ class PermissionServiceProvider extends ServiceProvider
         $this->registerModelBindings();
 
         $permissionLoader->registerPermissions();
+
+        $this->app->singleton(PermissionRegistrar::class, function ($app) use ($permissionLoader) {
+            return $permissionLoader;
+        });
     }
 
     public function register()

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -9,6 +9,7 @@ use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 trait HasPermissions
 {
@@ -21,6 +22,15 @@ trait HasPermissions
 
             $model->permissions()->detach();
         });
+    }
+
+    public function getPermissionClass()
+    {
+        if (! isset($this->permissionClass)) {
+            $this->permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
+        }
+
+        return $this->permissionClass;
     }
 
     /**
@@ -98,13 +108,45 @@ trait HasPermissions
     /**
      * Determine if the model may perform the given permission.
      *
-     * @param string|\Spatie\Permission\Contracts\Permission $permission
+     * @param string|int|\Spatie\Permission\Contracts\Permission $permission
+     * @param string|null $guardName
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function hasPermissionTo($permission, $guardName = null): bool
+    {
+        if (! is_string($permission) && ! is_int($permission) && ! $permission instanceof Permission) {
+            throw new PermissionDoesNotExist;
+        }
+
+        if (! PermissionRegistrar::$cacheIsTaggable) {
+            return $this->hasUncachedPermissionTo($permission, $guardName);
+        }
+
+        return cache()
+            ->tags($this->getCacheTags($permission))
+            ->remember(
+                $this->getCacheKey($permission),
+                PermissionRegistrar::$cacheExpirationTime,
+                function () use ($permission, $guardName) {
+                    return $this->hasUncachedPermissionTo($permission, $guardName);
+                }
+            );
+    }
+
+    /**
+     * Check the uncached permissions for the model.
+     *
+     * @param string|int|Permission $permission
      * @param string|null $guardName
      *
      * @return bool
      */
-    public function hasPermissionTo($permission, $guardName = null): bool
+    public function hasUncachedPermissionTo($permission, $guardName = null): bool
     {
+        $permissionClass = $this->getPermissionClass();
+
         if (is_string($permission)) {
             $permission = app(Permission::class)->findByName(
                 $permission,
@@ -113,10 +155,101 @@ trait HasPermissions
         }
 
         if (is_int($permission)) {
-            $permission = app(Permission::class)->findById($permission, $this->getDefaultGuardName());
+            $permission = $permissionClass->findById(
+                $permission,
+                $guardName ?? $this->getDefaultGuardName()
+            );
+        }
+
+        if (! $permission instanceof Permission) {
+            throw new PermissionDoesNotExist;
         }
 
         return $this->hasDirectPermission($permission) || $this->hasPermissionViaRole($permission);
+    }
+
+    /**
+     * An alias to hasPermissionTo(), but avoids throwing an exception.
+     *
+     * @param string|int|\Spatie\Permission\Contracts\Permission $permission
+     * @param string|null $guardName
+     *
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    public function checkPermissionTo($permission, $guardName = null): bool
+    {
+        try {
+            return $this->hasPermissionTo($permission, $guardName);
+        } catch (PermissionDoesNotExist $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Construct the key for the cache entry.
+     *
+     * @param null|string|int|\Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return string
+     */
+    protected function getCacheKey($permission = null)
+    {
+        $key = PermissionRegistrar::$cacheKey.'.'.$this->getClassCacheString();
+
+        if ($permission !== null) {
+            $key .= $this->getPermissionCacheString($permission);
+        }
+
+        return $key;
+    }
+
+    /**
+     * Construct the tags for the cache entry.
+     *
+     * @param null|string|int|\Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return array
+     */
+    protected function getCacheTags($permission = null)
+    {
+        $tags = [
+            PermissionRegistrar::$cacheKey,
+            $this->getClassCacheString(),
+        ];
+
+        if ($permission !== null) {
+            $tags[] = $this->getPermissionCacheString($permission);
+        }
+
+        return $tags;
+    }
+
+    /**
+     * Get the key to cache the model by.
+     *
+     * @return string
+     */
+    private function getClassCacheString()
+    {
+        return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
+    }
+
+    /**
+     * Get the key to cache the permission by.
+     *
+     * @param string|int|\Spatie\Permission\Contracts\Permission $permission
+     *
+     * @return mixed
+     */
+    protected function getPermissionCacheString($permission)
+    {
+        if ($permission instanceof Permission) {
+            $permission = $permission[PermissionRegistrar::$cacheModelKey];
+        }
+
+        return str_replace('\\', '.', Permission::class).'.'.$permission;
     }
 
     /**
@@ -125,6 +258,7 @@ trait HasPermissions
      * @param array ...$permissions
      *
      * @return bool
+     * @throws \Exception
      */
     public function hasAnyPermission(...$permissions): bool
     {
@@ -139,6 +273,29 @@ trait HasPermissions
         }
 
         return false;
+    }
+
+    /**
+     * Determine if the model has all of the given permissions.
+     *
+     * @param array ...$permissions
+     *
+     * @return bool
+     * @throws \Exception
+     */
+    public function hasAllPermissions(...$permissions): bool
+    {
+        if (is_array($permissions[0])) {
+            $permissions = $permissions[0];
+        }
+
+        foreach ($permissions as $permission) {
+            if (! $this->hasPermissionTo($permission)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -162,18 +319,24 @@ trait HasPermissions
      */
     public function hasDirectPermission($permission): bool
     {
+        $permissionClass = $this->getPermissionClass();
+
         if (is_string($permission)) {
-            $permission = app(Permission::class)->findByName($permission, $this->getDefaultGuardName());
+            $permission = $permissionClass->findByName($permission, $this->getDefaultGuardName());
             if (! $permission) {
                 return false;
             }
         }
 
         if (is_int($permission)) {
-            $permission = app(Permission::class)->findById($permission, $this->getDefaultGuardName());
+            $permission = $permissionClass->findById($permission, $this->getDefaultGuardName());
             if (! $permission) {
                 return false;
             }
+        }
+
+        if (! $permission instanceof Permission) {
+            return false;
         }
 
         return $this->permissions->contains('id', $permission->id);
@@ -192,13 +355,35 @@ trait HasPermissions
 
     /**
      * Return all the permissions the model has, both directly and via roles.
+     *
+     * @throws \Exception
      */
     public function getAllPermissions(): Collection
     {
-        return $this->permissions
-            ->merge($this->getPermissionsViaRoles())
-            ->sort()
-            ->values();
+        if (PermissionRegistrar::$cacheIsTaggable) {
+            return cache()->tags($this->getCacheTags())
+                ->remember(
+                    $this->getCacheKey(),
+                    PermissionRegistrar::$cacheExpirationTime,
+                    function () {
+                        $permissions = $this->permissions;
+
+                        if ($this->roles) {
+                            $permissions = $permissions->merge($this->getPermissionsViaRoles());
+                        }
+
+                        return $permissions->sort()->values();
+                    }
+                );
+        }
+
+        $permissions = $this->permissions;
+
+        if ($this->roles) {
+            $permissions = $permissions->merge($this->getPermissionsViaRoles());
+        }
+
+        return $permissions->sort()->values();
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -131,7 +131,8 @@ class CacheTest extends TestCase
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));
 
-        $this->assertQueryCount(0);
+        $this->assertQueryCount(self::QUERIES_PER_CACHE_PROVISION);
+        $this->resetQueryCount();
 
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
 


### PR DESCRIPTION
This adds substantial speed increases by caching the associations between models and permissions. Part of the changes focus on the `PermissionRegistar`, specifically caching for `getPermissions()`, thanks to @klincheg for these changes.

The rest is focussed on caching calls to `HasPermissionTo()` in `HasPermissions.php`. 

The association is cached under a compound key comprised of the package key, the model and the permission:
`spatie.permission.cache.App.Models.User.12.Spatie.Permission.Models.Permissions.view-dashboard`

These values are also used as tags: 
`spatie.permission.cache`, 
`App.Models.User.12`, 
`Spatie.Permission.Models.Permissions.view-dashboard`
(if tags are not supported then the package continues as before, as they are essential to this functionality)

As we are still using the package cache key, then the already existing cache-busting should not need to be updated to account for these changes. However, the usage of the model and the permissions in the tags allow for future addition of model specific, or permission specific cache-busting, helping prevent the stampeding herd effect that larger applications may experience each time a permission or role is updated.

Performance tests involved seeding a database with 250 users, who were assigned between 2 - 4 roles, which were assigned between 30 - 500 permissions. Then each permission for each user was tested:
```php
$this->users->each(function (User $user) {
    $user->getAllPermissions()->each(function (Permission $permission) use ($user) {
        $this->assertTrue($user->can($permission->name));
    });
});
``` 

I went through different variations of the above, some including non-assigned permissions, etc. 

These changes increase the speed of the checks from several minutes down to 4 - 20 seconds (approx 32000 assertions in a couple of seconds in some tests). And the database calls went from 1800+ to 0.

Things to note/get feedback on are:
 - Is the current cache busting effective enough for these changes? I reviewed the tests and ran through some real-world examples and had no issues, but a second opinion would be great.
 - The changes to the config could be breaking
 - The naming of `checkHasPermissionTo()` inside `HasPermissions` could be confused with the newly added method `checkPermissionTo()`
 - Clutter. I'm concious this has added a fair bit of new methods and checks, and I don't want to clutter up the package.

Closes #732 
Fixes #759 
Fixes #789 