### PR TITLE
Centralize Store for HasPermissions cache calls

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -48,8 +48,7 @@ class PermissionRegistrar
         $this->permissionClass = config('permission.models.permission');
         $this->roleClass = config('permission.models.role');
 
-        self::$cacheExpirationTime = config('permission.cache.expiration_time',
-            config('permission.cache_expiration_time'));
+        self::$cacheExpirationTime = config('permission.cache.expiration_time', config('permission.cache_expiration_time'));
         self::$cacheKey = config('permission.cache.key');
         self::$cacheModelKey = config('permission.cache.model_key');
         self::$cacheIsTaggable = ($cache->getStore() instanceof \Illuminate\Cache\TaggableStore);
@@ -146,5 +145,15 @@ class PermissionRegistrar
     public function getRoleClass(): Role
     {
         return app($this->roleClass);
+    }
+
+    /**
+     * Get the instance of the Cache Store.
+     *
+     * @return \Illuminate\Contracts\Cache\Store
+     */
+    public function getCacheStore(): \Illuminate\Contracts\Cache\Store
+    {
+        return $this->cache->getStore();
     }
 }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -122,15 +122,16 @@ trait HasPermissions
             throw new PermissionDoesNotExist;
         }
 
-        if (! PermissionRegistrar::$cacheIsTaggable) {
+        $registrar = app(PermissionRegistrar::class);
+        if (! $registrar::$cacheIsTaggable) {
             return $this->hasUncachedPermissionTo($permission, $guardName);
         }
 
-        return cache()
+        return $registrar->getCacheStore()
             ->tags($this->getCacheTags($permission))
             ->remember(
                 $this->getCacheKey($permission),
-                PermissionRegistrar::$cacheExpirationTime,
+                $registrar::$cacheExpirationTime,
                 function () use ($permission, $guardName) {
                     return $this->hasUncachedPermissionTo($permission, $guardName);
                 }
@@ -362,11 +363,13 @@ trait HasPermissions
      */
     public function getAllPermissions(): Collection
     {
-        if (PermissionRegistrar::$cacheIsTaggable) {
-            return cache()->tags($this->getCacheTags())
+        $registrar = app(PermissionRegistrar::class);
+        if ($registrar::$cacheIsTaggable) {
+            return $registrar->getCacheStore()
+                ->tags($this->getCacheTags())
                 ->remember(
                     $this->getCacheKey(),
-                    PermissionRegistrar::$cacheExpirationTime,
+                    $registrar::$cacheExpirationTime,
                     function () {
                         $permissions = $this->permissions;
 


### PR DESCRIPTION
Since the `cache()` helper is `Store`-agnostic, switched to use the Cache Repository defined by the Registrar.