### PR TITLE
Refactor cache tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.4.2|~3.5.0|~3.6.0|~3.7.0",
-        "phpunit/phpunit" : "^5.7|6.2|^7.0"
+        "phpunit/phpunit": "^5.7|6.2|^7.0",
+        "predis/predis": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,4 +19,7 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="CACHE_DRIVER" value="array"/>
+    </php>
 </phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Test;
 
 use Spatie\Permission\Contracts\Role;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
@@ -100,6 +101,10 @@ abstract class TestCase extends Orchestra
             $table->string('email');
         });
 
+        if ($this->app->make(PermissionRegistrar::class)->getCacheStore() instanceof \Illuminate\Cache\DatabaseStore) {
+            $this->createCacheTable();
+        }
+
         include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
 
         (new \CreatePermissionTables())->up();
@@ -121,5 +126,14 @@ abstract class TestCase extends Orchestra
     protected function reloadPermissions()
     {
         app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function createCacheTable()
+    {
+        Schema::create('cache', function ($table) {
+            $table->string('key')->unique();
+            $table->text('value');
+            $table->integer('expiration');
+        });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,6 +79,8 @@ abstract class TestCase extends Orchestra
 
         // Use test User model for users provider
         $app['config']->set('auth.providers.users.model', User::class);
+
+        $app['config']->set('cache.prefix', 'spatie_tests---');
     }
 
     /**
@@ -88,7 +90,7 @@ abstract class TestCase extends Orchestra
      */
     protected function setUpDatabase($app)
     {
-        $this->app['config']->set('permission.column_names.model_morph_key', 'model_test_id');
+        $app['config']->set('permission.column_names.model_morph_key', 'model_test_id');
 
         $app['db']->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
             $table->increments('id');
@@ -101,7 +103,7 @@ abstract class TestCase extends Orchestra
             $table->string('email');
         });
 
-        if ($this->app->make(PermissionRegistrar::class)->getCacheStore() instanceof \Illuminate\Cache\DatabaseStore) {
+        if ($app[PermissionRegistrar::class]->getCacheStore() instanceof \Illuminate\Cache\DatabaseStore) {
             $this->createCacheTable();
         }
 


### PR DESCRIPTION
This adds support for `manually` testing alternate cache drivers.

(Future plans to extract and automatically test multiple drivers.)

Until now the Tests have only been testing the default `array` driver. With this change one can update the phpunit.xml CACHE_DRIVER to manually test array/file/database/redis/memcached if the environment supports it.