### PR TITLE
Add cache-reset artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,6 +893,11 @@ To manually reset the cache for this package, you can run the following in your 
 $this->app->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
 ```
 
+Or you can use an Artisan command:
+```bash
+php artisan permission:cache-reset
+```
+
 
 ### Cache Identifier
 

--- a/src/Commands/CacheReset.php
+++ b/src/Commands/CacheReset.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\Permission\PermissionRegistrar;
+
+class CacheReset extends Command
+{
+    protected $signature = 'permission:cache-reset';
+
+    protected $description = 'Reset the permission cache';
+
+    public function handle()
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $this->info('Permission cache flushed.');
+    }
+}

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -32,6 +32,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->commands([
+                Commands\CacheReset::class,
                 Commands\CreateRole::class,
                 Commands\CreatePermission::class,
             ]);


### PR DESCRIPTION
This adds the often-requested ability to reset the permissions cache via an Artisan command
`php artisan permission:cache-reset`