### PR TITLE
Add ability to specify a cache driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ return [
          */
 
         'model_key' => 'name',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+        'store' => 'default',
     ],
 ];
 ```

--- a/config/permission.php
+++ b/config/permission.php
@@ -116,5 +116,12 @@ return [
          */
 
         'model_key' => 'name',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+        'store' => 'default',
     ],
 ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Test;
 
+use Illuminate\Support\Facades\Cache;
 use Spatie\Permission\Contracts\Role;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
@@ -103,7 +104,8 @@ abstract class TestCase extends Orchestra
             $table->string('email');
         });
 
-        if ($app[PermissionRegistrar::class]->getCacheStore() instanceof \Illuminate\Cache\DatabaseStore) {
+        if (Cache::getStore() instanceof \Illuminate\Cache\DatabaseStore ||
+            $app[PermissionRegistrar::class]->getCacheStore() instanceof \Illuminate\Cache\DatabaseStore) {
             $this->createCacheTable();
         }
 


### PR DESCRIPTION
A new config entry `permissions.cache.store` may be set to specify an alternate cache driver to use for permissions caching.
Valid entries are items found in the cache.php config file in the `stores` array.

At the time of this PR only the file/database/array/redis/memcached store drivers are tested, although others should work fine.