### PR TITLE
Rename getCacheKey method to resolve #955

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -130,7 +130,7 @@ trait HasPermissions
         return $registrar->getCacheStore()
             ->tags($this->getCacheTags($permission))
             ->remember(
-                $this->getCacheKey($permission),
+                $this->getCacheIdentifier($permission),
                 $registrar::$cacheExpirationTime,
                 function () use ($permission, $guardName) {
                     return $this->hasUncachedPermissionTo($permission, $guardName);
@@ -197,7 +197,7 @@ trait HasPermissions
      *
      * @return string
      */
-    protected function getCacheKey($permission = null)
+    protected function getCacheIdentifier($permission = null)
     {
         $key = PermissionRegistrar::$cacheKey.'.'.$this->getClassCacheString();
 
@@ -378,7 +378,7 @@ trait HasPermissions
             return $registrar->getCacheStore()
                 ->tags($this->getCacheTags())
                 ->remember(
-                    $this->getCacheKey(),
+                    $this->getCacheIdentifier(),
                     $registrar::$cacheExpirationTime,
                     $functionGetAllPermissions
                 );


### PR DESCRIPTION
The old repo highideas/laravel-users-online has a trait with getCacheKey method, so there is a conflict after the last releases of spatie/laravel-permission showing: `Trait method getCacheKey has not been applied, because there are collisions with other trait methods on App\Models\User`

Resolves #955