### PR TITLE
Avoid re-publishing migration if already present

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Spatie\Permission;
 
 use Illuminate\Routing\Route;
+use Illuminate\Support\Collection;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\Permission\Contracts\Role as RoleContract;
@@ -10,20 +12,16 @@ use Spatie\Permission\Contracts\Permission as PermissionContract;
 
 class PermissionServiceProvider extends ServiceProvider
 {
-    public function boot(PermissionRegistrar $permissionLoader)
+    public function boot(PermissionRegistrar $permissionLoader, Filesystem $filesystem)
     {
         if (isNotLumen()) {
             $this->publishes([
                 __DIR__.'/../config/permission.php' => config_path('permission.php'),
             ], 'config');
 
-            if (! class_exists('CreatePermissionTables')) {
-                $timestamp = date('Y_m_d_His', time());
-
-                $this->publishes([
-                    __DIR__.'/../database/migrations/create_permission_tables.php.stub' => $this->app->databasePath()."/migrations/{$timestamp}_create_permission_tables.php",
-                ], 'migrations');
-            }
+            $this->publishes([
+                __DIR__.'/../database/migrations/create_permission_tables.php.stub' => $this->getMigrationFileName($filesystem),
+            ], 'migrations');
 
             if (app()->version() >= '5.5') {
                 $this->registerMacroHelpers();
@@ -147,5 +145,22 @@ class PermissionServiceProvider extends ServiceProvider
 
             return $this;
         });
+    }
+
+    /**
+     * Returns existing migration file if found, else uses the current timestamp.
+     *
+     * @param Filesystem $filesystem
+     * @return string
+     */
+    protected function getMigrationFileName(Filesystem $filesystem): string
+    {
+        $timestamp = date('Y_m_d_His');
+
+        return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
+            ->flatMap(function ($path) use ($filesystem) {
+                return $filesystem->glob($path.'*_create_permission_tables.php');
+            })->push($this->app->databasePath()."/migrations/{$timestamp}_create_permission_tables.php")
+            ->first();
     }
 }


### PR DESCRIPTION
This now checks whether the migration already exists, and if so, re-uses the same filename for publishing, and if not found defaults to current timestamp. 
This allows re-publishing to avoid adding a new migration file unintentionally.

Resolves #960