### PR TITLE
Add fix for broken sync saved event

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -419,9 +419,14 @@ trait HasPermissions
             $class = \get_class($model);
 
             $class::saved(
-                function ($model) use ($permissions) {
-                    $model->permissions()->sync($permissions, false);
-                    $model->load('permissions');
+                function ($object) use ($permissions, $model) {
+                    static $modelLastFiredOn;
+                    if ($modelLastFiredOn !== null && $modelLastFiredOn === $model) {
+                        return;
+                    }
+                    $object->permissions()->sync($permissions, false);
+                    $object->load('permissions');
+                    $modelLastFiredOn = $object;
                 });
         }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -121,8 +121,14 @@ trait HasRoles
             $class = \get_class($model);
 
             $class::saved(
-                function ($model) use ($roles) {
-                    $model->roles()->sync($roles, false);
+                function ($object) use ($roles, $model) {
+                    static $modelLastFiredOn;
+                    if ($modelLastFiredOn !== null && $modelLastFiredOn === $model) {
+                        return;
+                    }
+                    $object->roles()->sync($roles, false);
+                    $object->load('roles');
+                    $modelLastFiredOn = $object;
                 });
         }
 

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -449,4 +449,34 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($user->hasPermissionTo('edit-articles'));
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-articles'));
     }
+
+    /** @test */
+    public function calling_givePermissionTo_before_saving_object_doesnt_interfere_with_other_objects()
+    {
+        $user = new User(['email' => 'test@user.com']);
+        $user->givePermissionTo('edit-news');
+        $user->save();
+
+        $user2 = new User(['email' => 'test2@user.com']);
+        $user2->givePermissionTo('edit-articles');
+        $user2->save();
+
+        $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
+        $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
+    }
+
+    /** @test */
+    public function calling_syncPermissions_before_saving_object_doesnt_interfere_with_other_objects()
+    {
+        $user = new User(['email' => 'test@user.com']);
+        $user->syncPermissions('edit-news');
+        $user->save();
+
+        $user2 = new User(['email' => 'test2@user.com']);
+        $user2->syncPermissions('edit-articles');
+        $user2->save();
+
+        $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
+        $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
+    }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -201,6 +201,36 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function calling_syncRoles_before_saving_object_doesnt_interfere_with_other_objects()
+    {
+        $user = new User(['email' => 'test@user.com']);
+        $user->syncRoles('testRole');
+        $user->save();
+
+        $user2 = new User(['email' => 'admin@user.com']);
+        $user2->syncRoles('testRole2');
+        $user2->save();
+
+        $this->assertTrue($user2->fresh()->hasRole('testRole2'));
+        $this->assertFalse($user2->fresh()->hasRole('testRole'));
+    }
+
+    /** @test */
+    public function calling_assignRole_before_saving_object_doesnt_interfere_with_other_objects()
+    {
+        $user = new User(['email' => 'test@user.com']);
+        $user->assignRole('testRole');
+        $user->save();
+
+        $admin_user = new User(['email' => 'admin@user.com']);
+        $admin_user->assignRole('testRole2');
+        $admin_user->save();
+
+        $this->assertTrue($admin_user->fresh()->hasRole('testRole2'));
+        $this->assertFalse($admin_user->fresh()->hasRole('testRole'));
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_syncing_a_role_from_another_guard()
     {
         $this->expectException(RoleDoesNotExist::class);


### PR DESCRIPTION
Fixes #971 

This remembers the model properties the event last fired for, so that it doesn't incorrectly assign the prior model's properties.

(I'd prefer to be able to un-register the event once it fires, and prefer to avoid creating a custom event just for this rare use case. This feels like a safe middle-ground.)