### PR TITLE
Updated UnauthorizedException

### DIFF
--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -6,9 +6,9 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UnauthorizedException extends HttpException
 {
-    private $requiredRoles = [];
+    public $requiredRoles = [];
 
-    private $requiredPermissions = [];
+    public $requiredPermissions = [];
 
     public static function forRoles(array $roles): self
     {


### PR DESCRIPTION
$requiredRoles and $requiredPermissions are now accessible and available for use on any ExceptionHandler.

ie. if you need to decide different actions for different permissions or roles; you can now access it via $exception->requiredPermissions or $exception->requiredPermissions on any handlers render method.