### PR TITLE
Change default cache time to DateInterval instead of integer/minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ return [
     'cache' => [
 
         /*
-         * By default all permissions will be cached for 24 hours unless a permission or
-         * role is updated. Then the cache will be flushed immediately.
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
          */
 
-        'expiration_time' => 60 * 24,
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
 
         /*
          * The key to use when tagging and prefixing entries in the cache.
@@ -226,6 +226,7 @@ return [
          * role caching using any of the `store` drivers listed in the cache.php config
          * file. Using 'default' here means to use the `default` set in cache.php.
          */
+
         'store' => 'default',
     ],
 ];

--- a/config/permission.php
+++ b/config/permission.php
@@ -95,11 +95,11 @@ return [
     'cache' => [
 
         /*
-         * By default all permissions will be cached for 24 hours unless a permission or
-         * role is updated. Then the cache will be flushed immediately.
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
          */
 
-        'expiration_time' => 60 * 24,
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
 
         /*
          * The key to use when tagging and prefixing entries in the cache.

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -27,7 +27,7 @@ class PermissionRegistrar
     /** @var string */
     protected $roleClass;
 
-    /** @var int */
+    /** @var DateInterval|int */
     public static $cacheExpirationTime;
 
     /** @var string */
@@ -58,6 +58,14 @@ class PermissionRegistrar
     protected function initializeCache()
     {
         self::$cacheExpirationTime = config('permission.cache.expiration_time', config('permission.cache_expiration_time'));
+
+        if (app()->version() <= '5.5') {
+            if (self::$cacheExpirationTime instanceof \DateInterval) {
+                $interval = self::$cacheExpirationTime;
+                self::$cacheExpirationTime = $interval->m * 30 * 60 * 24 + $interval->d * 60 * 24 + $interval->h * 60 + $interval->i;
+            }
+        }
+
         self::$cacheKey = config('permission.cache.key');
         self::$cacheModelKey = config('permission.cache.model_key');
 


### PR DESCRIPTION
This is in preparation for compatibility with Laravel 5.8's cache TTL change to seconds instead of minutes.

NOTE: If you leave your existing `config/permission.php` file alone, then with Laravel 5.8 the `60 * 24` will change from being treated as 24 hours to just 24 minutes. Depending on your app, this may or may not make a significant difference.  Updating your config file to a specific DateInterval will add specificity and insulate you from the TTL change in Laravel 5.8.

Refs:
https://laravel-news.com/cache-ttl-change-coming-to-laravel-5-8
https://github.com/laravel/framework/commit/fd6eb89b62ec09df1ffbee164831a827e83fa61d