### PR TITLE
Added guard to middleware and added tests

### DIFF
--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -23,7 +23,7 @@ class PermissionMiddleware
             : explode('|', $permission);
 
         foreach ($permissions as $permission) {
-            if (Auth::guard($guard)->user()->can($permission, $guard)) {
+            if (Auth::guard($guard)->user()->can($permission)) {
                 return $next($request);
             }
         }

--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -31,4 +31,3 @@ class PermissionMiddleware
         throw UnauthorizedException::forPermissions($permissions);
     }
 }
-

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -8,9 +8,13 @@ use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class RoleMiddleware
 {
-    public function handle($request, Closure $next, $role)
+    public function handle($request, Closure $next, $role, $guard = null)
     {
-        if (Auth::guest()) {
+        if (is_null($guard)) {
+            $guard = (require config_path('auth.php'))['defaults']['guard'];
+        }
+        
+        if (Auth::guard($guard)->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }
 
@@ -18,7 +22,7 @@ class RoleMiddleware
             ? $role
             : explode('|', $role);
 
-        if (! Auth::user()->hasAnyRole($roles)) {
+        if (! Auth::guard($guard)->user()->hasAnyRole($roles, $guard)) {
             throw UnauthorizedException::forRoles($roles);
         }
 

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -22,7 +22,7 @@ class RoleMiddleware
             ? $role
             : explode('|', $role);
 
-        if (! Auth::guard($guard)->user()->hasAnyRole($roles, $guard)) {
+        if (! Auth::guard($guard)->user()->hasAnyRole($roles)) {
             throw UnauthorizedException::forRoles($roles);
         }
 

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -13,7 +13,7 @@ class RoleMiddleware
         if (is_null($guard)) {
             $guard = (require config_path('auth.php'))['defaults']['guard'];
         }
-        
+
         if (Auth::guard($guard)->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -8,9 +8,13 @@ use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class RoleOrPermissionMiddleware
 {
-    public function handle($request, Closure $next, $roleOrPermission)
+    public function handle($request, Closure $next, $roleOrPermission, $guard = null)
     {
-        if (Auth::guest()) {
+        if (is_null($guard)) {
+            $guard = (require config_path('auth.php'))['defaults']['guard'];
+        }
+        
+        if (Auth::guard($guard)->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }
 
@@ -18,7 +22,7 @@ class RoleOrPermissionMiddleware
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        if (! Auth::user()->hasAnyRole($rolesOrPermissions) && ! Auth::user()->hasAnyPermission($rolesOrPermissions)) {
+        if (! Auth::guard($guard)->user()->hasAnyRole($rolesOrPermissions, $guard) && ! Auth::guard($guard)->user()->hasAnyPermission($rolesOrPermissions, $guard)) {
             throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -22,7 +22,7 @@ class RoleOrPermissionMiddleware
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        if (! Auth::guard($guard)->user()->hasAnyRole($rolesOrPermissions, $guard) && ! Auth::guard($guard)->user()->hasAnyPermission($rolesOrPermissions, $guard)) {
+        if (! Auth::guard($guard)->user()->hasAnyRole($rolesOrPermissions) && ! Auth::guard($guard)->user()->hasAnyPermission($rolesOrPermissions)) {
             throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -13,7 +13,7 @@ class RoleOrPermissionMiddleware
         if (is_null($guard)) {
             $guard = (require config_path('auth.php'))['defaults']['guard'];
         }
-        
+
         if (Auth::guard($guard)->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -395,7 +395,7 @@ class MiddlewareTest extends TestCase
         $this->assertEquals(
             $this->runMiddleware(
                 $this->roleMiddleware, 'testAdminRole', 'admin'
-            ), 200);            
+            ), 200);
     }
 
     /** @test */
@@ -416,7 +416,7 @@ class MiddlewareTest extends TestCase
         $this->assertEquals(
             $this->runMiddleware(
                 $this->permissionMiddleware, 'admin-permission', 'admin'
-            ), 200);            
+            ), 200);
     }
 
     /** @test */
@@ -438,7 +438,7 @@ class MiddlewareTest extends TestCase
         $this->assertEquals(
             $this->runMiddleware(
                 $this->roleOrPermissionMiddleware, 'testAdminRole|admin-permission', 'admin'
-            ), 200);            
+            ), 200);
     }
 
     protected function runMiddleware($middleware, ...$parameters)

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -14,12 +14,12 @@ class TestHelper
      *
      * @return int
      */
-    public function testMiddleware($middleware, $parameter)
+    public function testMiddleware($middleware, ...$parameters)
     {
         try {
             return $middleware->handle(new Request(), function () {
                 return (new Response())->setContent('<html></html>');
-            }, $parameter)->status();
+            }, ...$parameters)->status();
         } catch (HttpException $e) {
             return $e->getStatusCode();
         }


### PR DESCRIPTION
This is just a first draft of the changes required allow users to optionally specify the guard when using the permission middleware. As discussed here: https://github.com/spatie/laravel-permission/issues/978

```php
// Example without guard should use default guard from config file (usually web)
Route::group(['middleware' => ['role:auditor']], function () {
    //
});
// Example of middleware with guard specified
Route::group(['middleware' => ['role:auditor,admin']], function () {
    //
});
```

During the implementation of this feature I identified an issue with the current middleware that occurred when having multiple users logged into the system with different guards combined with running the `auth` middleware which updates the default guard in the config file during runtime.

```php
Auth::login($user);
Auth::guard('admin)->login($adminUser);

// I don't think this should pass because the permission middleware 
// did not specify the admin guard but it does because the auth:admin 
// middleware updated the default guard config file
Route::get('/test', function() {
   return 'success!'
})->middleware('auth:admin', 'permission:admin-only-permission');

// This should pass because we specified the guard for an admin permission
Route::get('/test', function() {
   return 'success!'
})->middleware('auth:admin', 'permission:admin-only-permission,admin');
```

The cause of the issue is that the Laravel configuration value `auth.defaults.guard` can be changed during runtime. It seems that when you perform a check on a route using the `auth` middleware a method is called that updates the config value. This appears to be so that subsequent calls to the auth factory default to that guard. That's handy in some situations however in our situation it meant that we had unexpected results from our middleware checks. By not providing a guard and therefore technically passing `null` as a guard, Laravel falls back to the default. And like I said, this value can change.

For example see this test which I have included:

```php
public function logging_in_both_users_and_calling_the_authenticate_middleware_with_a_guard_results_in_a_change_at_runtime_of_the_default_guard_config_value()
{
    Auth::login($this->testUser);

    $this->runMiddleware(
        $this->authenticateMiddleware
    );

    $this->assertEquals('web', config('auth.defaults.guard'));

    Auth::guard('admin')->login($this->testAdmin);

    $this->runMiddleware(
        $this->authenticateMiddleware, 'admin'
    );

    $this->assertEquals('admin', config('auth.defaults.guard'));
}
```

When combined with our middleware that uses the default guard we encounter an issue:

```php
public function ensure_that_the_role_middleware_is_not_affected_by_a_change_at_runtime_of_the_default_guard_config_value()
{
    Auth::login($this->testUser);

    $this->testAdmin->assignRole('testAdminRole');
    Auth::guard('admin')->login($this->testAdmin);

    // Simulate a runtime update of the config value
    config(['auth.defaults.guard' => 'admin']);

    $this->assertEquals(
        $this->runMiddleware(
            $this->roleMiddleware, 'testAdminRole'
        ), 403);

    $this->assertEquals(
        $this->runMiddleware(
            $this->roleMiddleware, 'testAdminRole', 'admin'
        ), 200);            
}
```
This test fails with the existing middleware implementation. The first assertion passes giving access to an admin role when it should be using the default guard which was originally `web`. So in this case I've updated the config value at runtime manually but that can happen if you use the `auth` middleware as shown in the first test.

My solution to this is for the middleware to fetch the default guard directly from the config file so we can be sure we get the original value. 

```php
if (is_null($guard)) {
    $guard = (require config_path('auth.php'))['defaults']['guard'];
}
```

This is just a draft but I hope I explained it in a way that can be understood. If not just let me know.
