### PR TITLE
add in-memory permission caching, switch to single cache key + fix bu…

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -102,7 +102,7 @@ return [
         'expiration_time' => \DateInterval::createFromDateString('24 hours'),
 
         /*
-         * The key to use when tagging and prefixing entries in the cache.
+         * The cache key used to store all permissions.
          */
 
         'key' => 'spatie.permission.cache',

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -39,9 +39,6 @@ class PermissionRegistrar
     /** @var string */
     public static $cacheModelKey;
 
-    /** @var bool */
-    public static $cacheIsTaggable = false;
-
     /**
      * PermissionRegistrar constructor.
      *
@@ -72,11 +69,7 @@ class PermissionRegistrar
         self::$cacheKey = config('permission.cache.key');
         self::$cacheModelKey = config('permission.cache.model_key');
 
-        $cache = $this->getCacheStoreFromConfig();
-
-        self::$cacheIsTaggable = ($cache->getStore() instanceof \Illuminate\Cache\TaggableStore);
-
-        $this->cache = self::$cacheIsTaggable ? $cache->tags(self::$cacheKey) : $cache;
+        $this->cache = $this->getCacheStoreFromConfig();
     }
 
     protected function getCacheStoreFromConfig(): \Illuminate\Contracts\Cache\Repository
@@ -122,7 +115,7 @@ class PermissionRegistrar
     public function forgetCachedPermissions()
     {
         $this->permissions = null;
-        self::$cacheIsTaggable ? $this->cache->flush() : $this->cache->forget(self::$cacheKey);
+        $this->cache->forget(self::$cacheKey);
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -178,50 +178,6 @@ trait HasPermissions
     }
 
     /**
-     * Construct the key for the cache entry.
-     *
-     * @param null|string|int|\Spatie\Permission\Contracts\Permission $permission
-     *
-     * @return string
-     */
-    protected function getPermissionCacheKey($permission = null)
-    {
-        $key = PermissionRegistrar::$cacheKey.'.'.$this->getClassCacheString();
-
-        if ($permission !== null) {
-            $key .= $this->getPermissionCacheString($permission);
-        }
-
-        return md5($key);
-    }
-
-    /**
-     * Get the key to cache the model by.
-     *
-     * @return string
-     */
-    private function getClassCacheString()
-    {
-        return str_replace('\\', '.', get_class($this)).'.'.$this->getKey();
-    }
-
-    /**
-     * Get the key to cache the permission by.
-     *
-     * @param string|int|\Spatie\Permission\Contracts\Permission $permission
-     *
-     * @return mixed
-     */
-    protected function getPermissionCacheString($permission)
-    {
-        if ($permission instanceof Permission) {
-            $permission = $permission[PermissionRegistrar::$cacheModelKey];
-        }
-
-        return str_replace('\\', '.', Permission::class).'.'.$permission;
-    }
-
-    /**
      * Determine if the model has any of the given permissions.
      *
      * @param array ...$permissions

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -205,7 +205,7 @@ trait HasPermissions
             $key .= $this->getPermissionCacheString($permission);
         }
 
-        return $key;
+        return md5($key);
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -150,7 +150,7 @@ class CacheTest extends TestCase
     /** @test */
     public function has_permission_to_should_use_the_cache()
     {
-        $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news']);
+        $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news', 'Edit News']);
         $this->testUser->assignRole('testRole');
 
         $this->resetQueryCount();
@@ -159,11 +159,15 @@ class CacheTest extends TestCase
 
         $this->resetQueryCount();
         $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));
-        $this->assertQueryCount($this->cache_run_count + $this->cache_untagged_count);
+        $this->assertQueryCount(0);
 
         $this->resetQueryCount();
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
-        $this->assertQueryCount($this->cache_init_count);
+        $this->assertQueryCount(0);
+
+        $this->resetQueryCount();
+        $this->assertTrue($this->testUser->hasPermissionTo('Edit News'));
+        $this->assertQueryCount(0);
     }
 
     /** @test */

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -14,7 +14,6 @@ class CacheTest extends TestCase
     protected $cache_load_count = 0;
     protected $cache_run_count = 2;
     protected $cache_reload_count = 0;
-    protected $cache_untagged_count = 0;
     protected $cache_relations_count = 1;
 
     protected $registrar;
@@ -36,20 +35,7 @@ class CacheTest extends TestCase
                 $this->cache_init_count = 1;
                 $this->cache_load_count = 1;
                 $this->cache_reload_count = 1;
-                $this->cache_untagged_count = -1;
                 break;
-            case $cacheStore instanceof \Illuminate\Cache\FileStore:
-                $this->cache_untagged_count = -2;
-                break;
-            case $cacheStore instanceof \Illuminate\Cache\RedisStore:
-                $this->cache_untagged_count = 0;
-                break;
-            case $cacheStore instanceof \Illuminate\Cache\MemcachedStore:
-                $this->cache_untagged_count = 0;
-                break;
-            case $cacheStore instanceof \Illuminate\Cache\ArrayStore:
-                $this->cache_untagged_count = 0;
-            default:
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -129,6 +129,7 @@ abstract class TestCase extends Orchestra
         $app[Permission::class]->create(['name' => 'edit-news']);
         $app[Permission::class]->create(['name' => 'edit-blog']);
         $app[Permission::class]->create(['name' => 'admin-permission', 'guard_name' => 'admin']);
+        $app[Permission::class]->create(['name' => 'Edit News']);
     }
 
     /**


### PR DESCRIPTION
This PR is an attempt to address both https://github.com/spatie/laravel-permission/issues/1031 and https://github.com/spatie/laravel-permission/issues/1030

* Add in-memory permission object caching
* Switch to single cache key for all permissions
* Fix bug where permissions containing spaces aren't cached

**This definitely needs eyes from someone who's more familiar with the codebase than myself.**

I setup a local testing env with a replica of my production database.

**Before Patch**

A page with a table of results, where each row checked against 4 to 5 permissions, resulted in roughly 500 calls to a memcached server taking up approximately 350+-ms.

**After Patch**

It does only 1 call to the memcached server for the single cache key `spatie.permission.cache`.
