### PR TITLE
TravisCI tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/database": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.2|~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.4.2|~3.5.0|~3.6.0|~3.7.0",
         "phpunit/phpunit": "^5.7|6.2|^7.0",
         "predis/predis": "^1.1"
     },


### PR DESCRIPTION
Force CI tests to run only on older versions until we drop older PHP and older Laravel version support.

Will probably move to minimum PHP 7.2 