### PR TITLE
new getPermissionNames() function

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -468,6 +468,11 @@ trait HasPermissions
         return $this;
     }
 
+    public function getPermissionNames(): Collection
+    {
+        return $this->permissions->pluck('name');
+    }
+
     /**
      * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
      *

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -240,7 +240,7 @@ trait HasRoles
             return $role instanceof Role ? $role->name : $role;
         });
 
-        return $roles->intersect($this->roles->pluck('name')) == $roles;
+        return $roles->intersect($this->getRoleNames()) == $roles;
     }
 
     /**

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -479,4 +479,14 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
     }
+    
+    /** @test */
+    public function it_can_retrieve_permission_names()
+    {
+        $this->testUser->givePermissionTo('edit-news', 'edit-articles');
+        $this->assertEquals(
+            collect(['edit-news', 'edit-articles']),
+            $this->testUser->getPermissionNames()
+        );
+    }
 }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -479,7 +479,7 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
     }
-    
+
     /** @test */
     public function it_can_retrieve_permission_names()
     {


### PR DESCRIPTION
Hello,

I've noticed the `getRoleNames()` function on the HasRole trait but the counter-part for permissions missing, so i've added the `getPermissionNames()` function in the HasPermission trait.

I've also written a test for it, let's see if it passes Travis CI.