### PR TITLE
null-filtering permissions inconsistency against roles

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -399,6 +399,10 @@ trait HasPermissions
         $permissions = collect($permissions)
             ->flatten()
             ->map(function ($permission) {
+                if (empty($permission)) {
+                    return false;
+                }
+
                 return $this->getStoredPermission($permission);
             })
             ->filter(function ($permission) {


### PR DESCRIPTION
Noticed an inconsistency between roles and permissions and applied the fix :)

see https://github.com/spatie/laravel-permission/commit/7656d0c2c17b8183ae4029607cf6576ef8c8eeb6