### PR TITLE
[Performance] avoid to iterate the list twice and returns on first found permission

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -137,11 +137,15 @@ class PermissionRegistrar
 
         $permissions = clone $this->permissions;
 
-        foreach ($params as $attr => $value) {
-            $permissions = $permissions->where($attr, $value);
-        }
+        return collect([$permissions->first(function ($item) use ($params) {
+            foreach ($params as $key => $value) {
+                if ($item[$key] !== $value) {
+                    return false;
+                }
+            }
+            return true;
+        })]);
 
-        return $permissions;
     }
 
     /**

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -143,9 +143,9 @@ class PermissionRegistrar
                     return false;
                 }
             }
+
             return true;
         })]);
-
     }
 
     /**


### PR DESCRIPTION
Hello,

I have a project with 350 permissions. I sidebar menu checks permission to create the proper items for the user. There are around 350 checks in there.
With the current implementation (latest version) for each permission check in `getPermissions` the permission list iterates twice with two `wheres` (one for `guard_name` and one for `id` or `name`).
On my situation, each check takes around `6ms` to find the proper permission. With around 350 checks on my menu, I get a delay around 2 seconds to generate.

With this patch, the `getPermissions` iterates the permission list once and stops on the first found permission. This drops my times under `300ms`.

I believe this is a good performance improvement.
Any suggestions, thoughts are welcome.
Thanks

All tests are green.

