### PR TITLE
Add permission:show

### DIFF
--- a/src/Commands/Show.php
+++ b/src/Commands/Show.php
@@ -7,9 +7,9 @@ use Illuminate\Support\Collection;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 
-class Table extends Command
+class Show extends Command
 {
-    protected $signature = 'permission:table
+    protected $signature = 'permission:show
             {guard? : The name of the guard}';
 
     protected $description = 'Show a table of roles and permissions per guard';

--- a/src/Commands/Show.php
+++ b/src/Commands/Show.php
@@ -10,12 +10,14 @@ use Spatie\Permission\Models\Permission;
 class Show extends Command
 {
     protected $signature = 'permission:show
-            {guard? : The name of the guard}';
+            {guard? : The name of the guard}
+            {style? : The display style (default|borderless|compact|box)}';
 
     protected $description = 'Show a table of roles and permissions per guard';
 
     public function handle()
     {
+        $style = $this->argument('style') ?? 'default';
         $guard = $this->argument('guard');
 
         if ($guard) {
@@ -41,7 +43,8 @@ class Show extends Command
 
             $this->table(
                 $roles->keys()->prepend('')->toArray(),
-                $body->toArray()
+                $body->toArray(),
+                $style
             );
         }
     }

--- a/src/Commands/Table.php
+++ b/src/Commands/Table.php
@@ -27,13 +27,11 @@ class Table extends Command
         foreach ($guards as $guard) {
             $this->info("Guard: $guard");
 
-            $permissions = Permission::whereGuardName($guard)->orderBy('name')->pluck('name');
-
             $roles = Role::whereGuardName($guard)->orderBy('name')->get()->mapWithKeys(function (Role $role) {
                 return [$role->name => $role->permissions->pluck('name')];
             });
 
-            $header = $roles->keys()->prepend('');
+            $permissions = Permission::whereGuardName($guard)->orderBy('name')->pluck('name');
 
             $body = $permissions->map(function ($permission) use ($roles) {
                 return $roles->map(function (Collection $role_permissions) use ($permission) {
@@ -41,7 +39,10 @@ class Table extends Command
                 })->prepend($permission);
             });
 
-            $this->table($header->toArray(), $body->toArray());
+            $this->table(
+                $roles->keys()->prepend('')->toArray(),
+                $body->toArray()
+            );
         }
     }
 }

--- a/src/Commands/Table.php
+++ b/src/Commands/Table.php
@@ -4,8 +4,8 @@ namespace Spatie\Permission\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
 
 class Table extends Command
 {
@@ -18,7 +18,7 @@ class Table extends Command
     {
         $guard = $this->argument('guard');
 
-        if($guard){
+        if ($guard) {
             $guards = Collection::make([$guard]);
         } else {
             $guards = Permission::pluck('guard_name')->merge(Role::pluck('guard_name'))->unique();

--- a/src/Commands/Table.php
+++ b/src/Commands/Table.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class Table extends Command
+{
+    protected $signature = 'permission:table
+            {guard? : The name of the guard}';
+
+    protected $description = 'Show a table of roles and permissions per guard';
+
+    public function handle()
+    {
+        $guard = $this->argument('guard');
+
+        if($guard){
+            $guards = Collection::make([$guard]);
+        } else {
+            $guards = Permission::pluck('guard_name')->merge(Role::pluck('guard_name'))->unique();
+        }
+
+        foreach ($guards as $guard) {
+            $this->info("Guard: $guard");
+
+            $permissions = Permission::whereGuardName($guard)->orderBy('name')->pluck('name');
+
+            $roles = Role::whereGuardName($guard)->orderBy('name')->get()->mapWithKeys(function (Role $role) {
+                return [$role->name => $role->permissions->pluck('name')];
+            });
+
+            $header = $roles->keys()->prepend('');
+
+            $body = $permissions->map(function ($permission) use ($roles) {
+                return $roles->map(function (Collection $role_permissions) use ($permission) {
+                    return $role_permissions->contains($permission) ? ' ✔' : ' ·';
+                })->prepend($permission);
+            });
+
+            $this->table($header->toArray(), $body->toArray());
+        }
+    }
+}

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -33,7 +33,7 @@ class PermissionServiceProvider extends ServiceProvider
                 Commands\CacheReset::class,
                 Commands\CreateRole::class,
                 Commands\CreatePermission::class,
-                Commands\Table::class,
+                Commands\Show::class,
             ]);
         }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -33,6 +33,7 @@ class PermissionServiceProvider extends ServiceProvider
                 Commands\CacheReset::class,
                 Commands\CreateRole::class,
                 Commands\CreatePermission::class,
+                Commands\Table::class,
             ]);
         }
 

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -91,8 +91,8 @@ class CommandTest extends TestCase
 
         $output = Artisan::output();
 
-        $this->assertStringContainsString('Guard: web', $output);
-        $this->assertStringContainsString('Guard: admin', $output);
+        $this->assertTrue(strpos($output, 'Guard: web') !== false);
+        $this->assertTrue(strpos($output, 'Guard: admin') !== false);
 
         // |               | testRole | testRole2 |
         $this->assertRegExp('/\|\s+\|\s+testRole\s+\|\s+testRole2\s+\|/', $output);
@@ -118,7 +118,7 @@ class CommandTest extends TestCase
 
         $output = Artisan::output();
 
-        $this->assertStringContainsString('Guard: web', $output);
-        $this->assertStringNotContainsString('Guard: admin', $output);
+        $this->assertTrue(strpos($output, 'Guard: web') !== false);
+        $this->assertTrue(strpos($output, 'Guard: admin') === false);
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -110,4 +110,15 @@ class CommandTest extends TestCase
         // | edit-articles |  ·       |  ·        |
         $this->assertRegExp('/\|\s+edit-articles\s+\|\s+✔\s+\|\s+·\s+\|/', $output);
     }
+
+    /** @test */
+    public function it_shows_one_table()
+    {
+        Artisan::call('permission:table', ['guard' => 'web']);
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Guard: web', $output);
+        $this->assertStringNotContainsString('Guard: admin', $output);
+    }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -83,4 +83,31 @@ class CommandTest extends TestCase
 
         $this->assertCount(1, Permission::where('name', 'new-permission')->get());
     }
+
+    /** @test */
+    public function it_can_show_a_permission_table()
+    {
+        Artisan::call('permission:table');
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Guard: web', $output);
+        $this->assertStringContainsString('Guard: admin', $output);
+
+        // |               | testRole | testRole2 |
+        $this->assertRegExp('/\|\s+\|\s+testRole\s+\|\s+testRole2\s+\|/', $output);
+
+        // | edit-articles |  ·       |  ·        |
+        $this->assertRegExp('/\|\s+edit-articles\s+\|\s+·\s+\|\s+·\s+\|/', $output);
+
+        Role::findByName('testRole')->givePermissionTo('edit-articles');
+        $this->reloadPermissions();
+
+        Artisan::call('permission:table');
+
+        $output = Artisan::output();
+
+        // | edit-articles |  ·       |  ·        |
+        $this->assertRegExp('/\|\s+edit-articles\s+\|\s+✔\s+\|\s+·\s+\|/', $output);
+    }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -85,9 +85,9 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function it_can_show_a_permission_table()
+    public function it_can_show_permission_tables()
     {
-        Artisan::call('permission:table');
+        Artisan::call('permission:show');
 
         $output = Artisan::output();
 
@@ -103,7 +103,7 @@ class CommandTest extends TestCase
         Role::findByName('testRole')->givePermissionTo('edit-articles');
         $this->reloadPermissions();
 
-        Artisan::call('permission:table');
+        Artisan::call('permission:show');
 
         $output = Artisan::output();
 
@@ -112,9 +112,9 @@ class CommandTest extends TestCase
     }
 
     /** @test */
-    public function it_shows_one_table()
+    public function it_can_show_permissions_for_guard()
     {
-        Artisan::call('permission:table', ['guard' => 'web']);
+        Artisan::call('permission:show', ['guard' => 'web']);
 
         $output = Artisan::output();
 


### PR DESCRIPTION
Funny tables, useful for debugging.
Returns a table per guard, or set the `guard` argument.

`artisan permission:show web`

```
Guard name: web
+------------------+-------+---------+--------+
|                  | admin | browser | editor |
+------------------+-------+---------+--------+
| manage users     |  ✔    |  ·      |  ·     |
| browse catalog   |  ✔    |  ✔      |  ✔     |
| export catalog   |  ✔    |  ·      |  ·     |
| manage settings  |  ✔    |  ·      |  ·     |
| bulk edit        |  ✔    |  ·      |  ✔     |
| import catalog   |  ✔    |  ·      |  ·     |
| browse resellers |  ✔    |  ✔      |  ✔     |
| browse orders    |  ✔    |  ✔      |  ✔     |
| manage offers    |  ✔    |  ·      |  ✔     |
| view invoices    |  ✔    |  ✔      |  ✔     |
+------------------+-------+---------+--------+
```

With tests. 