### PR TITLE
Add orchestra/testbench 3.8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/database": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.2|~3.5.0|~3.6.0|~3.7.0",
+        "orchestra/testbench": "~3.4.2|~3.5.0|~3.6.0|~3.7.0|~3.8.0",
         "phpunit/phpunit": "^5.7|6.2|^7.0",
         "predis/predis": "^1.1"
     },


### PR DESCRIPTION
Since other dependencies specify support for Laravel 5.8, `orchestra/testbench` should also allow for the 3.8 release.