### PR TITLE
Show error when permission:cache-reset command fails

### DIFF
--- a/src/Commands/CacheReset.php
+++ b/src/Commands/CacheReset.php
@@ -13,8 +13,10 @@ class CacheReset extends Command
 
     public function handle()
     {
-        app(PermissionRegistrar::class)->forgetCachedPermissions();
-
-        $this->info('Permission cache flushed.');
+        if (app(PermissionRegistrar::class)->forgetCachedPermissions()) {
+            $this->info('Permission cache flushed.');
+        } else {
+            $this->error('Unable to flush cache.');
+        }
     }
 }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -115,7 +115,8 @@ class PermissionRegistrar
     public function forgetCachedPermissions()
     {
         $this->permissions = null;
-        $this->cache->forget(self::$cacheKey);
+
+        return $this->cache->forget(self::$cacheKey);
     }
 
     /**


### PR DESCRIPTION
permission:cache-reset always returns a 'Permission cache flushed.' If the delete method from the FileStore cache class returns `false` it wont be acknowledge and the user wont be notified that the cache was not cleared.

In my case the cache was created by the apache user `www-data`, but when I ran the command `php artisan permission:cache-reset` I always got the 'Permission cache flushed.'  message when in fact the cache file was not deleted, this caused issues when running the seeder, telling me that the Permission already existed.

This PR will surface the `forget` method response, and if its false print an error, so the user will at least know that the cache file is still there.