### PR TITLE
Load roles relationship only when missing

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -262,10 +262,17 @@ trait HasPermissions
      */
     public function getPermissionsViaRoles(): Collection
     {
-        return $this->load('roles', 'roles.permissions')
-            ->roles->flatMap(function ($role) {
-                return $role->permissions;
-            })->sort()->values();
+        $relationships = ['roles', 'roles.permissions'];
+
+        if (method_exists($this, 'loadMissing')) {
+            $this->loadMissing($relationships);
+        } else {
+            $this->load($relationships);
+        }
+
+        return $this->roles->flatMap(function ($role) {
+            return $role->permissions;
+        })->sort()->values();
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -183,7 +183,7 @@ class CacheTest extends TestCase
         $actual = $this->testUser->getAllPermissions()->pluck('name');
         $this->assertEquals($actual, collect($expected));
 
-        $this->assertQueryCount(3);
+        $this->assertQueryCount(method_exists($this->testUser, 'loadMissing') ? 2 : 3);
     }
 
     /** @test */


### PR DESCRIPTION
Currently, if you use getPermissionsViaRoles or any related methods (like getAllPermissions), it will query the DB on every call. My PR makes sure that the DB is queried only, if permissions via roles have not been loaded yet.