### PR TITLE
Fix hasDirectPermission DocBlock

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -231,6 +231,7 @@ trait HasPermissions
      * @param string|int|\Spatie\Permission\Contracts\Permission $permission
      *
      * @return bool
+     * @throws PermissionDoesNotExist
      */
     public function hasDirectPermission($permission): bool
     {


### PR DESCRIPTION
hasDirectPermission()'s DocBlock didn't indicate that it can throw PermissionDoesNotExist exception.