### PR TITLE
Flush permissions cache when removing a role from a model

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -150,6 +150,8 @@ trait HasRoles
 
         $this->load('roles');
 
+        $this->forgetCachedPermissions();
+
         return $this;
     }
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -103,6 +103,22 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    public function it_flushes_the_cache_when_removing_a_role_from_a_user()
+    {
+        $this->testUser->assignRole('testRole');
+
+        $this->registrar->getPermissions();
+
+        $this->testUser->removeRole('testRole');
+
+        $this->resetQueryCount();
+
+        $this->registrar->getPermissions();
+
+        $this->assertQueryCount($this->cache_init_count + $this->cache_load_count + $this->cache_run_count);
+    }
+
+    /** @test */
     public function user_creation_should_not_flush_the_cache()
     {
         $this->registrar->getPermissions();


### PR DESCRIPTION
According to the docs the hasRoles trait's removeRole() method should clear the permissions cache, but currently it doesn't seem to be. Hopefully this PR should resolve