### PR TITLE
add unique modifier to name attribute of roles and permissions table

### DIFF
--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -18,14 +18,14 @@ class CreatePermissionTables extends Migration
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->unique();
             $table->string('guard_name');
             $table->timestamps();
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->unique();
             $table->string('guard_name');
             $table->timestamps();
         });


### PR DESCRIPTION
I am just adding the unique modifier to the name attribute of roles and permissions table because of when checking for a specific role or permission when there are two different roles with the same name, here I have been faced with such an issue. the same issue exists with the permissions table.