### PR TITLE
add UNIQUE constraint to name/guard_name column pair for roles and pe…

### DIFF
--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -21,6 +21,7 @@ class CreatePermissionTables extends Migration
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
+            $table->unique(['name', 'guard_name']);
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) {
@@ -28,6 +29,7 @@ class CreatePermissionTables extends Migration
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
+            $table->unique(['name', 'guard_name']);
         });
 
         Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {


### PR DESCRIPTION
…rmissions tables

add UNIQUE constraint to name/guard_name column pair for roles and permissions tables in the migration to prevent creating duplicate Roles and Permissions per guard, which can break someone's code quite easily.