### PR TITLE
Feature/check many direct permissions

### DIFF
--- a/docs/basic-usage/role-permissions.md
+++ b/docs/basic-usage/role-permissions.md
@@ -90,6 +90,20 @@ but `false` for `$user->hasDirectPermission('edit articles')`.
 
 This method is useful if one builds a form for setting permissions for roles and users in an application and wants to restrict or change inherited permissions of roles of the user, i.e. allowing to change only direct permissions of the user.
 
+You can check if the user has direct permissions without passing by the role's permissions:
+
+```php
+// Check if the user has all direct permissions
+$user->hasAllDirectPermissions(['edit articles', 'delete articles']);
+
+// Check if the user has any permission directly
+$user->hasAnyDirectPermission(['create articles', 'delete articles']);
+```
+By following the previous example, when we call `$user->hasAllDirectPermissions(['edit articles', 'delete articles'])` 
+it returns `true`, because the user has all these direct permissions. When we call
+`$user->hasAnyDirectPermission('edit articles')`, it returns `true` because the user has one of the provided permissions.
+
+
 You can list all of these permissions:
 
 ```php
@@ -105,8 +119,15 @@ $user->getAllPermissions();
 
 All these responses are collections of `Spatie\Permission\Models\Permission` objects.
 
+
+
 If we follow the previous example, the first response will be a collection with the `delete article` permission and 
 the second will be a collection with the `edit article` permission and the third will contain both.
+
+If we follow the previous example, the first response will be a collection with the `delete article` permission and 
+the second will be a collection with the `edit article` permission and the third will contain both.
+
+
 
 ### NOTE about using permission names in policies
 

--- a/docs/basic-usage/role-permissions.md
+++ b/docs/basic-usage/role-permissions.md
@@ -90,17 +90,18 @@ but `false` for `$user->hasDirectPermission('edit articles')`.
 
 This method is useful if one builds a form for setting permissions for roles and users in an application and wants to restrict or change inherited permissions of roles of the user, i.e. allowing to change only direct permissions of the user.
 
-You can check if the user has direct permissions without passing by the role's permissions:
+You can check if the user has All or Any of a set of permissions directly assigned:
 
 ```php
-// Check if the user has all direct permissions
+// Check if the user has All direct permissions
 $user->hasAllDirectPermissions(['edit articles', 'delete articles']);
 
-// Check if the user has any permission directly
+// Check if the user has Any permission directly
 $user->hasAnyDirectPermission(['create articles', 'delete articles']);
 ```
 By following the previous example, when we call `$user->hasAllDirectPermissions(['edit articles', 'delete articles'])` 
-it returns `true`, because the user has all these direct permissions. When we call
+it returns `true`, because the user has all these direct permissions. 
+When we call
 `$user->hasAnyDirectPermission('edit articles')`, it returns `true` because the user has one of the provided permissions.
 
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -438,4 +438,36 @@ trait HasPermissions
     {
         app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
+
+    /**
+     * Check if there are all the direct permissions
+     * @param array $permissions
+     * @return bool
+     */
+    public function hasAllDirectPermissions(array $permissions) : bool
+    {
+        foreach ($permissions as $permission) {
+            if(! $this->hasDirectPermission($permission)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if there are any the direct permissions
+     * @param array $permissions
+     * @return bool
+     */
+    public function hasAnyDirectPermission(array $permissions) : bool
+    {
+        foreach ($permissions as $permission) {
+            if($this->hasDirectPermission($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -440,12 +440,16 @@ trait HasPermissions
     }
 
     /**
-     * Check if there are all the direct permissions.
-     * @param array $permissions
+     * Check if the model has All of the requested Direct permissions.
+     * @param array ...$permissions
      * @return bool
      */
-    public function hasAllDirectPermissions(array $permissions) : bool
+    public function hasAllDirectPermissions(...$permissions) : bool
     {
+        if (is_array($permissions[0])) {
+            $permissions = $permissions[0];
+        }
+
         foreach ($permissions as $permission) {
             if (! $this->hasDirectPermission($permission)) {
                 return false;
@@ -456,12 +460,16 @@ trait HasPermissions
     }
 
     /**
-     * Check if there are any the direct permissions.
-     * @param array $permissions
+     * Check if the model has Any of the requested Direct permissions.
+     * @param array ...$permissions
      * @return bool
      */
-    public function hasAnyDirectPermission(array $permissions) : bool
+    public function hasAnyDirectPermission(...$permissions) : bool
     {
+        if (is_array($permissions[0])) {
+            $permissions = $permissions[0];
+        }
+        
         foreach ($permissions as $permission) {
             if ($this->hasDirectPermission($permission)) {
                 return true;

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -440,14 +440,14 @@ trait HasPermissions
     }
 
     /**
-     * Check if there are all the direct permissions
+     * Check if there are all the direct permissions.
      * @param array $permissions
      * @return bool
      */
     public function hasAllDirectPermissions(array $permissions) : bool
     {
         foreach ($permissions as $permission) {
-            if(! $this->hasDirectPermission($permission)) {
+            if (! $this->hasDirectPermission($permission)) {
                 return false;
             }
         }
@@ -456,14 +456,14 @@ trait HasPermissions
     }
 
     /**
-     * Check if there are any the direct permissions
+     * Check if there are any the direct permissions.
      * @param array $permissions
      * @return bool
      */
     public function hasAnyDirectPermission(array $permissions) : bool
     {
         foreach ($permissions as $permission) {
-            if($this->hasDirectPermission($permission)) {
+            if ($this->hasDirectPermission($permission)) {
                 return true;
             }
         }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -497,4 +497,19 @@ class HasPermissionsTest extends TestCase
             $this->testUser->getPermissionNames()
         );
     }
+
+    /** @test */
+    public function it_can_check_many_direct_permissions()
+    {
+        $this->testUser->givePermissionTo(['edit-articles', 'edit-news']);
+        $this->assertTrue($this->testUser->hasAllDirectPermissions(['edit-news', 'edit-articles']));
+        $this->assertFalse($this->testUser->hasAllDirectPermissions(['edit-articles', 'edit-news', 'edit-blog']));
+    }
+
+    /** @test */
+    public function it_can_check_if_there_is_any_of_the_direct_permissions_given()
+    {
+        $this->testUser->givePermissionTo(['edit-articles', 'edit-news']);
+        $this->assertTrue($this->testUser->hasAnyDirectPermission(['edit-news', 'edit-blog']));
+    }
 }


### PR DESCRIPTION
There is a method to allow us to check if the user has a direct permission. There is also a method that allow to check if the user has all permissions but this method check if the user has this direct permission or if the user's role has this permission.
So I created two methods that allow to make checks only based on direct permissions.

- The first one allows me to check if the user has directly all the permissions that will be passed by parameters

- The second one allows me to check if the user has directly one of the permissions that will be passed by parameters