### PR TITLE
Added publish shortcut console commands.

### DIFF
--- a/docs/installation-laravel.md
+++ b/docs/installation-laravel.md
@@ -23,7 +23,7 @@ The service provider will automatically get registered. Or you may manually add 
 You must publish [the migration](https://github.com/spatie/laravel-permission/blob/master/database/migrations/create_permission_tables.php.stub) with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"
+php artisan permission:migration
 ```
 
 If you're using UUIDs or GUIDs for your `User` models you can update the `create_permission_tables.php` migration and replace `$table->unsignedBigInteger($columnNames['model_morph_key'])` with `$table->uuid($columnNames['model_morph_key'])`.
@@ -38,7 +38,7 @@ php artisan migrate
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"
+php artisan permission:config
 ```
 
 When published, [the `config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/master/config/permission.php) initially contains:

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -27,5 +27,7 @@ class Publish extends Command
         Artisan::call('vendor:publish', [
             '--provider' => PermissionServiceProvider::class,
         ]);
+
+        $this->info(Artisan::output());
     }
 }

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Permission\PermissionServiceProvider;
+
+class Publish extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'permission:publish';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the laravel-permission config file and migration';
+
+    public function handle()
+    {
+        Artisan::call('vendor:publish', [
+            "--provider" => PermissionServiceProvider::class,
+        ]);
+    }
+}

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -25,7 +25,7 @@ class Publish extends Command
     public function handle()
     {
         Artisan::call('vendor:publish', [
-            "--provider" => PermissionServiceProvider::class,
+            '--provider' => PermissionServiceProvider::class,
         ]);
     }
 }

--- a/src/Commands/PublishConfig.php
+++ b/src/Commands/PublishConfig.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Permission\PermissionServiceProvider;
+
+class PublishConfig extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'permission:config';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the laravel-permission config file';
+
+    public function handle()
+    {
+        Artisan::call('vendor:publish', [
+            "--provider" => PermissionServiceProvider::class,
+            "--tag" => 'config',
+        ]);
+    }
+}

--- a/src/Commands/PublishConfig.php
+++ b/src/Commands/PublishConfig.php
@@ -28,5 +28,7 @@ class PublishConfig extends Command
             '--provider' => PermissionServiceProvider::class,
             '--tag' => 'config',
         ]);
+
+        $this->info(Artisan::output());
     }
 }

--- a/src/Commands/PublishConfig.php
+++ b/src/Commands/PublishConfig.php
@@ -25,8 +25,8 @@ class PublishConfig extends Command
     public function handle()
     {
         Artisan::call('vendor:publish', [
-            "--provider" => PermissionServiceProvider::class,
-            "--tag" => 'config',
+            '--provider' => PermissionServiceProvider::class,
+            '--tag' => 'config',
         ]);
     }
 }

--- a/src/Commands/PublishMigration.php
+++ b/src/Commands/PublishMigration.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Permission\PermissionServiceProvider;
+
+class PublishMigration extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'permission:migration';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the laravel-permission migration';
+
+    public function handle()
+    {
+        Artisan::call('vendor:publish', [
+            "--provider" => PermissionServiceProvider::class,
+            "--tag" => 'migrations',
+        ]);
+    }
+}

--- a/src/Commands/PublishMigration.php
+++ b/src/Commands/PublishMigration.php
@@ -28,5 +28,7 @@ class PublishMigration extends Command
             '--provider' => PermissionServiceProvider::class,
             '--tag' => 'migrations',
         ]);
+
+        $this->info(Artisan::output());
     }
 }

--- a/src/Commands/PublishMigration.php
+++ b/src/Commands/PublishMigration.php
@@ -25,8 +25,8 @@ class PublishMigration extends Command
     public function handle()
     {
         Artisan::call('vendor:publish', [
-            "--provider" => PermissionServiceProvider::class,
-            "--tag" => 'migrations',
+            '--provider' => PermissionServiceProvider::class,
+            '--tag' => 'migrations',
         ]);
     }
 }

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -32,6 +32,9 @@ class PermissionServiceProvider extends ServiceProvider
                 Commands\CreateRole::class,
                 Commands\CreatePermission::class,
                 Commands\Show::class,
+                Commands\Publish::class,
+                Commands\PublishConfig::class,
+                Commands\PublishMigration::class,
             ]);
         }
 

--- a/tests/PublishTest.php
+++ b/tests/PublishTest.php
@@ -14,7 +14,7 @@ class PublishTest extends TestCase
         $this->clearConfigFile();
         $this->clearMigrationFile();
 
-        $this->artisan('permission:publish');
+        $this->artisan('permission:publish')->expectsOutput('Publishing complete.');
 
         $this->assertConfigFileExists();
         $this->assertMigrationFileExists();
@@ -25,7 +25,7 @@ class PublishTest extends TestCase
     {
         $this->clearConfigFile();
 
-        $this->artisan('permission:config');
+        $this->artisan('permission:config')->expectsOutput('Publishing complete.');
 
         $this->assertConfigFileExists();
     }
@@ -35,7 +35,7 @@ class PublishTest extends TestCase
     {
         $this->clearMigrationFile();
 
-        $this->artisan('permission:migration');
+        $this->artisan('permission:migration')->expectsOutput('Publishing complete.');
 
         $this->assertMigrationFileExists();
     }

--- a/tests/PublishTest.php
+++ b/tests/PublishTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Support\Str;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+
+class PublishTest extends TestCase
+{
+
+    /** @test */
+    public function it_can_publish_the_config_file_and_migration_with_the_permission_publish_shortcut()
+    {
+        $this->clearConfigFile();
+        $this->clearMigrationFile();
+
+        $this->artisan('permission:publish');
+
+        $this->assertConfigFileExists();
+        $this->assertMigrationFileExists();
+    }
+
+    /** @test */
+    public function it_can_publish_the_config_file_with_the_permission_config_shortcut()
+    {
+        $this->clearConfigFile();
+
+        $this->artisan('permission:config');
+
+        $this->assertConfigFileExists();
+    }
+
+    /** @test */
+    public function it_can_publish_the_migration_with_the_permission_migration_shortcut()
+    {
+        $this->clearMigrationFile();
+
+        $this->artisan('permission:migration');
+
+        $this->assertMigrationFileExists();
+    }
+
+    private function assertConfigFileExists()
+    {
+        $filesystem = new Filesystem(new Local(config_path()));
+        $this->assertTrue($filesystem->has('permission.php'), 'Failed to locate config file.');
+    }
+
+    private function assertMigrationFileExists()
+    {
+        $filesystem = new Filesystem(new Local(database_path('migrations')));
+
+        foreach ($filesystem->listContents() as $file) {
+            if(Str::endsWith($file['path'], '_create_permission_tables.php')){
+                $this->assertTrue(true);
+                return;
+            }
+        }
+
+        $this->fail('Failed to locate migration file.');
+    }
+
+    private function clearConfigFile()
+    {
+        $filesystem = new Filesystem(new Local(config_path()));
+        if($filesystem->has('permission.php')){
+            $filesystem->delete('permission.php');
+        }
+    }
+
+    private function clearMigrationFile()
+    {
+        $filesystem = new Filesystem(new Local(database_path('migrations')));
+
+        foreach ($filesystem->listContents() as $file) {
+            if(Str::endsWith($file['path'], '_create_permission_tables.php')){
+                $filesystem->delete($file['path']);
+            }
+        }
+    }
+}

--- a/tests/PublishTest.php
+++ b/tests/PublishTest.php
@@ -3,12 +3,11 @@
 namespace Spatie\Permission\Test;
 
 use Illuminate\Support\Str;
-use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
 
 class PublishTest extends TestCase
 {
-
     /** @test */
     public function it_can_publish_the_config_file_and_migration_with_the_permission_publish_shortcut()
     {
@@ -52,7 +51,7 @@ class PublishTest extends TestCase
         $filesystem = new Filesystem(new Local(database_path('migrations')));
 
         foreach ($filesystem->listContents() as $file) {
-            if(Str::endsWith($file['path'], '_create_permission_tables.php')){
+            if (Str::endsWith($file['path'], '_create_permission_tables.php')) {
                 $this->assertTrue(true);
                 return;
             }
@@ -64,7 +63,7 @@ class PublishTest extends TestCase
     private function clearConfigFile()
     {
         $filesystem = new Filesystem(new Local(config_path()));
-        if($filesystem->has('permission.php')){
+        if ($filesystem->has('permission.php')) {
             $filesystem->delete('permission.php');
         }
     }
@@ -74,7 +73,7 @@ class PublishTest extends TestCase
         $filesystem = new Filesystem(new Local(database_path('migrations')));
 
         foreach ($filesystem->listContents() as $file) {
-            if(Str::endsWith($file['path'], '_create_permission_tables.php')){
+            if (Str::endsWith($file['path'], '_create_permission_tables.php')) {
                 $filesystem->delete($file['path']);
             }
         }

--- a/tests/PublishTest.php
+++ b/tests/PublishTest.php
@@ -53,6 +53,7 @@ class PublishTest extends TestCase
         foreach ($filesystem->listContents() as $file) {
             if (Str::endsWith($file['path'], '_create_permission_tables.php')) {
                 $this->assertTrue(true);
+
                 return;
             }
         }


### PR DESCRIPTION
This PR adds shortcut commands to make publishing the config file and migration more easily:

- `permission:publish` as a shortcut to `vendor:publish --provider="Spatie\Permission\PermissionServiceProvider"`
- `permission:migration` as a shortcut to `vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="migrations"`
- `permission:config` as a shortcut to `vendor:publish --provider="Spatie\Permission\PermissionServiceProvider" --tag="config"`

Since the console doesn't provide autocompletion I often find myself copying these lines from the docs.
This way the commands are easier to remember or can be looked up using the `artisan:list` command.

Maybe three commands is overkill, another option would be to use a single command with a tag parameter like
- `permission:publish`
- `permission:publish --tag="migrations"`
- `permission:publish --tag="config"`

Love to discuss this one, would be interesting for other packages as well imho.

