### PR TITLE
Remove version checks

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -40,10 +40,6 @@ class Permission extends Model implements PermissionContract
             throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
         }
 
-        if (isNotLumen() && app()::VERSION < '5.4') {
-            return parent::create($attributes);
-        }
-
         return static::query()->create($attributes);
     }
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -37,10 +37,6 @@ class Role extends Model implements RoleContract
             throw RoleAlreadyExists::create($attributes['name'], $attributes['guard_name']);
         }
 
-        if (isNotLumen() && app()::VERSION < '5.4') {
-            return parent::create($attributes);
-        }
-
         return static::query()->create($attributes);
     }
 

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -59,13 +59,6 @@ class PermissionRegistrar
     {
         self::$cacheExpirationTime = config('permission.cache.expiration_time', config('permission.cache_expiration_time'));
 
-        if (app()->version() <= '5.5') {
-            if (self::$cacheExpirationTime instanceof \DateInterval) {
-                $interval = self::$cacheExpirationTime;
-                self::$cacheExpirationTime = $interval->m * 30 * 60 * 24 + $interval->d * 60 * 24 + $interval->h * 60 + $interval->i;
-            }
-        }
-
         self::$cacheKey = config('permission.cache.key');
         self::$cacheModelKey = config('permission.cache.model_key');
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -263,17 +263,10 @@ trait HasPermissions
      */
     public function getPermissionsViaRoles(): Collection
     {
-        $relationships = ['roles', 'roles.permissions'];
-
-        if (method_exists($this, 'loadMissing')) {
-            $this->loadMissing($relationships);
-        } else {
-            $this->load($relationships);
-        }
-
-        return $this->roles->flatMap(function ($role) {
-            return $role->permissions;
-        })->sort()->values();
+        return $this->loadMissing('roles', 'roles.permissions')
+            ->roles->flatMap(function ($role) {
+                return $role->permissions;
+            })->sort()->values();
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -199,7 +199,7 @@ class CacheTest extends TestCase
         $actual = $this->testUser->getAllPermissions()->pluck('name');
         $this->assertEquals($actual, collect($expected));
 
-        $this->assertQueryCount(method_exists($this->testUser, 'loadMissing') ? 2 : 3);
+        $this->assertQueryCount(2);
     }
 
     /** @test */


### PR DESCRIPTION
Now that this package only supports modern versions of Laravel, these old version checks are not needed anymore.