### PR TITLE
hasDirectPermission cleanup

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -246,7 +246,7 @@ trait HasPermissions
         }
 
         if (! $permission instanceof Permission) {
-            return false;
+            throw new PermissionDoesNotExist;
         }
 
         return $this->permissions->contains('id', $permission->id);

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -239,16 +239,10 @@ trait HasPermissions
 
         if (is_string($permission)) {
             $permission = $permissionClass->findByName($permission, $this->getDefaultGuardName());
-            if (! $permission) {
-                return false;
-            }
         }
 
         if (is_int($permission)) {
             $permission = $permissionClass->findById($permission, $this->getDefaultGuardName());
-            if (! $permission) {
-                return false;
-            }
         }
 
         if (! $permission instanceof Permission) {

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -164,7 +164,9 @@ class HasPermissionsTest extends TestCase
     {
         $user = User::create(['email' => 'user1@test.com']);
 
-        $this->assertFalse($user->hasDirectPermission(new \stdClass()));
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $user->hasDirectPermission(new \stdClass());
     }
 
     /** @test */
@@ -172,7 +174,9 @@ class HasPermissionsTest extends TestCase
     {
         $user = User::create(['email' => 'user1@test.com']);
 
-        $this->assertFalse($user->hasDirectPermission(null));
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $user->hasDirectPermission(null);
     }
 
     /** @test */


### PR DESCRIPTION
This PR makes two changes:

a) It deletes some unreachable code. findByName and findById throw an exception, so the following if clause was never fulfilled.

b) If instance of Permission model cannot be retrieved, exception should be thrown and not simply false returned. This is clearly indicated by the tests names (which were also properly fixed).