### PR TITLE
Enforce unique constraints on database level

### DIFF
--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -21,6 +21,8 @@ class CreatePermissionTables extends Migration
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) {
@@ -28,6 +30,8 @@ class CreatePermissionTables extends Migration
             $table->string('name');
             $table->string('guard_name');
             $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
         });
 
         Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {


### PR DESCRIPTION
Role and Permission unique name <-> guard constraints are already enforced on the PHP level, so it only makes sense to also enforce them on database level.

https://github.com/spatie/laravel-permission/blob/e3821559c69b2b1ea8fdd967fa89ba13a01ead78/src/Models/Role.php#L37
https://github.com/spatie/laravel-permission/blob/e3821559c69b2b1ea8fdd967fa89ba13a01ead78/src/Models/Permission.php#L40