### PR TITLE
Added missing `guardName` to Exception `PermissionDoesNotExist`

### DIFF
--- a/src/Exceptions/PermissionDoesNotExist.php
+++ b/src/Exceptions/PermissionDoesNotExist.php
@@ -11,8 +11,8 @@ class PermissionDoesNotExist extends InvalidArgumentException
         return new static("There is no permission named `{$permissionName}` for guard `{$guardName}`.");
     }
 
-    public static function withId(int $permissionId)
+    public static function withId(int $permissionId, string $guardName = '')
     {
-        return new static("There is no [permission] with id `{$permissionId}`.");
+        return new static("There is no [permission] with id `{$permissionId}` for guard `{$guardName}`.");
     }
 }


### PR DESCRIPTION
Referenced here: https://github.com/spatie/laravel-permission/blob/master/src/Models/Permission.php#L110