### PR TITLE
Update HasPermissionsTest.php

### DIFF
--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -376,7 +376,7 @@ class HasPermissionsTest extends TestCase
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-news']),
-            $this->testUser->getAllPermissions()->pluck('name')
+            $this->testUser->getAllPermissions()->pluck('name')->sort()->values()
         );
     }
 


### PR DESCRIPTION
Fixed random test failure adding ```->sort()->values()``` to ```pluck()```
Exact same issue as https://github.com/spatie/laravel-permission/pull/1324