### PR TITLE
Add splat operator for hasAnyRole()

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -218,7 +218,7 @@ trait HasRoles
      *
      * @return bool
      */
-    public function hasAnyRole($roles): bool
+    public function hasAnyRole(...$roles): bool
     {
         return $this->hasRole($roles);
     }


### PR DESCRIPTION
Added splat operator to ```hasAnyRole()```

Fixes the following : https://github.com/spatie/laravel-permission/blob/master/tests/HasRolesTest.php#L492