### PR TITLE
Remove duplicate scope lookups

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -18,7 +18,7 @@ trait HasPermissions
     public static function bootHasPermissions()
     {
         static::deleting(function ($model) {
-            if (method_exists($model, 'isForceDeleting') && !$model->isForceDeleting()) {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
                 return;
             }
 
@@ -28,7 +28,7 @@ trait HasPermissions
 
     public function getPermissionClass()
     {
-        if (!isset($this->permissionClass)) {
+        if (! isset($this->permissionClass)) {
             $this->permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
         }
 
@@ -69,7 +69,7 @@ trait HasPermissions
             $query->whereHas('permissions', function ($query) use ($permissions) {
                 $query->where(function ($query) use ($permissions) {
                     foreach ($permissions as $permission) {
-                        $query->orWhere(config('permission.table_names.permissions') . '.id', $permission->id);
+                        $query->orWhere(config('permission.table_names.permissions').'.id', $permission->id);
                     }
                 });
             });
@@ -77,7 +77,7 @@ trait HasPermissions
                 $query->orWhereHas('roles', function ($query) use ($rolesWithPermissions) {
                     $query->where(function ($query) use ($rolesWithPermissions) {
                         foreach ($rolesWithPermissions as $role) {
-                            $query->orWhere(config('permission.table_names.roles') . '.id', $role->id);
+                            $query->orWhere(config('permission.table_names.roles').'.id', $role->id);
                         }
                     });
                 });
@@ -96,7 +96,7 @@ trait HasPermissions
             $listOfPermissions = $listOfPermissions->all();
         }
 
-        if (!is_array($listOfPermissions)) {
+        if (! is_array($listOfPermissions)) {
             $listOfPermissions = [$listOfPermissions];
         }
 
@@ -111,11 +111,11 @@ trait HasPermissions
             } else {
                 $method = is_numeric($permission) ? 'findById' : 'findByName';
 
-                if (!is_numeric($permission) && !isset($listOfPermissionNames[$permission])) {
+                if (! is_numeric($permission) && ! isset($listOfPermissionNames[$permission])) {
                     $thisPermission = $this->getPermissionClass()->{$method}($permission, $guard);
                     $permissions[$thisPermission->id] = $thisPermission;
                     $listOfPermissionNames[$thisPermission->name] = null;
-                } elseif (is_numeric($permission) && !isset($permissions[$permission])) {
+                } elseif (is_numeric($permission) && ! isset($permissions[$permission])) {
                     $thisPermission = $this->getPermissionClass()->{$method}($permission, $guard);
                     $permissions[$thisPermission->id] = $thisPermission;
                 }
@@ -152,7 +152,7 @@ trait HasPermissions
             );
         }
 
-        if (!$permission instanceof Permission) {
+        if (! $permission instanceof Permission) {
             throw new PermissionDoesNotExist;
         }
 
@@ -223,7 +223,7 @@ trait HasPermissions
         }
 
         foreach ($permissions as $permission) {
-            if (!$this->hasPermissionTo($permission)) {
+            if (! $this->hasPermissionTo($permission)) {
                 return false;
             }
         }
@@ -263,7 +263,7 @@ trait HasPermissions
             $permission = $permissionClass->findById($permission, $this->getDefaultGuardName());
         }
 
-        if (!$permission instanceof Permission) {
+        if (! $permission instanceof Permission) {
             throw new PermissionDoesNotExist;
         }
 
@@ -421,7 +421,7 @@ trait HasPermissions
      */
     protected function ensureModelSharesGuard($roleOrPermission)
     {
-        if (!$this->getGuardNames()->contains($roleOrPermission->guard_name)) {
+        if (! $this->getGuardNames()->contains($roleOrPermission->guard_name)) {
             throw GuardDoesNotMatch::create($roleOrPermission->guard_name, $this->getGuardNames());
         }
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -17,7 +17,7 @@ trait HasRoles
     public static function bootHasRoles()
     {
         static::deleting(function ($model) {
-            if (method_exists($model, 'isForceDeleting') && !$model->isForceDeleting()) {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
                 return;
             }
 
@@ -27,7 +27,7 @@ trait HasRoles
 
     public function getRoleClass()
     {
-        if (!isset($this->roleClass)) {
+        if (! isset($this->roleClass)) {
             $this->roleClass = app(PermissionRegistrar::class)->getRoleClass();
         }
 
@@ -63,7 +63,7 @@ trait HasRoles
             $listOfRoles = $listOfRoles->all();
         }
 
-        if (!is_array($listOfRoles)) {
+        if (! is_array($listOfRoles)) {
             $listOfRoles = [$listOfRoles];
         }
 
@@ -78,11 +78,11 @@ trait HasRoles
             } else {
                 $method = is_numeric($role) ? 'findById' : 'findByName';
 
-                if (!is_numeric($role) && !isset($listOfRoleNames[$role])) {
+                if (! is_numeric($role) && ! isset($listOfRoleNames[$role])) {
                     $thisRole = $this->getRoleClass()->{$method}($role, $guard);
                     $roles[$thisRole->id] = $thisRole;
                     $listOfRoleNames[$thisRole->name] = null;
-                } elseif (is_numeric($role) && !isset($roles[$role])) {
+                } elseif (is_numeric($role) && ! isset($roles[$role])) {
                     $thisRole = $this->getRoleClass()->{$method}($role, $guard);
                     $roles[$thisRole->id] = $thisRole;
                 }
@@ -92,7 +92,7 @@ trait HasRoles
         return $query->whereHas('roles', function ($query) use ($roles) {
             $query->where(function ($query) use ($roles) {
                 foreach ($roles as $role) {
-                    $query->orWhere(config('permission.table_names.roles') . '.id', $role->id);
+                    $query->orWhere(config('permission.table_names.roles').'.id', $role->id);
                 }
             });
         });
@@ -312,7 +312,7 @@ trait HasRoles
             return explode('|', $pipeString);
         }
 
-        if (!in_array($quoteCharacter, ["'", '"'])) {
+        if (! in_array($quoteCharacter, ["'", '"'])) {
             return explode('|', $pipeString);
         }
 


### PR DESCRIPTION
Something that caught my eye is that scopeRole will continue to query for each (int, string or collection) parameter that has been passed to it.

In a scenario where the a role exists with the id of 1 and a name of 'User'
`App\User::role([1, 'User'])->first();` will cause two queries to be fired off, however both will return the same result.

``select * from `roles` where `id` = 1 and `guard_name` = 'web' limit 1`` Finished in 390us.
``select * from `roles` where `name` = 'User' and `guard_name` = 'web' limit 1`` Finished in 370us.

It might be worthwhile to change the original scopeRole to combat duplicate lookups.
```
    /**
     * Scope the model query to certain roles only.
     *
     * @param \Illuminate\Database\Eloquent\Builder $query
     * @param string|array|\Spatie\Permission\Contracts\Role|\Illuminate\Support\Collection $roles
     * @param string $guard
     *
     * @return \Illuminate\Database\Eloquent\Builder
     */
    public function scopeRole(Builder $query, $listOfRoles, $guard = null): Builder
    {
        if ($listOfRoles instanceof Collection) {
            $listOfRoles = $listOfRoles->all();
        }

        if (!is_array($listOfRoles)) {
            $listOfRoles = [$listOfRoles];
        }

        $guard = $guard ?: $this->getDefaultGuardName();

        $listOfRoleNames = [];
        $roles = [];

        foreach ($listOfRoles as $role) {
            if ($role instanceof Role) {
                $roles[$role->id] = $role;
            } else {
                $method = is_numeric($role) ? 'findById' : 'findByName';

                if (!is_numeric($role) && !isset($listOfRoleNames[$role])) {
                    $thisRole = $this->getRoleClass()->{$method}($role, $guard);
                    $roles[$thisRole->id] = $thisRole;
                    $listOfRoleNames[$thisRole->name] = null;
                } elseif (is_numeric($role) && !isset($roles[$role])) {
                    $thisRole = $this->getRoleClass()->{$method}($role, $guard);
                    $roles[$thisRole->id] = $thisRole;
                }
            }
        }

        return $query->whereHas('roles', function ($query) use ($roles) {
            $query->where(function ($query) use ($roles) {
                foreach ($roles as $role) {
                    $query->orWhere(config('permission.table_names.roles') . '.id', $role->id);
                }
            });
        });
    }
```