### PR TITLE
Updated HasPermissions.php

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -265,11 +265,10 @@ trait HasPermissions
 
     /**
      * Return all the permissions the model has, both directly and via roles.
-     *
-     * @throws \Exception
      */
     public function getAllPermissions(): Collection
     {
+        /** @var Collection $permissions */
         $permissions = $this->permissions;
 
         if ($this->roles) {


### PR DESCRIPTION
- Removed ```@throws \Exception``` in PHPDoc because IDE was complaining about unhandled Exception when using ```getAllPermissions()```, while in the worst case scenario, as far as I can tell, it will just return an empty Collection.
- Added IDE helper for ```$permissions```