### PR TITLE
Refactor scopePermission() to use whereIn instead of orWhere

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -67,11 +67,11 @@ trait HasPermissions
 
         return $query->where(function (Builder $query) use ($permissions, $rolesWithPermissions) {
             $query->whereHas('permissions', function (Builder $subQuery) use ($permissions) {
-                $subQuery->whereIn(config('permission.table_names.permissions') . '.id', \array_column($permissions, 'id'));
+                $subQuery->whereIn(config('permission.table_names.permissions').'.id', \array_column($permissions, 'id'));
             });
             if (count($rolesWithPermissions) > 0) {
                 $query->orWhereHas('roles', function (Builder $subQuery) use ($rolesWithPermissions) {
-                    $subQuery->whereIn(config('permission.table_names.roles') . '.id', \array_column($rolesWithPermissions, 'id'));
+                    $subQuery->whereIn(config('permission.table_names.roles').'.id', \array_column($rolesWithPermissions, 'id'));
                 });
             }
         });

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -65,21 +65,13 @@ trait HasPermissions
             return array_merge($result, $permission->roles->all());
         }, []));
 
-        return $query->where(function ($query) use ($permissions, $rolesWithPermissions) {
-            $query->whereHas('permissions', function ($query) use ($permissions) {
-                $query->where(function ($query) use ($permissions) {
-                    foreach ($permissions as $permission) {
-                        $query->orWhere(config('permission.table_names.permissions').'.id', $permission->id);
-                    }
-                });
+        return $query->where(function (Builder $query) use ($permissions, $rolesWithPermissions) {
+            $query->whereHas('permissions', function (Builder $subQuery) use ($permissions) {
+                $subQuery->whereIn(config('permission.table_names.permissions') . '.id', \array_column($permissions, 'id'));
             });
             if (count($rolesWithPermissions) > 0) {
-                $query->orWhereHas('roles', function ($query) use ($rolesWithPermissions) {
-                    $query->where(function ($query) use ($rolesWithPermissions) {
-                        foreach ($rolesWithPermissions as $role) {
-                            $query->orWhere(config('permission.table_names.roles').'.id', $role->id);
-                        }
-                    });
+                $query->orWhereHas('roles', function (Builder $subQuery) use ($rolesWithPermissions) {
+                    $subQuery->whereIn(config('permission.table_names.roles') . '.id', \array_column($rolesWithPermissions, 'id'));
                 });
             }
         });


### PR DESCRIPTION
Updated `scopePermission()` in trait `HasPermissions.php`
- faster/prettier than multiple orWhere