### PR TITLE
Add scopeWhereRole to hasRoles trait

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -118,13 +118,11 @@ trait HasRoles
         $guard = is_null($guard) ? $this->getDefaultGuardName() : $guard;
 
         return $query->whereHas('roles', function ($query) use ($roles, $guard) {
-            $query->where(function ($query) use ($roles, $guard) {
+            $query->where(config('permission.table_names.roles').'.guard_name', $guard);
+            return $query->where(function ($query) use ($roles) {
                 foreach ($roles as $role) {
                     $column = is_numeric($role) ? 'id' : 'name';
-                    $query->orWhere([
-                        [config('permission.table_names.roles').".{$column}", '=', $role],
-                        [config('permission.table_names.roles').'.guard_name', '=', $guard],
-                    ]);
+                    $query->orWhere(config('permission.table_names.roles').".{$column}", $role);
                 }
             });
         });

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -129,7 +129,7 @@ trait HasRoles
             });
         });
     }
-    
+
     /**
      * Assign the given role to the model.
      *

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -119,6 +119,7 @@ trait HasRoles
 
         return $query->whereHas('roles', function ($query) use ($roles, $guard) {
             $query->where(config('permission.table_names.roles').'.guard_name', $guard);
+
             return $query->where(function ($query) use ($roles) {
                 foreach ($roles as $role) {
                     $column = is_numeric($role) ? 'id' : 'name';

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -401,7 +401,7 @@ class HasRolesTest extends TestCase
         $this->assertEquals($scopedUsers3->count(), 1);
     }
 
-   /** @test */
+    /** @test */
     public function it_can_scope_users_using_a_string_using_whereRole()
     {
         $user1 = User::create(['email' => 'user1@test.com']);

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -401,6 +401,112 @@ class HasRolesTest extends TestCase
         $this->assertEquals($scopedUsers3->count(), 1);
     }
 
+   /** @test */
+    public function it_can_scope_users_using_a_string_using_whereRole()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignRole('testRole');
+        $user2->assignRole('testRole2');
+
+        $scopedUsers = User::whereRole('testRole')->get();
+
+        $this->assertEquals($scopedUsers->count(), 1);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_an_array_using_whereRole()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignRole($this->testUserRole);
+        $user2->assignRole('testRole2');
+
+        $scopedUsers1 = User::whereRole([$this->testUserRole])->get();
+
+        $scopedUsers2 = User::whereRole(['testRole', 'testRole2'])->get();
+
+        $this->assertEquals($scopedUsers1->count(), 1);
+        $this->assertEquals($scopedUsers2->count(), 2);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_an_array_of_ids_and_names_using_whereRole()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+
+        $user1->assignRole($this->testUserRole);
+
+        $user2->assignRole('testRole2');
+
+        $roleName = $this->testUserRole->name;
+
+        $otherRoleId = app(Role::class)->find(2)->id;
+
+        $scopedUsers = User::whereRole([$roleName, $otherRoleId])->get();
+
+        $this->assertEquals($scopedUsers->count(), 2);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_a_collection_using_whereRole()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignRole($this->testUserRole);
+        $user2->assignRole('testRole2');
+
+        $scopedUsers1 = User::whereRole([$this->testUserRole])->get();
+        $scopedUsers2 = User::whereRole(collect(['testRole', 'testRole2']))->get();
+
+        $this->assertEquals($scopedUsers1->count(), 1);
+        $this->assertEquals($scopedUsers2->count(), 2);
+    }
+
+    /** @test */
+    public function it_can_scope_users_using_an_object_using_whereRole()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignRole($this->testUserRole);
+        $user2->assignRole('testRole2');
+
+        $scopedUsers1 = User::whereRole($this->testUserRole)->get();
+        $scopedUsers2 = User::whereRole([$this->testUserRole])->get();
+        $scopedUsers3 = User::whereRole(collect([$this->testUserRole]))->get();
+
+        $this->assertEquals($scopedUsers1->count(), 1);
+        $this->assertEquals($scopedUsers2->count(), 1);
+        $this->assertEquals($scopedUsers3->count(), 1);
+    }
+
+    /** @test */
+    public function it_can_scope_against_a_specific_guard_using_whereRole()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->assignRole('testRole');
+        $user2->assignRole('testRole2');
+
+        $scopedUsers1 = User::whereRole('testRole', 'web')->get();
+
+        $this->assertEquals($scopedUsers1->count(), 1);
+
+        $user3 = Admin::create(['email' => 'user1@test.com']);
+        $user4 = Admin::create(['email' => 'user1@test.com']);
+        $user5 = Admin::create(['email' => 'user2@test.com']);
+        $testAdminRole2 = app(Role::class)->create(['name' => 'testAdminRole2', 'guard_name' => 'admin']);
+        $user3->assignRole($this->testAdminRole);
+        $user4->assignRole($this->testAdminRole);
+        $user5->assignRole($testAdminRole2);
+        $scopedUsers2 = Admin::whereRole('testAdminRole', 'admin')->get();
+        $scopedUsers3 = Admin::whereRole('testAdminRole2', 'admin')->get();
+
+        $this->assertEquals($scopedUsers2->count(), 2);
+        $this->assertEquals($scopedUsers3->count(), 1);
+    }
+
     /** @test */
     public function it_throws_an_exception_when_trying_to_scope_a_role_from_another_guard()
     {


### PR DESCRIPTION
Hi there,

It appears that scopeRole fires off a query to check each string or int that has been passed to it, scopeWhereRole aims to reduce these additional queries by only using the query builder.

Examples:
`App\User::role(['User', 'Admin'])->get();` will run the following queries:

``select * from `roles` where `name` = 'User' and `guard_name` = 'web' limit 1``
``select * from `roles` where `name` = `Admin' and `guard_name` = 'web' limit 1``

``select * from `users` where exists (select * from `roles` inner join `model_has_roles` on `roles`.`id` = `model_has_roles`.`role_id` where `users`.`id` = `model_has_roles`.`model_id` and `model_has_roles`.`model_type` = 'App\User' and (`roles`.`id` = 1 or `roles`.`id` = 2)) and `users`.`deleted_at` is null``

While `App\User::whereRole(['User', 'Admin'])->get();` will only run the one query:
``select * from `users` where exists (select * from `roles` inner join `model_has_roles` on `roles`.`id` = `model_has_roles`.`role_id` where `users`.`id` = `model_has_roles`.`model_id` and `model_has_roles`.`model_type` = 'App\User' and ((`roles`.`name` = 'User' and `roles`.`guard_name` = 'web') or (`roles`.`name` = 'Admin' and `roles`.`guard_name` = 'web'))) and `users`.`deleted_at` is null``

It seems that the reason for the additional ``select * from `roles` where ...`` queries in the original scopeRole function are because it does a check to see if the role exists or not, if the role is not already an `instanceof Role` then it will query to see if the int (id) or string (name) are roles that actually exist, if any do not exist then an exception will be triggered.

Personally I'd prefer that scopeRole worked in the way that this PR has for scopeWhereRole, as I'd be willing to lose the exception in favour of reducing additional queries, however I understand not everyone would want to, hence opting to instead call the function scopeWhereRole.

Thanks.