### PR TITLE
Proposition to create many roles

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -48,7 +48,7 @@ class Role extends Model implements RoleContract
 
         return static::query()->create($attributes);
     }
-	
+
     /**
      * Create many roles.
      *

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -39,7 +39,10 @@ class Role extends Model implements RoleContract
         ])->first();
 
         if ($existingRole) {
-            if ($withException) throw RoleAlreadyExists::named($attributes['name'], $attributes['guard_name']);
+            if ($withException) {
+                throw RoleAlreadyExists::named($attributes['name'], $attributes['guard_name']);
+            }
+
             return $existingRole;
         }
 


### PR DESCRIPTION
Model Role:
- Updated ```create()``` so that it (optionally) returns the existing model instead of throwing a ```RoleAlreadyExists``` Exception. It still does return Exception by default, same as prior to current change proposal.
- Added ```createMany``` to create many roles in one go. Usage example : 
```
    $rolesToCreate = [
        [
            'name' => 'Super Admin',
            //'description' => 'Musa',
            //'guard_name' => 'admin',
        ],
        [
            'name' => 'Tenant',
            //'description' => 'Dirigeant de l\'Enseigne',
            //'guard_name' => 'web',
        ],
    ];
    Role::createMany($rolesToCreate);
```
or 
```
    $roleAdmin = [
        'name' => 'Super Admin',
        //'description' => 'Musa',
        //'guard_name' => 'admin',
    ];

    $roleTenant = [
        'name' => 'Tenant',
        //'description' => 'Şirket yöneticisi',
        //'guard_name' => 'web',
    ];

    $rolesToCreate = collect([$roleAdmin, $roleTenant]);
    Role::createMany($rolesToCreate);
```

It would make seeding easier.

- Minor style changes.