### PR TITLE
Remove old Lumen dependencies

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -14,7 +14,7 @@ class PermissionServiceProvider extends ServiceProvider
 {
     public function boot(PermissionRegistrar $permissionLoader, Filesystem $filesystem)
     {
-        if (isNotLumen()) {
+        if (function_exists('config_path')) { // function not available and 'publish' not relevant in Lumen
             $this->publishes([
                 __DIR__.'/../config/permission.php' => config_path('permission.php'),
             ], 'config');
@@ -44,12 +44,10 @@ class PermissionServiceProvider extends ServiceProvider
 
     public function register()
     {
-        if (isNotLumen()) {
-            $this->mergeConfigFrom(
-                __DIR__.'/../config/permission.php',
-                'permission'
-            );
-        }
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/permission.php',
+            'permission'
+        );
 
         $this->registerBladeExtensions();
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,15 +18,3 @@ if (! function_exists('getModelForGuard')) {
             })->get($guard);
     }
 }
-
-if (! function_exists('isNotLumen')) {
-    /**
-     * check if application is lumen.
-     *
-     * @return bool
-     */
-    function isNotLumen(): bool
-    {
-        return ! preg_match('/lumen/i', app()->version());
-    }
-}


### PR DESCRIPTION
Since this package supports Laravel 5.8+ and Lumen's use of Illuminate/Support allows the publishes and mergeConfigFrom methods, there's no longer a need to be so specific about detecting Lumen in relation to those.
Thus the code can be simplified.
This allows removing the `isNotLumen` helper as well, which avoids the risk of false-positive responses from a clashing global helper function of the same name.