### PR TITLE
Add cascade-permission-middleware

### DIFF
--- a/docs/basic-usage/middleware.md
+++ b/docs/basic-usage/middleware.md
@@ -15,7 +15,7 @@ Route::group(['middleware' => ['can:publish articles']], function () {
 
 ## Package Middleware
 
-This package comes with `RoleMiddleware`, `PermissionMiddleware` and `RoleOrPermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
+This package comes with `RoleMiddleware`, `PermissionMiddleware`, `RoleOrPermissionMiddleware` and `CascadePermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
 
 ```php
 protected $routeMiddleware = [
@@ -23,6 +23,7 @@ protected $routeMiddleware = [
     'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
     'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
     'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
+    'permissionsCascade' => \Spatie\Permission\Middlewares\CascadePermissionMiddleware::class,
 ];
 ```
 
@@ -81,3 +82,15 @@ public function __construct()
     $this->middleware(['role_or_permission:super-admin|edit articles']);
 }
 ```
+
+You can use the `CascadePermissionMiddleware` as a sort of wildcard, where it looks for matches based on progressive lookups of strings delimited with dot-notation:
+
+```php
+Route::group(['middleware' => ['permissionsCascade:users.modify.delete']], function () {
+    // will pass if the logged in user has either the `users`
+    // or `users.modify` or `users.modify.delete` permission. 
+    // (And those permissions must exist for the current guard)
+});
+```
+
+

--- a/src/Middlewares/CascadePermissionMiddleware.php
+++ b/src/Middlewares/CascadePermissionMiddleware.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Spatie\Permission\Middlewares;
+
+use Closure;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+
+class CascadePermissionMiddleware
+{
+    /**
+     * Do a cascading permissions check by recreating the permission namespace tier-by-tier.
+     *
+     * example:
+     * admin.auth.users.modify.create
+     *
+     * checks the permissions in the following dot-notation-nested order to find first match
+     * admin
+     * admin.auth
+     * admin.auth.users
+     * admin.auth.users.modify
+     * admin.auth.users.modify.create
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $permission, $guard = null)
+    {
+        if (is_null($guard)) {
+            $guard = config('auth.defaults.guard');
+        }
+
+        //guests are not allowed
+        if (app('auth')->guard($guard)->guest()) {
+            throw UnauthorizedException::notLoggedIn();
+        }
+
+        $permissions = is_array($permission) ? $permission : explode('|', $permission);
+
+        foreach ($permissions as $permission) {
+
+            // split elements using dot-notation
+            $parts = explode('.', $permission);
+            $ability = '';
+
+            foreach ($parts as $part) {
+                // reassemble and check each tier
+                $ability .= $ability ? '.'.$part : $part;
+
+                if (app('auth')->guard($guard)->user()->can($ability)) {
+                    //exit on first match
+                    return $next($request);
+                }
+            }
+        }
+
+        // if no requested permission tier is matched, deny
+        throw UnauthorizedException::forPermissions($permissions);
+    }
+}

--- a/tests/CascadeMiddlewareTest.php
+++ b/tests/CascadeMiddlewareTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Middlewares\CascadePermissionMiddleware;
+
+class CascadeMiddlewareTest extends TestCase
+{
+    protected $cascadeMiddleware;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        app(Permission::class)->create(['name' => 'admin', 'guard_name' => 'admin']);
+        app(Permission::class)->create(['name' => 'admin.auth', 'guard_name' => 'admin']);
+        app(Permission::class)->create(['name' => 'admin.auth.users', 'guard_name' => 'admin']);
+        app(Permission::class)->create(['name' => 'admin.auth.users.modify', 'guard_name' => 'admin']);
+
+        $this->cascadeMiddleware = new CascadePermissionMiddleware($this->app);
+    }
+
+    /** @test */
+    public function guests_cannot_access_a_route_protected_by_cascade_middleware()
+    {
+        $this->assertEquals(
+            $this->runMiddleware($this->cascadeMiddleware, 'a.permission.assigned.to.the.route'),
+            Response::HTTP_FORBIDDEN
+        );
+    }
+
+    /** @test */
+    public function logged_in_user_can_pass_cascademiddleware_if_one_of_the_cascade_permissions_match()
+    {
+        // This user is authenticated by the `admin` guard, which matches the guard_name of permissions created in setUp()
+        Auth::login($this->testAdmin);
+
+        // 'admin' here is part of the permission 'name', and has no relation to the 'guard_name'
+        Auth::user()->givePermissionTo('admin.auth');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->cascadeMiddleware, 'admin.auth.users'),
+            Response::HTTP_OK
+        );
+    }
+
+    /** @test */
+    public function logged_in_user_cannot_pass_cascademiddleware_if_not_enough_of_the_cascade_permissions_match()
+    {
+        Auth::login($this->testAdmin);
+
+        Auth::user()->givePermissionTo('admin.auth.users');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->cascadeMiddleware, 'admin.auth'),
+            Response::HTTP_FORBIDDEN
+        );
+    }
+
+    /** @test */
+    public function logged_in_user_cannot_pass_cascademiddleware_if_no_cascade_permissions_match()
+    {
+        Auth::login($this->testUser);
+
+        $this->assertEquals(
+            $this->runMiddleware($this->cascadeMiddleware, 'something.not.assigned'),
+            Response::HTTP_FORBIDDEN
+        );
+    }
+
+    protected function runMiddleware($middleware, $parameter)
+    {
+        try {
+            return $middleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, $parameter)->status();
+        } catch (UnauthorizedException $e) {
+            return $e->getStatusCode();
+        }
+    }
+}


### PR DESCRIPTION
Allows checking of dot-notated permissions in a cascading manner.

* checks the permissions in the following dot-notation-nested order to find first match
     * admin
     * admin.auth
     * admin.auth.users
     * admin.auth.users.modify
     * admin.auth.users.modify.create


Heavily inspired by contribution from @eduardoarandah