### PR TITLE
clear class permissions var on boot

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -105,6 +105,16 @@ class PermissionRegistrar
     }
 
     /**
+     * Clear class permissions.
+     */
+    public function clearClassPermissions()
+    {
+        $this->permissions = null;
+
+        return true;
+    }
+
+    /**
      * Get the permissions based on the passed params.
      *
      * @param array $params

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -110,8 +110,6 @@ class PermissionRegistrar
     public function clearClassPermissions()
     {
         $this->permissions = null;
-
-        return true;
     }
 
     /**

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -106,6 +106,8 @@ class PermissionRegistrar
 
     /**
      * Clear class permissions.
+     * This is only intended to be called by the PermissionServiceProvider on boot,
+     * so that long-running instances like Swoole don't keep old data in memory.
      */
     public function clearClassPermissions()
     {

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -35,6 +35,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerModelBindings();
 
+        $permissionLoader->clearClassPermissions();
         $permissionLoader->registerPermissions();
 
         $this->app->singleton(PermissionRegistrar::class, function ($app) use ($permissionLoader) {


### PR DESCRIPTION
For long running processes like swoole, PermissionRegistrar $permissions needs to be cleared when the service provider is booted.

Fixes #1365 