### PR TITLE
Add wildcard permissions

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -93,8 +93,7 @@ return [
     'display_permission_in_exception' => false,
 
     /*
-     * By default, wildcard permission usage is disabled.
-     * When set to true, wildcard permission handling is enabled.
+     * By default wildcard permission lookups are disabled.
      */
 
     'enable_wildcard_permission' => false,

--- a/config/permission.php
+++ b/config/permission.php
@@ -92,6 +92,13 @@ return [
 
     'display_permission_in_exception' => false,
 
+    /*
+     * By default, wildcard permission usage is disabled.
+     * When set to true, wildcard permission handling is enabled.
+     */
+
+    'enable_wildcard_permission' => false,
+
     'cache' => [
 
         /*

--- a/docs/advanced-usage/extending.md
+++ b/docs/advanced-usage/extending.md
@@ -10,7 +10,7 @@ If you are creating your own User models and wish Authorization features to be a
 
 
 ## Extending Role and Permission Models
-If you are extending or replacing the role/permission models, you will need to specify your new models in this package's `config/permissions.php` file. 
+If you are extending or replacing the role/permission models, you will need to specify your new models in this package's `config/permission.php` file. 
 
 First be sure that you've published the configuration file (see the Installation instructions), and edit it to update the `models.role` and `models.permission` values to point to your new models.
 

--- a/docs/basic-usage/wildcard-permissions.md
+++ b/docs/basic-usage/wildcard-permissions.md
@@ -27,7 +27,7 @@ this is the common use-case, representing {resource}.{action}.{target}.
 
 ### Using Wildcards
 
-Each part can also contains wildcards (*). So let's say we assign the following permission to a user:
+Each part can also contain wildcards (*). So let's say we assign the following permission to a user:
 
 ```php
 $user->givePermissionTo('posts.*');

--- a/docs/basic-usage/wildcard-permissions.md
+++ b/docs/basic-usage/wildcard-permissions.md
@@ -1,0 +1,62 @@
+---
+title: Wildcard permissions
+weight: 3
+---
+
+Wildcard permissions can be enabled in the permission config file:
+
+```php
+// config/permission.php
+'enable_wildcard_permissions' => true,
+```
+
+When enabled, wildcard permissions offers you a flexible representation for a variety of permission schemes. The idea
+ behind wildcard permissions is based on the default permission implementation of 
+ [Apache Shiro](https://shiro.apache.org/permissions.html).
+
+A wildcard permission string is made of one or more parts separated by dots (.).
+
+```php
+$permission = 'posts.create.1';
+```
+
+The meaning of each part of the string depends on the application layer. 
+
+> You can use as many parts as you like. So you are not limited to the three-tiered structure, even though 
+this is the common use-case, representing {resource}.{action}.{target}.
+
+### Using Wildcards
+
+Each part can also have wildcards (*). So let's say we assign the following permission to a user:
+
+```php
+$user->givePermissionTo('posts.*');
+// is the same as
+$user->givePermissionTo('posts');
+```
+
+Everyone who is assigned to this permission will be allowed every action on posts. It is not necessary to use a 
+wildcard on the last part of the string. This is automatically assumed.
+
+```php
+// will be true
+$user->can('posts.create');
+$user->can('posts.edit');
+$user->can('posts.delete');
+``` 
+
+Besides the use of parts and wildcards, subparts can also be used. Subparts are divided with commas (,). This is a 
+powerful feature, that let's you create complex permission schemes.
+
+```php
+// user can only do the actions create, update and view on both resources posts and users
+$user->givePermissionTo('posts,users.create,update,view');
+
+// user can do the actions create, update, view on any available resource
+$user->givePermissionTo('*.create,update,view');
+
+// user can do any action on posts with ids 1, 4 and 6 
+$user->givePermissionTo('posts.*.1,4,6');
+```
+
+> As said before, the meaning of each part is determined by the application layer! So, you are free to use each part as you like. And you can use as many parts and subparts as you want.

--- a/docs/basic-usage/wildcard-permissions.md
+++ b/docs/basic-usage/wildcard-permissions.md
@@ -7,11 +7,11 @@ Wildcard permissions can be enabled in the permission config file:
 
 ```php
 // config/permission.php
-'enable_wildcard_permissions' => true,
+'enable_wildcard_permission' => true,
 ```
 
 When enabled, wildcard permissions offers you a flexible representation for a variety of permission schemes. The idea
- behind wildcard permissions is based on the default permission implementation of 
+ behind wildcard permissions is inspired by the default permission implementation of 
  [Apache Shiro](https://shiro.apache.org/permissions.html).
 
 A wildcard permission string is made of one or more parts separated by dots (.).
@@ -27,7 +27,7 @@ this is the common use-case, representing {resource}.{action}.{target}.
 
 ### Using Wildcards
 
-Each part can also have wildcards (*). So let's say we assign the following permission to a user:
+Each part can also contains wildcards (*). So let's say we assign the following permission to a user:
 
 ```php
 $user->givePermissionTo('posts.*');
@@ -45,8 +45,10 @@ $user->can('posts.edit');
 $user->can('posts.delete');
 ``` 
 
+### Subparts
+
 Besides the use of parts and wildcards, subparts can also be used. Subparts are divided with commas (,). This is a 
-powerful feature, that let's you create complex permission schemes.
+powerful feature that lets you create complex permission schemes.
 
 ```php
 // user can only do the actions create, update and view on both resources posts and users

--- a/src/Exceptions/WildcardPermissionInvalidArgument.php
+++ b/src/Exceptions/WildcardPermissionInvalidArgument.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class WildcardPermissionInvalidArgument extends InvalidArgumentException
+{
+    public static function create()
+    {
+        return new static("Wildcard permission must be string, permission id or permission instance");
+    }
+}

--- a/src/Exceptions/WildcardPermissionInvalidArgument.php
+++ b/src/Exceptions/WildcardPermissionInvalidArgument.php
@@ -8,6 +8,6 @@ class WildcardPermissionInvalidArgument extends InvalidArgumentException
 {
     public static function create()
     {
-        return new static("Wildcard permission must be string, permission id or permission instance");
+        return new static('Wildcard permission must be string, permission id or permission instance');
     }
 }

--- a/src/Exceptions/WildcardPermissionNotProperlyFormatted.php
+++ b/src/Exceptions/WildcardPermissionNotProperlyFormatted.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class WildcardPermissionNotProperlyFormatted extends InvalidArgumentException
+{
+    public static function create(string $permission)
+    {
+        return new static("Wildcard permission `{$permission}` is not properly formatted.");
+    }
+}

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -135,6 +135,10 @@ class Role extends Model implements RoleContract
      */
     public function hasPermissionTo($permission): bool
     {
+        if (config('permission.enable_wildcard_permission', false)) {
+            return $this->hasWildcardPermission($permission, $this->getDefaultGuardName());
+        }
+
         $permissionClass = $this->getPermissionClass();
 
         if (is_string($permission)) {

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\Permission\Traits;
 
-use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
-use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
 use Spatie\Permission\Guard;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
@@ -13,6 +11,7 @@ use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
 
 trait HasPermissions
 {
@@ -133,7 +132,7 @@ trait HasPermissions
             );
         }
 
-        if (!$permission instanceof Permission) {
+        if (! $permission instanceof Permission) {
             throw new PermissionDoesNotExist;
         }
 

--- a/src/WildcardPermission.php
+++ b/src/WildcardPermission.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Spatie\Permission;
+
+use Illuminate\Support\Collection;
+use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
+
+class WildcardPermission
+{
+    /** @var string */
+    const WILDCARD_TOKEN = '*';
+
+    /** @var string */
+    const PART_DELIMITER = '.';
+
+    /** @var string */
+    const SUBPART_DELIMITER = ',';
+
+    /** @var string */
+    protected $permission;
+
+    /** @var Collection */
+    protected $parts;
+
+    /**
+     * @param string $permission
+     */
+    public function __construct(string $permission)
+    {
+        $this->permission = $permission;
+        $this->parts = collect();
+
+        $this->setParts();
+    }
+
+    /**
+     * @param string|WildcardPermission $permission
+     *
+     * @return bool
+     */
+    public function implies($permission): bool
+    {
+        if (is_string($permission)) {
+            $permission = new self($permission);
+        }
+
+        $otherParts = $permission->getParts();
+
+        $i = 0;
+        foreach ($otherParts as $otherPart) {
+            if ($this->getParts()->count() - 1 < $i) {
+                return true;
+            }
+
+            if (! $this->parts->get($i)->contains(self::WILDCARD_TOKEN)
+                && ! $this->containsAll($this->parts->get($i), $otherPart)) {
+                return false;
+            }
+
+            $i++;
+        }
+
+        for ($i; $i < $this->parts->count(); $i++) {
+            if (! $this->parts->get($i)->contains(self::WILDCARD_TOKEN)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Collection $part
+     * @param Collection $otherPart
+     *
+     * @return bool
+     */
+    protected function containsAll(Collection $part, Collection $otherPart): bool
+    {
+        foreach ($otherPart->toArray() as $item) {
+            if (! $part->contains($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getParts(): Collection
+    {
+        return $this->parts;
+    }
+
+    /**
+     * Sets the different parts and subparts from permission string.
+     *
+     * @return void
+     */
+    protected function setParts(): void
+    {
+        if (empty($this->permission) || $this->permission == null) {
+            throw WildcardPermissionNotProperlyFormatted::create($this->permission);
+        }
+
+        $parts = collect(explode(self::PART_DELIMITER, $this->permission));
+
+        $parts->each(function ($item, $key) {
+            $subParts = collect(explode(self::SUBPART_DELIMITER, $item));
+
+            if ($subParts->isEmpty() || $subParts->contains('')) {
+                throw WildcardPermissionNotProperlyFormatted::create($this->permission);
+            }
+
+            $this->parts->add($subParts);
+        });
+
+        if ($this->parts->isEmpty()) {
+            throw WildcardPermissionNotProperlyFormatted::create($this->permission);
+        }
+    }
+}

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -234,7 +234,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->expectException(PermissionDoesNotExist::class);
 
-        $this->testUser->hasPermissionTo('does-not-exist');
+        $this->testUser->hasPermissionTo(7892);
     }
 
     /** @test */
@@ -242,7 +242,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->expectException(PermissionDoesNotExist::class);
 
-        $this->testUser->hasPermissionTo('admin-permission');
+        $this->testUser->hasPermissionTo(83743847);
     }
 
     /** @test */

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -234,7 +234,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->expectException(PermissionDoesNotExist::class);
 
-        $this->testUser->hasPermissionTo(7892);
+        $this->testUser->hasPermissionTo('does-not-exist');
     }
 
     /** @test */
@@ -242,7 +242,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->expectException(PermissionDoesNotExist::class);
 
-        $this->testUser->hasPermissionTo(83743847);
+        $this->testUser->hasPermissionTo('does-not-exist');
     }
 
     /** @test */

--- a/tests/WildcardHasPermissionsTest.php
+++ b/tests/WildcardHasPermissionsTest.php
@@ -2,11 +2,10 @@
 
 namespace Spatie\Permission\Test;
 
+use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
-use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
-use Spatie\Permission\Models\Role;
 
 class WildcardHasPermissionsTest extends TestCase
 {

--- a/tests/WildcardHasPermissionsTest.php
+++ b/tests/WildcardHasPermissionsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
+
+class WildcardHasPermissionsTest extends TestCase
+{
+    /** @test */
+    public function it_can_check_wildcard_permission()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $permission1 = Permission::create(['name' => 'articles.edit,view,create']);
+        $permission2 = Permission::create(['name' => 'news.*']);
+        $permission3 = Permission::create(['name' => 'posts.*']);
+
+        $user1->givePermissionTo([$permission1, $permission2, $permission3]);
+
+        $this->assertTrue($user1->hasPermissionTo('posts.create'));
+        $this->assertTrue($user1->hasPermissionTo('posts.create.123'));
+        $this->assertTrue($user1->hasPermissionTo('posts.*'));
+        $this->assertTrue($user1->hasPermissionTo('articles.view'));
+        $this->assertFalse($user1->hasPermissionTo('projects.view'));
+    }
+
+    /** @test */
+    public function it_can_check_wildcard_permissions_via_roles()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $user1->assignRole('testRole');
+
+        $permission1 = Permission::create(['name' => 'articles,projects.edit,view,create']);
+        $permission2 = Permission::create(['name' => 'news.*.456']);
+        $permission3 = Permission::create(['name' => 'posts']);
+
+        $this->testUserRole->givePermissionTo([$permission1, $permission2, $permission3]);
+
+        $this->assertTrue($user1->hasPermissionTo('posts.create'));
+        $this->assertTrue($user1->hasPermissionTo('news.create.456'));
+        $this->assertTrue($user1->hasPermissionTo('projects.create'));
+        $this->assertTrue($user1->hasPermissionTo('articles.view'));
+        $this->assertFalse($user1->hasPermissionTo('articles.list'));
+        $this->assertFalse($user1->hasPermissionTo('projects.list'));
+    }
+
+    /** @test */
+    public function it_can_check_non_wildcard_permissions()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $permission1 = Permission::create(['name' => 'edit articles']);
+        $permission2 = Permission::create(['name' => 'create news']);
+        $permission3 = Permission::create(['name' => 'update comments']);
+
+        $user1->givePermissionTo([$permission1, $permission2, $permission3]);
+
+        $this->assertTrue($user1->hasPermissionTo('edit articles'));
+        $this->assertTrue($user1->hasPermissionTo('create news'));
+        $this->assertTrue($user1->hasPermissionTo('update comments'));
+    }
+
+    /** @test */
+    public function it_can_verify_complex_wildcard_permissions()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $permission1 = Permission::create(['name' => '*.create,update,delete.*.test,course,finance']);
+        $permission2 = Permission::create(['name' => 'papers,posts,projects,orders.*.test,test1,test2.*']);
+        $permission3 = Permission::create(['name' => 'User::class.create,edit,view']);
+
+        $user1->givePermissionTo([$permission1, $permission2, $permission3]);
+
+        $this->assertTrue($user1->hasPermissionTo('invoices.delete.367463.finance'));
+        $this->assertTrue($user1->hasPermissionTo('projects.update.test2.test3'));
+        $this->assertTrue($user1->hasPermissionTo('User::class.edit'));
+        $this->assertFalse($user1->hasPermissionTo('User::class.delete'));
+        $this->assertFalse($user1->hasPermissionTo('User::class.*'));
+    }
+
+    /** @test */
+    public function it_throws_exception_when_wildcard_permission_is_not_properly_formatted()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $permission = Permission::create(['name' => '*..']);
+
+        $user1->givePermissionTo([$permission]);
+
+        $this->expectException(WildcardPermissionNotProperlyFormatted::class);
+
+        $user1->hasPermissionTo('invoices.*');
+    }
+}

--- a/tests/WildcardMiddlewareTest.php
+++ b/tests/WildcardMiddlewareTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Middlewares\RoleMiddleware;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Middlewares\PermissionMiddleware;
+use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;
+
+class WildcardMiddlewareTest extends TestCase
+{
+    protected $roleMiddleware;
+    protected $permissionMiddleware;
+    protected $roleOrPermissionMiddleware;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->roleMiddleware = new RoleMiddleware();
+
+        $this->permissionMiddleware = new PermissionMiddleware();
+
+        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware();
+
+        app('config')->set('permission.enable_wildcard_permission', true);
+    }
+
+    /** @test */
+    public function a_guest_cannot_access_a_route_protected_by_the_permission_middleware()
+    {
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'articles.edit'
+            ), 403);
+    }
+
+    /** @test */
+    public function a_user_can_access_a_route_protected_by_permission_middleware_if_have_this_permission()
+    {
+        Auth::login($this->testUser);
+
+        Permission::create(['name' => 'articles']);
+
+        $this->testUser->givePermissionTo('articles');
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'articles.edit'
+            ), 200);
+    }
+
+    /** @test */
+    public function a_user_can_access_a_route_protected_by_this_permission_middleware_if_have_one_of_the_permissions()
+    {
+        Auth::login($this->testUser);
+
+        Permission::create(['name' => 'articles.*.test']);
+
+        $this->testUser->givePermissionTo('articles.*.test');
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'news.edit|articles.create.test'
+            ), 200);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, ['news.edit', 'articles.create.test']
+            ), 200);
+    }
+
+    /** @test */
+    public function a_user_cannot_access_a_route_protected_by_the_permission_middleware_if_have_a_different_permission()
+    {
+        Auth::login($this->testUser);
+
+        Permission::create(['name' => 'articles.*']);
+
+        $this->testUser->givePermissionTo('articles.*');
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'news.edit'
+            ), 403);
+    }
+
+    /** @test */
+    public function a_user_cannot_access_a_route_protected_by_permission_middleware_if_have_not_permissions()
+    {
+        Auth::login($this->testUser);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'articles.edit|news.edit'
+            ), 403);
+    }
+
+    /** @test */
+    public function a_user_can_access_a_route_protected_by_permission_or_role_middleware_if_has_this_permission_or_role()
+    {
+        Auth::login($this->testUser);
+
+        Permission::create(['name' => 'articles.*']);
+
+        $this->testUser->assignRole('testRole');
+        $this->testUser->givePermissionTo('articles.*');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|news.edit|articles.create'),
+            200
+        );
+
+        $this->testUser->removeRole('testRole');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|articles.edit'),
+            200
+        );
+
+        $this->testUser->revokePermissionTo('articles.*');
+        $this->testUser->assignRole('testRole');
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, 'testRole|articles.edit'),
+            200
+        );
+
+        $this->assertEquals(
+            $this->runMiddleware($this->roleOrPermissionMiddleware, ['testRole', 'articles.edit']),
+            200
+        );
+    }
+
+    /** @test */
+    public function the_required_permissions_can_be_fetched_from_the_exception()
+    {
+        Auth::login($this->testUser);
+
+        $requiredPermissions = [];
+
+        try {
+            $this->permissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, 'permission.some');
+        } catch (UnauthorizedException $e) {
+            $requiredPermissions = $e->getRequiredPermissions();
+        }
+
+        $this->assertEquals(['permission.some'], $requiredPermissions);
+    }
+
+    protected function runMiddleware($middleware, $parameter)
+    {
+        try {
+            return $middleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, $parameter)->status();
+        } catch (UnauthorizedException $e) {
+            return $e->getStatusCode();
+        }
+    }
+}

--- a/tests/WildcardRoleTest.php
+++ b/tests/WildcardRoleTest.php
@@ -2,12 +2,7 @@
 
 namespace Spatie\Permission\Test;
 
-use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Exceptions\RoleDoesNotExist;
-use Spatie\Permission\Exceptions\GuardDoesNotMatch;
-use Spatie\Permission\Exceptions\RoleAlreadyExists;
-use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
 class WildcardRoleTest extends TestCase
 {

--- a/tests/WildcardRoleTest.php
+++ b/tests/WildcardRoleTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Exceptions\RoleDoesNotExist;
+use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Spatie\Permission\Exceptions\RoleAlreadyExists;
+use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+
+class WildcardRoleTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        Permission::create(['name' => 'other-permission']);
+
+        Permission::create(['name' => 'wrong-guard-permission', 'guard_name' => 'admin']);
+    }
+
+    /** @test */
+    public function it_can_be_given_a_permission()
+    {
+        Permission::create(['name' => 'posts.*']);
+        $this->testUserRole->givePermissionTo('posts.*');
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo('posts.create'));
+    }
+
+    /** @test */
+    public function it_can_be_given_multiple_permissions_using_an_array()
+    {
+        Permission::create(['name' => 'posts.*']);
+        Permission::create(['name' => 'news.*']);
+
+        $this->testUserRole->givePermissionTo(['posts.*', 'news.*']);
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo('posts.create'));
+        $this->assertTrue($this->testUserRole->hasPermissionTo('news.create'));
+    }
+
+    /** @test */
+    public function it_can_be_given_multiple_permissions_using_multiple_arguments()
+    {
+        Permission::create(['name' => 'posts.*']);
+        Permission::create(['name' => 'news.*']);
+
+        $this->testUserRole->givePermissionTo('posts.*', 'news.*');
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo('posts.edit.123'));
+        $this->assertTrue($this->testUserRole->hasPermissionTo('news.view.1'));
+    }
+
+    /** @test */
+    public function it_can_be_given_a_permission_using_objects()
+    {
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo($this->testUserPermission));
+    }
+
+    /** @test */
+    public function it_returns_false_if_it_does_not_have_the_permission()
+    {
+        $this->assertFalse($this->testUserRole->hasPermissionTo('other-permission'));
+    }
+
+    /** @test */
+    public function it_returns_false_if_permission_does_not_exists()
+    {
+        $this->assertFalse($this->testUserRole->hasPermissionTo('doesnt-exist'));
+    }
+
+    /** @test */
+    public function it_returns_false_if_it_does_not_have_a_permission_object()
+    {
+        $permission = app(Permission::class)->findByName('other-permission');
+
+        $this->assertFalse($this->testUserRole->hasPermissionTo($permission));
+    }
+
+    /** @test */
+    public function it_creates_permission_object_with_findOrCreate_if_it_does_not_have_a_permission_object()
+    {
+        $permission = app(Permission::class)->findOrCreate('another-permission');
+
+        $this->assertFalse($this->testUserRole->hasPermissionTo($permission));
+
+        $this->testUserRole->givePermissionTo($permission);
+
+        $this->testUserRole = $this->testUserRole->fresh();
+
+        $this->assertTrue($this->testUserRole->hasPermissionTo('another-permission'));
+    }
+
+    /** @test */
+    public function it_returns_false_when_a_permission_of_the_wrong_guard_is_passed_in()
+    {
+        $permission = app(Permission::class)->findByName('wrong-guard-permission', 'admin');
+
+        $this->assertFalse($this->testUserRole->hasPermissionTo($permission));
+    }
+}

--- a/tests/WildcardRouteTest.php
+++ b/tests/WildcardRouteTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Http\Response;
+
+class WildcardRouteTest extends TestCase
+{
+    /** @test */
+    public function test_permission_function()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $router = $this->getRouter();
+
+        $router->get('permission-test', $this->getRouteResponse())
+                ->name('permission.test')
+                ->permission(['articles.edit', 'articles.save']);
+
+        $this->assertEquals(['permission:articles.edit|articles.save'], $this->getLastRouteMiddlewareFromRouter($router));
+    }
+
+    /** @test */
+    public function test_role_and_permission_function_together()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $router = $this->getRouter();
+
+        $router->get('role-permission-test', $this->getRouteResponse())
+                ->name('role-permission.test')
+                ->role('superadmin|admin')
+                ->permission('user.create|user.edit');
+
+        $this->assertEquals(
+            [
+                'role:superadmin|admin',
+                'permission:user.create|user.edit',
+            ],
+            $this->getLastRouteMiddlewareFromRouter($router)
+        );
+    }
+
+    protected function getLastRouteMiddlewareFromRouter($router)
+    {
+        return last($router->getRoutes()->get())->middleware();
+    }
+
+    protected function getRouter()
+    {
+        return app('router');
+    }
+
+    protected function getRouteResponse()
+    {
+        return function () {
+            return (new Response())->setContent('<html></html>');
+        };
+    }
+}


### PR DESCRIPTION
Allows using wildcard permissions based on the default wildcard permission implementation of [Apache Shiro](https://shiro.apache.org/permissions.html).

Enable wildcard permissions in the config file:

```php
// config/permission.php
'enable_wildcard_permission' => true,
```

When enabled, wildcard permissions offers you a flexible representation for a variety of permission schemes.

Some examples:

```php
// user can only do the actions create, update and view on both resources posts and users
$user->givePermissionTo('posts,users.create,update,view');

// user can do the actions create, update, view on any available resource
$user->givePermissionTo('*.create,update,view');

// user can do any action on posts with ids 1, 4 and 6 
$user->givePermissionTo('posts.*.1,4,6');
```

See full documentation at

```php
// docs/basic-usage/wildcard-permissions.md
```