### PR TITLE
Fix: hasPermissionTo and hasDirectPermission

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -132,11 +132,11 @@ trait HasPermissions
 
         if ( $permission instanceof Permission) {
             if($guardName){
-                return $this->getAllPermissions()->where('guard_name', '=', $guardName)->filter(function ($row, $key) use ($permission) {
+                return $this->getAllPermissions()->where('guard_name', '=', $guardName)->filter(function ($row) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
             } else {
-                return $this->getAllPermissions()->filter(function($row, $key) use ($permission) {
+                return $this->getAllPermissions()->filter(function($row) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
             }
@@ -284,7 +284,7 @@ trait HasPermissions
         }
 
         if ( $permission instanceof Permission) {
-            return $this->permissions->filter(function ($row, $key) use ($permission) {
+            return $this->permissions->filter(function ($row) use ($permission) {
               return $row == $permission;
             })->count() > 0;
         }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -284,7 +284,7 @@ trait HasPermissions
 
         if ($permission instanceof Permission) {
             return $this->permissions->filter(function ($row) use ($permission) {
-              return $row == $permission;
+                return $row == $permission;
             })->count() > 0;
         }
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -136,7 +136,7 @@ trait HasPermissions
                     return $row == $permission;
                 })->count() > 0;
             } else {
-                return $this->getAllPermissions()->filter(function($row) use ($permission) {
+                return $this->getAllPermissions()->filter(function ($row) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
             }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -130,7 +130,7 @@ trait HasPermissions
                 : $this->getAllPermissions()->contains('id', $permission);
         }
 
-        if ( $permission instanceof Permission) {
+        if ($permission instanceof Permission) {
             if($guardName){
                 return $this->getAllPermissions()->where('guard_name', '=', $guardName)->filter(function ($row) use ($permission) {
                     return $row == $permission;
@@ -283,7 +283,7 @@ trait HasPermissions
             return $this->permissions->contains('id', $permission);
         }
 
-        if ( $permission instanceof Permission) {
+        if ($permission instanceof Permission) {
             return $this->permissions->filter(function ($row) use ($permission) {
               return $row == $permission;
             })->count() > 0;

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -131,7 +131,7 @@ trait HasPermissions
         }
 
         if ($permission instanceof Permission) {
-            if($guardName){
+            if ($guardName) {
                 return $this->getAllPermissions()->where('guard_name', '=', $guardName)->filter(function ($row) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
@@ -143,7 +143,6 @@ trait HasPermissions
         }
 
         return false;
-
     }
 
     /**
@@ -456,7 +455,6 @@ trait HasPermissions
     {
         return Guard::getDefaultName($this);
     }
-
 
     /**
      * Forget the cached permissions.

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -120,19 +120,19 @@ trait HasPermissions
 
         if (is_string($permission)) {
             return $guardName
-                ? $this->getPermissionsViaRoles()->where('guard_name','=',$guardName)->contains('name', $permission)
+                ? $this->getPermissionsViaRoles()->where('guard_name', '=', $guardName)->contains('name', $permission)
                 : $this->getPermissionsViaRoles()->contains('name', $permission);
         }
 
         if (is_int($permission)) {
             return $guardName
-                ? $this->getPermissionsViaRoles()->where('guard_name','=',$guardName)->contains('id', $permission)
+                ? $this->getPermissionsViaRoles()->where('guard_name', '=', $guardName)->contains('id', $permission)
                 : $this->getPermissionsViaRoles()->contains('id', $permission);
         }
 
         if ( $permission instanceof Permission) {
             if($guardName){
-                return $this->getPermissionsViaRoles()->where('guard_name','=',$guardName)->filter(function($row, $key) use ($permission) {
+                return $this->getPermissionsViaRoles()->where('guard_name', '=', $guardName)->filter(function($row, $key) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
             } else {
@@ -277,12 +277,10 @@ trait HasPermissions
     {
         if (is_string($permission)) {
             return $this->permissions->contains('name', $permission);
-            // $permission = $this->permissions->where('guard_name','=',$guardName)->firstWhere('name', '=', $permission);
         }
 
         if (is_int($permission)) {
             return $this->permissions->contains('id', $permission);
-            // $permission = $this->permissions->where('guard_name','=',$guardName)->contains('id', $permission);
         }
 
         if ( $permission instanceof Permission) {

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -120,23 +120,23 @@ trait HasPermissions
 
         if (is_string($permission)) {
             return $guardName
-                ? $this->getPermissionsViaRoles()->where('guard_name', '=', $guardName)->contains('name', $permission)
-                : $this->getPermissionsViaRoles()->contains('name', $permission);
+                ? $this->getAllPermissions()->where('guard_name', '=', $guardName)->contains('name', $permission)
+                : $this->getAllPermissions()->contains('name', $permission);
         }
 
         if (is_int($permission)) {
             return $guardName
-                ? $this->getPermissionsViaRoles()->where('guard_name', '=', $guardName)->contains('id', $permission)
-                : $this->getPermissionsViaRoles()->contains('id', $permission);
+                ? $this->getAllPermissions()->where('guard_name', '=', $guardName)->contains('id', $permission)
+                : $this->getAllPermissions()->contains('id', $permission);
         }
 
         if ( $permission instanceof Permission) {
             if($guardName){
-                return $this->getPermissionsViaRoles()->where('guard_name', '=', $guardName)->filter(function($row, $key) use ($permission) {
+                return $this->getAllPermissions()->where('guard_name', '=', $guardName)->filter(function ($row, $key) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
             } else {
-                return $this->getPermissionsViaRoles()->filter(function($row, $key) use ($permission) {
+                return $this->getAllPermissions()->filter(function($row, $key) use ($permission) {
                     return $row == $permission;
                 })->count() > 0;
             }
@@ -284,7 +284,7 @@ trait HasPermissions
         }
 
         if ( $permission instanceof Permission) {
-            return $this->permissions->filter(function($row, $key) use ($permission) {
+            return $this->permissions->filter(function ($row, $key) use ($permission) {
               return $row == $permission;
             })->count() > 0;
         }


### PR DESCRIPTION
Adjust hasPermissionTo and hasDirectPermission functions so that they
use the Auth\User data to check for permissions using the proper
$connection to ensure the correct database is used.