### PR TITLE
Exclude pivot details in json output

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -21,6 +21,8 @@ class Permission extends Model implements PermissionContract
 
     protected $guarded = ['id'];
 
+    protected $hidden = ['pivot'];
+
     public function __construct(array $attributes = [])
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -20,6 +20,8 @@ class Role extends Model implements RoleContract
 
     protected $guarded = ['id'];
 
+    protected $hidden = ['pivot'];
+
     public function __construct(array $attributes = [])
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -52,4 +52,14 @@ class PermissionTest extends TestCase
 
         $this->assertEquals($this->testUserPermission->id, $permission_by_id->id);
     }
+
+    /** @test */
+    public function permission_pivot_data_is_excluded_with_json_output()
+    {
+        $this->testUser->givePermissionTo('edit-news');
+
+        $users = User::with('roles', 'permissions')->paginate();
+
+        $this->assertStringNotContainsString('pivot', response()->json($users));
+    }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -239,4 +239,15 @@ class RoleTest extends TestCase
             $this->testUserRole->guard_name
         );
     }
+
+    /** @test */
+    public function role_pivot_data_is_excluded_with_json_output()
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $this->testUser->assignRole($this->testUserRole);
+
+        $users = User::with('roles', 'permissions')->paginate();
+
+        $this->assertStringNotContainsString('pivot', response()->json($users));
+    }
 }


### PR DESCRIPTION
Requested various times, such as in #302