### PR TITLE
Change model delete event to deleted

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -16,7 +16,7 @@ trait HasRoles
 
     public static function bootHasRoles()
     {
-        static::deleting(function ($model) {
+        static::deleted(function ($model) {
             if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
                 return;
             }


### PR DESCRIPTION
I have been using this package on many projects I work on, but on my last one I have used the Observers pattern and made an Observer for the User model `UserObserver` to make use of model events, and I am using the `deleting` event to make sure that user does not have any records associated, if so, I won’t allow the deletion, It looks likes this:

```php
public function deleting(User $user)
{
       if ($user->emergencyCar) {
           return false;
       }

}
```

And on my controller I am checking `$user->delete()` if it returns true or false.
But since the `User` model has the `HasRoles` trait which has the `deleting` event responsible for deleting the pivot table entries of the user roles and permissions, and this causes deleting the user roles and permissions entries but keeping the user, based on the logic on my Observer.

I think this problem may also be encountered by anyone trying to stop model deletion using model `deleting` event.
My solution for this is to change the `deleting` event to `deleted` this way we can make sure that roles and permissions entries are only deleted after the user has been deleted.
