### PR TITLE
Add PHPDoc to models

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -14,6 +14,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $guard_name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection $roles
+ * @property-read \Illuminate\Database\Eloquent\Collection $users
+ */
 class Permission extends Model implements PermissionContract
 {
     use HasRoles;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -13,6 +13,15 @@ use Spatie\Permission\Traits\RefreshesPermissionCache;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $guard_name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection $permissions
+ * @property-read \Illuminate\Database\Eloquent\Collection $users
+ */
 class Role extends Model implements RoleContract
 {
     use HasPermissions;


### PR DESCRIPTION
Both models have no PHPDoc annotations that define the attributes that exist on the models. This means that IDEs and static analysis tools are unable to infer what properties exist.

This PR adds the missing PHPDoc annotations for better IDE support and better support for static analysis tools (e.g. Phan / PHPStan).