### PR TITLE
Add `display_role_in_exception` key with default value `false` to permission config

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -85,12 +85,20 @@ return [
     ],
 
     /*
-     * When set to true, the required permission/role names are added to the exception
+     * When set to true, the required permission names are added to the exception
      * message. This could be considered an information leak in some contexts, so
      * the default setting is false here for optimum safety.
      */
 
     'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to the exception
+     * message. This could be considered an information leak in some contexts, so
+     * the default setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
 
     /*
      * By default wildcard permission lookups are disabled.


### PR DESCRIPTION
The `UnauthorizedException::forRolesOrPermissions` checks for the non-existent configuration key `display_role_in_exception`. This PR adds that config key with a default value of `false` to `config/permission.php`.

Fixes #1467 