### PR TITLE
Speed up permissions cache lookups

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -36,7 +36,7 @@ class Permission extends Model implements PermissionContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']])->first();
+        $permission = static::getPermission(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']]);
 
         if ($permission) {
             throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
@@ -85,7 +85,7 @@ class Permission extends Model implements PermissionContract
     public static function findByName(string $name, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermissions(['name' => $name, 'guard_name' => $guardName])->first();
+        $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
         if (! $permission) {
             throw PermissionDoesNotExist::create($name, $guardName);
         }
@@ -106,7 +106,7 @@ class Permission extends Model implements PermissionContract
     public static function findById(int $id, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermissions(['id' => $id, 'guard_name' => $guardName])->first();
+        $permission = static::getPermission(['id' => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);
@@ -126,13 +126,23 @@ class Permission extends Model implements PermissionContract
     public static function findOrCreate(string $name, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermissions(['name' => $name, 'guard_name' => $guardName])->first();
+        $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $permission) {
             return static::query()->create(['name' => $name, 'guard_name' => $guardName]);
         }
 
         return $permission;
+    }
+
+    /**
+     * Get a cached permission.
+     */
+    protected static function getPermission(array $params): ?PermissionContract
+    {
+        return app(PermissionRegistrar::class)
+            ->setPermissionClass(static::class)
+            ->getPermission($params);
     }
 
     /**


### PR DESCRIPTION
Uses `$collection->first(...)` instead of `$collection->where(...)->where(...)->first()` to avoid creating two temporary arrays and stop as soon as a match is found.

In my project - PHP 7.4, Xdebug and Debugbar enabled, and 380 permissions - it reduced the `Permission::findByName()` time from 48.54ms average to 6.19ms. On a page with 48 permissions checks, that reduced the total find time from 2330ms to 297ms, and the overall page load **from 3.4 seconds to 1.1 seconds**.