### PR TITLE
Feature/use auth guard for permission checks

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -106,6 +106,13 @@ return [
 
     'enable_wildcard_permission' => false,
 
+    /*
+     * By default the guard for permission checks is auto discovered
+     * if enable all permission checks will use the auth guard used for login
+     */
+
+    'enable_dynamic_auth_guard_checks' => false,
+
     'cache' => [
 
         /*

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -87,7 +87,7 @@ class PermissionRegistrar
     {
         app(Gate::class)->before(function (Authorizable $user, string $ability) {
             if (method_exists($user, 'checkPermissionTo')) {
-                return $user->checkPermissionTo($ability) ?: null;
+                return $user->checkPermissionTo($ability, currentAuthGuard()) ?: null;
             }
         });
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,3 +18,22 @@ if (! function_exists('getModelForGuard')) {
             })->get($guard);
     }
 }
+
+if (! function_exists('currentAuthGuard')) {
+    /**
+     *
+     * @return string|null
+     */
+    function currentAuthGuard()
+    {
+        if(! config('permission.enable_dynamic_auth_guard_checks')) {
+            return null;
+        }
+
+        foreach (array_keys(config('auth.guards')) as $guard) {
+
+            if (auth()->guard($guard)->check()) return $guard;
+        }
+        return null;
+    }
+}

--- a/tests/DynamicAuthGuardChecksTest.php
+++ b/tests/DynamicAuthGuardChecksTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Middlewares\PermissionMiddleware;
+use Spatie\Permission\Middlewares\RoleMiddleware;
+use Spatie\Permission\Middlewares\RoleOrPermissionMiddleware;
+use Spatie\Permission\Models\Permission;
+
+class DynamicAuthGuardChecksTest extends TestCase
+{
+    protected $roleMiddleware;
+    protected $permissionMiddleware;
+    protected $roleOrPermissionMiddleware;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->roleMiddleware = new RoleMiddleware();
+
+        $this->permissionMiddleware = new PermissionMiddleware();
+
+        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware();
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('auth.guards', [
+            'api' => ['driver' => 'session', 'provider' => 'users'],
+            'web' => ['driver' => 'session', 'provider' => 'users'],
+            'abc' => ['driver' => 'abc'],
+        ]);
+
+        $app['config']->set('permission.enable_dynamic_auth_guard_checks', true);
+    }
+
+    /** @test */
+    public function it_can_honour_guard_used_for_login()
+    {
+
+        $this->testUser->givePermissionTo(Permission::create([
+            'name' => 'do_this',
+            'guard_name' => 'web',
+        ]));
+
+        $this->testUser->givePermissionTo(Permission::create([
+            'name' => 'do_that',
+            'guard_name' => 'api',
+        ]));
+
+        Auth::guard('web')->setUser($this->testUser);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'do_this'
+            ), 200);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'do_that'
+            ), 403);
+
+        Auth::guard('api')->setUser($this->testUser);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'do_this'
+            ), 403);
+
+        $this->assertEquals(
+            $this->runMiddleware(
+                $this->permissionMiddleware, 'do_that'
+            ), 200);
+    }
+
+
+
+    protected function runMiddleware($middleware, $parameter)
+    {
+        try {
+            return $middleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, $parameter)->status();
+        } catch (UnauthorizedException $e) {
+            return $e->getStatusCode();
+        }
+    }
+}


### PR DESCRIPTION
Closes #1515 

As I mentioned in #1384 the solution provided by that PR is way to deep into the guard resolving strategy.

My solution to the problem starts on the gate level.
The package already supports to specify the guard name when we call `checkPermissionTo` on guard level.

For Backwards compatibility I added a feature flag to the config file.

**One Concern**
When the feature flag defaults to true there is one failing test:
```
Spatie\Permission\Test\MiddlewareTest::a_user_cannot_access_a_route_protected_by_the_permission_middleware_of_a_different_guard
```
To be honest I don't know what this test want to provide.
I don't understand which part from the guard guessing logic kicks in.
the user have only one permission so the guard_name is irrelevant for the test case.

To make the test pass with this new feature we just need to login the admin with the admin guard.
```
Auth::guard('admin')->setUser($this->testAdmin);
Auth::guard('web')->setUser($this->testUser);
```
The TestCase sets the guard providers as follows:
```
$app['config']->set('auth.guards.admin', ['driver' => 'session', 'provider' => 'admins']);
$app['config']->set('auth.providers.admins', ['driver' => 'eloquent', 'model' => Admin::class]);
```

So in the real world there is no way that the `$this->testAdmin` is logged in with the guard `web`.
