### PR TITLE
PermissionRegistrar::initializeCache public to easily reinitialize cache store

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -49,7 +49,7 @@ class PermissionRegistrar
         $this->initializeCache();
     }
 
-    protected function initializeCache()
+    public function initializeCache()
     {
         self::$cacheExpirationTime = config('permission.cache.expiration_time', config('permission.cache_expiration_time'));
 


### PR DESCRIPTION
Because a reference to the cache store gets stored during application boot makes it cumbersome to change for example any cache prefixes. Having public access to PermissionRegistrar::initializeCache() method makes it possible to easily manually reinitialize the stored cache store if you wish to use this package for example with multitenancy.