### PR TITLE
Change users relationship type to BelongsToMany

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -8,7 +8,6 @@ use Spatie\Permission\Traits\HasRoles;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
@@ -59,7 +58,7 @@ class Permission extends Model implements PermissionContract
     /**
      * A permission belongs to some users of the model associated with its guard.
      */
-    public function users(): MorphToMany
+    public function users(): BelongsToMany
     {
         return $this->morphedByMany(
             getModelForGuard($this->attributes['guard_name']),

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -10,7 +10,6 @@ use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Role extends Model implements RoleContract
@@ -56,7 +55,7 @@ class Role extends Model implements RoleContract
     /**
      * A role belongs to some users of the model associated with its guard.
      */
-    public function users(): MorphToMany
+    public function users(): BelongsToMany
     {
         return $this->morphedByMany(
             getModelForGuard($this->attributes['guard_name']),

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Traits;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Guard;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
@@ -9,7 +10,6 @@ use Spatie\Permission\WildcardPermission;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
 
@@ -40,7 +40,7 @@ trait HasPermissions
     /**
      * A model may have multiple direct permissions.
      */
-    public function permissions(): MorphToMany
+    public function permissions(): BelongsToMany
     {
         return $this->morphToMany(
             config('permission.models.permission'),

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\Permission\Traits;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\Permission\PermissionRegistrar;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 trait HasRoles
 {
@@ -37,7 +37,7 @@ trait HasRoles
     /**
      * A model may have multiple roles.
      */
-    public function roles(): MorphToMany
+    public function roles(): BelongsToMany
     {
         return $this->morphToMany(
             config('permission.models.role'),


### PR DESCRIPTION
Currently the relationship between users and both roles and permissions is of type `MorphToMany`, which is great if you need that flexibility. When you know you only have one kind of model (probably `User`), you don't need all that polymorphism.

I've tried to extend some classes to remove the morph, but this impossible because the return type can't be changed. However, the `MorphToMany` type is an extension of `BelongsToMany`. So in this PR I've changed the return type to that.

All the tests still pass and this should not introduce any breaking changes.