### PR TITLE
Declare table relations earlier to improve guarded/fillable detection accuracy

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -26,8 +26,11 @@ class Permission extends Model implements PermissionContract
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
+    }
 
-        $this->setTable(config('permission.table_names.permissions'));
+    public function getTable()
+    {
+        return config('permission.table_names.permissions', parent::getTable());
     }
 
     public static function create(array $attributes = [])

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -25,8 +25,11 @@ class Role extends Model implements RoleContract
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
+    }
 
-        $this->setTable(config('permission.table_names.roles'));
+    public function getTable()
+    {
+        return config('permission.table_names.roles', parent::getTable());
     }
 
     public static function create(array $attributes = [])


### PR DESCRIPTION
Declare table relations earlier to improve guarded/fillable detection accuracy.

Relates to requirements from Laravel's security patches in August 2020, in Laravel 6.18.35, 7.24.0
https://blog.laravel.com/security-release-laravel-61835-7240

Fixes #1542 

Co-authored-by: ReeceM <2767904+ReeceM@users.noreply.github.com>
