### PR TITLE
Update Auth0 sponsorship link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <table>
    <tr>
       <td><img src="https://user-images.githubusercontent.com/6287961/92889815-d64c3d80-f416-11ea-894a-b4de7e8f7eef.png"></td>
-      <td>If you want to quickly add authentication and authorization to Laravel projects, feel free to check Auth0's Laravel SDK and free plan at <a href="https://auth0.com/overview?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=laravel-permission&utm_content=auth">https://auth0.com/overview</a>.</td>
+      <td>If you want to quickly add authentication and authorization to Laravel projects, feel free to check Auth0's Laravel SDK and free plan at <a href="https://auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=laravel-permission&utm_content=auth">https://auth0.com/developers</a>.</td>
    </tr>
 </table>
 


### PR DESCRIPTION
Hey Freek and team Spatie

We recently launched a new page specifically geared towards developers on auth0.com.
Can we change the link in the sponsorship message?

Thanks again for your open-source work!