### PR TITLE
Add HasFactory trait to models.

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Permission\Guard;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Traits\HasRoles;
@@ -17,6 +18,7 @@ class Permission extends Model implements PermissionContract
 {
     use HasRoles;
     use RefreshesPermissionCache;
+    use HasFactory;
 
     protected $guarded = ['id'];
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Permission\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Permission\Traits\HasPermissions;
@@ -16,6 +17,7 @@ class Role extends Model implements RoleContract
 {
     use HasPermissions;
     use RefreshesPermissionCache;
+    use HasFactory;
 
     protected $guarded = ['id'];
 


### PR DESCRIPTION
This PR adds the new `HasFactory` trait to the `Role` and `Permission` models. This will enable the creation of factory classes on consuming projects that use built-in models.

In the project that I'm working on, we have defined a `RoleFactory` and a `PermissionFactory` for the built-in models. While updating to Laravel 8 and converting the factories for the two models to classes, we discover that the models don't use the HasFactory trait. Adding this trait will enable the usage of factory classes on models using the factory method from the trait.