### PR TITLE
Default guard should be config's default guard instead of first key from all available drivers.

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -50,6 +50,6 @@ class Guard
     {
         $default = config('auth.defaults.guard');
 
-        return static::getNames($class)->first() ?: $default;
+        return $default ?? static::getNames($class)->first();
     }
 }


### PR DESCRIPTION
After hours of searching to know that why when I set everything in config and database to `api` but my code doesn't work I found that in `getDefaultName` method instead of getting default guard from `defaults` we're getting it from first key of `guards` which is weird. 