### PR TITLE
allow checking for role_or_permission with multiple guards

### DIFF
--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -3,14 +3,15 @@
 namespace Spatie\Permission\Middlewares;
 
 use Closure;
-use Illuminate\Support\Facades\Auth;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 
 class RoleOrPermissionMiddleware
 {
-    public function handle($request, Closure $next, $roleOrPermission, $guard = null)
+    public function handle($request, Closure $next, $roleOrPermission)
     {
-        if (Auth::guard($guard)->guest()) {
+        $user = $request->user();
+
+        if (!$user) {
             throw UnauthorizedException::notLoggedIn();
         }
 
@@ -18,7 +19,7 @@ class RoleOrPermissionMiddleware
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        if (! Auth::guard($guard)->user()->hasAnyRole($rolesOrPermissions) && ! Auth::guard($guard)->user()->hasAnyPermission($rolesOrPermissions)) {
+        if (! $user->hasAnyRole($rolesOrPermissions) && ! $user->hasAnyPermission($rolesOrPermissions)) {
             throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 


### PR DESCRIPTION
atm in multi guards setup we cant check for the same role/perm with different guards ex.
```
// wont work as the middleware will bail on first error
'middleware' => [
     'role_or_permission:user|user.edit,web',
     'role_or_permission:user|user.edit,agent'
],
```

[nor its documented](https://spatie.be/docs/laravel-permission/v3/basic-usage/multiple-guards) on how to use the middleware in this scenarios.

so with the new changes you only need the role / perm ex.
```
'middleware' => 'role_or_permission:user|user.edit',
```

and the mw will take care of the rest as the guard is already resolved when the user logs in.

also i've read https://github.com/spatie/laravel-permission/issues/1156 over & over but cant find a way around for using the middleware with that setup.

if all good i can update the docs as well 🥇 .