### PR TITLE
Use Eloquent\Collection instead of Support\Collection

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -4,7 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Collection;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Permission\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Collection;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -5,7 +5,7 @@ namespace Spatie\Permission;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Access\Gate;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Collection;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 
@@ -23,7 +23,7 @@ class PermissionRegistrar
     /** @var string */
     protected $roleClass;
 
-    /** @var \Illuminate\Support\Collection */
+    /** @var \Illuminate\Database\Eloquent\Collection */
     protected $permissions;
 
     /** @var \DateInterval|int */
@@ -119,7 +119,7 @@ class PermissionRegistrar
      *
      * @param array $params
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getPermissions(array $params = []): Collection
     {


### PR DESCRIPTION
The extended Eloquent\Model will use Eloquent\Collection: for consistency, collection merging, etc