### PR TITLE
Add check permission via role config.

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -108,7 +108,7 @@ return [
 
     /*
      * When you use Model has multiple role.
-     * But you want to give permissions directly to Model, Not use default permissions from role.
+     * But you want to give and check permissions directly to Model, Not use default permissions from role.
      */
 
     'check_permission_via_role' => true,

--- a/config/permission.php
+++ b/config/permission.php
@@ -106,6 +106,13 @@ return [
 
     'enable_wildcard_permission' => false,
 
+    /*
+     * When you use Model has multiple role.
+     * But you want to give permissions directly to Model, Not use default permissions from role.
+     */
+
+    'check_permission_via_role' => true,
+
     'cache' => [
 
         /*

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -255,7 +255,7 @@ trait HasPermissions
      */
     protected function hasPermissionViaRole(Permission $permission): bool
     {
-        return $this->hasRole($permission->roles);
+        return config('permission.check_permission_via_role', false) && $this->hasRole($permission->roles);
     }
 
     /**

--- a/tests/CheckPermissionViaRoleTest.php
+++ b/tests/CheckPermissionViaRoleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+class CheckPermissionViaRoleTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function check_permission_via_role_true_assert_true()
+    {
+        config()->set('permission.check_permission_via_role', true);
+
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertTrue($this->testUser->checkPermissionTo($this->testUserPermission));
+    }
+
+    /** @test */
+    public function check_permission_via_role_true_assert_false()
+    {
+        config()->set('permission.check_permission_via_role', true);
+
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertFalse($this->testUser->checkPermissionTo($this->testUserPermission));
+    }
+
+    /** @test */
+    public function check_permission_via_role_false_assert_true()
+    {
+        config()->set('permission.check_permission_via_role', false);
+
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+        $this->testUser->givePermissionTo($this->testUserPermission);
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertTrue($this->testUserRole->checkPermissionTo($this->testUserPermission));
+    }
+
+    /** @test */
+    public function check_permission_via_role_false_assert_false()
+    {
+        config()->set('permission.check_permission_via_role', false);
+
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+        $this->testUser->assignRole($this->testUserRole);
+
+        $this->assertTrue($this->testUserRole->checkPermissionTo($this->testUserPermission));
+    }
+}


### PR DESCRIPTION
From #1632 

I add check permission via role config, In case  you want to give and check permissions from `model_has_permissions` only.
Not to check permissions from Role.

### ** Not support when check permission directly from role.