### PR TITLE
Fix bug when adding roles to a model that doesn't yet exist

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -352,9 +352,9 @@ trait HasPermissions
                     if ($modelLastFiredOn !== null && $modelLastFiredOn === $model) {
                         return;
                     }
-                    $object->permissions()->sync($permissions, false);
-                    $object->load('permissions');
-                    $modelLastFiredOn = $object;
+                    $model->permissions()->sync($permissions, false);
+                    $model->load('permissions');
+                    $modelLastFiredOn = $model;
                 }
             );
         }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -348,13 +348,8 @@ trait HasPermissions
 
             $class::saved(
                 function ($object) use ($permissions, $model) {
-                    static $modelLastFiredOn;
-                    if ($modelLastFiredOn !== null && $modelLastFiredOn === $model) {
-                        return;
-                    }
                     $model->permissions()->sync($permissions, false);
                     $model->load('permissions');
-                    $modelLastFiredOn = $model;
                 }
             );
         }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -120,13 +120,8 @@ trait HasRoles
 
             $class::saved(
                 function ($object) use ($roles, $model) {
-                    static $modelLastFiredOn;
-                    if ($modelLastFiredOn !== null && $modelLastFiredOn === $model) {
-                        return;
-                    }
                     $model->roles()->sync($roles, false);
                     $model->load('roles');
-                    $modelLastFiredOn = $model;
                 }
             );
         }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -476,6 +476,9 @@ class HasPermissionsTest extends TestCase
         $user2->givePermissionTo('edit-articles');
         $user2->save();
 
+        $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
+        $this->assertFalse($user->fresh()->hasPermissionTo('edit-articles'));
+
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
     }
@@ -490,6 +493,9 @@ class HasPermissionsTest extends TestCase
         $user2 = new User(['email' => 'test2@user.com']);
         $user2->syncPermissions('edit-articles');
         $user2->save();
+
+        $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
+        $this->assertFalse($user->fresh()->hasPermissionTo('edit-articles'));
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -247,6 +247,9 @@ class HasRolesTest extends TestCase
         $user2->syncRoles('testRole2');
         $user2->save();
 
+        $this->assertTrue($user->fresh()->hasRole('testRole'));
+        $this->assertFalse($user->fresh()->hasRole('testRole2'));
+
         $this->assertTrue($user2->fresh()->hasRole('testRole2'));
         $this->assertFalse($user2->fresh()->hasRole('testRole'));
     }
@@ -261,6 +264,9 @@ class HasRolesTest extends TestCase
         $admin_user = new User(['email' => 'admin@user.com']);
         $admin_user->assignRole('testRole2');
         $admin_user->save();
+
+        $this->assertTrue($user->fresh()->hasRole('testRole'));
+        $this->assertFalse($user->fresh()->hasRole('testRole2'));
 
         $this->assertTrue($admin_user->fresh()->hasRole('testRole2'));
         $this->assertFalse($admin_user->fresh()->hasRole('testRole'));


### PR DESCRIPTION
**Brief description of the bug**
In our app, we have Nova setup so the client can create new users and assign them different roles within the application. We're using [this package](https://github.com/vyuldashev/nova-permission) to bring the Role adding, etc functionality to Nova.

However, whenever a new user was created and roles were assigned to that user, it seemed to override the roles of other users as well.

**Debugging**
I spent an hour or so trying to get to the bottom of this. I did some debugging in the Nova package itself but couldn't find anything, then I started looking at this package.

When `dd`'ing (sorry not Ray just yet), that `$object` was an instance of one of the other models (a different user), whereas `$model` was the instance of the model I was creating in Nova.

I changed around references of `$object` to `$model` and hey-presto, it started to function as expected (eg. the roles for the new user were only assigned to the new user, not anyone else).

---

Let me know if you have any questions or if you'd like me to make any changes.