### PR TITLE
Fix 'Undefined variable: class' if have $guardName

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -24,9 +24,9 @@ class Guard
             }
         }
 
-        if (! isset($guardName)) {
-            $class = is_object($model) ? get_class($model) : $model;
+        $class = is_object($model) ? get_class($model) : $model;
 
+        if (! isset($guardName)) {
             $guardName = (new \ReflectionClass($class))->getDefaultProperties()['guard_name'] ?? null;
         }
 


### PR DESCRIPTION
This fix fixes the following errors:
```
   ErrorException 

  Undefined variable: class

  at vendor/spatie/laravel-permission/src/Guard.php:43
     39▕                 }
     40▕ 
     41▕                 return config("auth.providers.{$guard['provider']}.model");
     42▕             })
  ➜  43▕             ->filter(function ($model) use ($class) {
     44▕                 return $class === $model;
     45▕             })
     46▕             ->keys();
     47▕     }
```