### PR TITLE
Retrieve guard only once in middlewares

### DIFF
--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -9,7 +9,9 @@ class PermissionMiddleware
 {
     public function handle($request, Closure $next, $permission, $guard = null)
     {
-        if (app('auth')->guard($guard)->guest()) {
+        $authGuard = app('auth')->guard($guard);
+
+        if ($authGuard->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }
 
@@ -18,7 +20,7 @@ class PermissionMiddleware
             : explode('|', $permission);
 
         foreach ($permissions as $permission) {
-            if (app('auth')->guard($guard)->user()->can($permission)) {
+            if ($authGuard->user()->can($permission)) {
                 return $next($request);
             }
         }

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -10,7 +10,9 @@ class RoleMiddleware
 {
     public function handle($request, Closure $next, $role, $guard = null)
     {
-        if (Auth::guard($guard)->guest()) {
+        $authGuard = Auth::guard($guard);
+
+        if ($authGuard->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }
 
@@ -18,7 +20,7 @@ class RoleMiddleware
             ? $role
             : explode('|', $role);
 
-        if (! Auth::guard($guard)->user()->hasAnyRole($roles)) {
+        if (! $authGuard->user()->hasAnyRole($roles)) {
             throw UnauthorizedException::forRoles($roles);
         }
 

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -10,7 +10,8 @@ class RoleOrPermissionMiddleware
 {
     public function handle($request, Closure $next, $roleOrPermission, $guard = null)
     {
-        if (Auth::guard($guard)->guest()) {
+        $authGuard = Auth::guard($guard);
+        if ($authGuard->guest()) {
             throw UnauthorizedException::notLoggedIn();
         }
 
@@ -18,7 +19,7 @@ class RoleOrPermissionMiddleware
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        if (! Auth::guard($guard)->user()->hasAnyRole($rolesOrPermissions) && ! Auth::guard($guard)->user()->hasAnyPermission($rolesOrPermissions)) {
+        if (! $authGuard->user()->hasAnyRole($rolesOrPermissions) && ! $authGuard->user()->hasAnyPermission($rolesOrPermissions)) {
             throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 


### PR DESCRIPTION
This should speed up the middlewares marginally as we don't have to retrieve the same guard several time over to act upon it.