### PR TITLE
Add functionality for regular expression has checking

### DIFF
--- a/docs/basic-usage/direct-permissions.md
+++ b/docs/basic-usage/direct-permissions.md
@@ -53,6 +53,12 @@ $user->hasAnyPermission(['edit articles', 'publish articles', 'unpublish article
 $user->hasAllPermissions(['edit articles', 'publish articles', 'unpublish articles']);
 ```
 
+...or if a user has ANY permission matching a regular expression
+
+```php
+$user->hasPregPermission('publish articles'); // Matches "publish articles" AND "unpublish articles"
+```
+
 You may also pass integers to lookup by permission id
 
 ```php

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -177,6 +177,29 @@ trait HasPermissions
 
         return false;
     }
+    
+    /**
+     * Check if any permissions match PHP Regular Expression
+     * @param  string      $pattern
+     * @param  string|null $guardName
+     * @return boolean
+     */
+    public function hasPregPermission($pattern, string $guardName = null): bool
+    {
+        $guardName = $guardName ?? $this->getDefaultGuardName();
+        
+        foreach ($this->getAllPermissions() as $userPermission) {
+            if ($guardName !== $userPermission->guard_name) {
+                continue;
+            }
+
+            if (preg_match("/$pattern/", $userPermission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * @deprecated since 2.35.0


### PR DESCRIPTION
Queries all permissions and filters based on a regular expression providing a solution for situations where you want to check if any permissions in a structured set are attached.

**Example**
If you want to hide/show an "Imports" menu item if they have access to at least 1 of the imports available. Instead of running `Auth::user()->hasAnyPermission('imports.foo', 'imports.bar', 'imports.apple', 'imports.banana')` you can run `Auth::user()->hasPregPermission('imports.')`