### PR TITLE
Remove redundant code in getMigrationFileName() function

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -176,9 +176,6 @@ class PermissionServiceProvider extends ServiceProvider
         $filesystem = $this->app->make(Filesystem::class);
 
         return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
-            ->flatMap(function ($path) use ($filesystem) {
-                return $filesystem->glob($path.'*_create_permission_tables.php');
-            })->push($this->app->databasePath()."/migrations/{$timestamp}_create_permission_tables.php")
             ->flatMap(function ($path) use ($filesystem, $migrationFileName) {
                 return $filesystem->glob($path.'*_'.$migrationFileName);
             })


### PR DESCRIPTION
Unless I'm mistaken, these lines can be safely deleted.