### PR TITLE
[docs] Update exceptions.md

### DIFF
--- a/docs/advanced-usage/exceptions.md
+++ b/docs/advanced-usage/exceptions.md
@@ -3,7 +3,7 @@ title: Exceptions
 weight: 3
 ---
 
-If you need to override exceptions thrown by this package, you can simply use normal [Laravel practices for handling exceptions](https://laravel.com/docs/errors#render-method).
+If you need to override exceptions thrown by this package, you can simply use normal [Laravel practices for handling exceptions](https://laravel.com/docs/8.x/errors#rendering-exceptions).
 
 An example is shown below for your convenience, but nothing here is specific to this package other than the name of the exception.
 
@@ -12,15 +12,14 @@ You can find all the exceptions added by this package in the code here: https://
 
 **app/Exceptions/Handler.php**
 ```php
-public function render($request, Throwable $exception)
+
+public function register()
 {
-    if ($exception instanceof \Spatie\Permission\Exceptions\UnauthorizedException) {
+    $this->renderable(function (\Spatie\Permission\Exceptions\UnauthorizedException $e, $request) {
         return response()->json([
             'responseMessage' => 'You do not have the required authorization.',
             'responseStatus'  => 403,
         ]);
-    }
-
-    return parent::render($request, $exception);
+    });
 }
 ```


### PR DESCRIPTION
Currently the exception snippet uses laravel 7.x syntax.
This PR update the snippet to use latest laravel 8.x syntax.