### PR TITLE
Update new-app.md

### DIFF
--- a/docs/basic-usage/new-app.md
+++ b/docs/basic-usage/new-app.md
@@ -132,7 +132,7 @@ Super-Admins are a common feature. Using the following approach allows that when
 
 +        // Implicitly grant "Super Admin" role all permission checks using can()
 +        Gate::before(function ($user, $ability) {
-+            if ($user->hasRole('Super-Admin')) {
++            if ($user->hasRole('super-admin')) {
 +                return true;
 +            }
 +        });


### PR DESCRIPTION
The capitalization of super-admin in AuthServiceProvider change in case returns false in the Gate function, disallowing the super admin user to override permissions. This might be due to the fact that variable and constant names are case sensitive in PHP.
New adopters of Spatie/Permissions rely on the documentation for a guide and it has caused quite some issues. ==>
http://5.9.10.113/64808362/laravel-spatie-roles-super-admin-not-working
https://stackoverflow.com/questions/65213504/how-to-use-correctly-super-admins-role-in-laravel-spatie
https://www.bountysource.com/issues/98599883-defining-a-super-admin-not-working