### PR TITLE
Make cache more than 90% smaller and Speed up permissions cache lookups

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -122,17 +122,6 @@ return [
         'key' => 'spatie.permission.cache',
 
         /*
-         * When checking for a permission against a model by passing a Permission
-         * instance to the check, this key determines what attribute on the
-         * Permissions model is used to cache against.
-         *
-         * Ideally, this should match your preferred way of checking permissions, eg:
-         * `$user->can('view-posts')` would be 'name'.
-         */
-
-        'model_key' => 'name',
-
-        /*
          * You may optionally indicate a specific cache driver to use for permission and
          * role caching using any of the `store` drivers listed in the cache.php config
          * file. Using 'default' here means to use the `default` set in cache.php.

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -163,12 +163,40 @@ class Permission extends Model implements PermissionContract
     }
 
     /**
-     * Set roles for cache load.
+     * Fill model from array.
      *
-     * @param \Illuminate\Database\Eloquent\Collection $roles
+     * @param array $attributes
      */
-    public function setRolesCollection(Collection $roles)
+    protected function fillModelFromArray(array $attributes)
     {
-        $this->relations['roles'] = $roles;
+        if (isset($attributes['roles'])) {
+            $roleClass = app(PermissionRegistrar::class)->getRoleClass();
+            $this->relations['roles'] = new Collection();
+
+            foreach ($attributes['roles'] as $value) {
+                $this->relations['roles']->push($roleClass::getModelFromArray($value));
+            }
+            unset($attributes['roles']);
+        }
+
+        $this->attributes = $attributes;
+        if (isset($attributes['id'])) {
+            $this->exists = true;
+            $this->original['id'] = $attributes['id'];
+        }
+        return $this;
+    }
+
+    /**
+     * Get model from array.
+     *
+     * @param array $attributes
+     *
+     * @return \Spatie\Permission\Contracts\Permission
+     */
+    public static function getModelFromArray(array $attributes): ?PermissionContract
+    {
+        $permission = new static;
+        return $permission->fillModelFromArray($attributes);
     }
 }

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -36,7 +36,7 @@ class Permission extends Model implements PermissionContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
-        $permission = static::getPermissions(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']])->first();
+        $permission = static::getPermission(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']]);
 
         if ($permission) {
             throw PermissionAlreadyExists::create($attributes['name'], $attributes['guard_name']);
@@ -85,7 +85,7 @@ class Permission extends Model implements PermissionContract
     public static function findByName(string $name, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermissions(['name' => $name, 'guard_name' => $guardName])->first();
+        $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
         if (! $permission) {
             throw PermissionDoesNotExist::create($name, $guardName);
         }
@@ -106,7 +106,7 @@ class Permission extends Model implements PermissionContract
     public static function findById(int $id, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermissions(['id' => $id, 'guard_name' => $guardName])->first();
+        $permission = static::getPermission(['id' => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);
@@ -126,7 +126,7 @@ class Permission extends Model implements PermissionContract
     public static function findOrCreate(string $name, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermissions(['name' => $name, 'guard_name' => $guardName])->first();
+        $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $permission) {
             return static::query()->create(['name' => $name, 'guard_name' => $guardName]);
@@ -137,16 +137,35 @@ class Permission extends Model implements PermissionContract
 
     /**
      * Get the current cached permissions.
+     *
+     * @param array $params
+     * @param bool $onlyOne
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
      */
-    protected static function getPermissions(array $params = []): Collection
+    protected static function getPermissions(array $params = [], bool $onlyOne = false): Collection
     {
         return app(PermissionRegistrar::class)
             ->setPermissionClass(static::class)
-            ->getPermissions($params);
+            ->getPermissions($params, $onlyOne);
+    }
+
+    /**
+     * Get the current cached first permission.
+     *
+     * @param array $params
+     *
+     * @return \Spatie\Permission\Contracts\Permission
+     */
+    protected static function getPermission(array $params = []): ?PermissionContract
+    {
+        return static::getPermissions($params, true)->first();
     }
 
     /**
      * Set roles for cache load.
+     *
+     * @param \Illuminate\Database\Eloquent\Collection $roles
      */
     public function setRolesCollection(Collection $roles)
     {

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -144,4 +144,12 @@ class Permission extends Model implements PermissionContract
             ->setPermissionClass(static::class)
             ->getPermissions($params);
     }
+
+    /**
+     * Set roles for cache load.
+     */
+    public function setRolesCollection(Collection $roles)
+    {
+        $this->relations['roles'] = $roles;
+    }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -157,4 +157,32 @@ class Role extends Model implements RoleContract
 
         return $this->permissions->contains('id', $permission->id);
     }
+
+    /**
+     * Fill model from array.
+     *
+     * @param array $attributes
+     */
+    protected function fillModelFromArray(array $attributes)
+    {
+        $this->attributes = $attributes;
+        if (isset($attributes['id'])) {
+            $this->exists = true;
+            $this->original['id'] = $attributes['id'];
+        }
+        return $this;
+    }
+
+    /**
+     * Get model from array.
+     *
+     * @param array $attributes
+     *
+     * @return \Spatie\Permission\Contracts\Role
+     */
+    public static function getModelFromArray(array $attributes): ?RoleContract
+    {
+        $roles = new static;
+        return $roles->fillModelFromArray($attributes);
+    }
 }


### PR DESCRIPTION
**Fully backwards compatible.**
This adds substantial speed increases by making cache smaller on the associations between models and permissions. Part of the changes focus on the `PermissionRegistar`, specifically `getPermissions()`.

@drbyte @freekmurze , i'm really not that immersed on this package, please check this PR, 
~~I have my doubts if the fields `'id', 'name', 'guard_name'` can change by custom fields, but~~ this idea makes everything faster when you have tons of permissions and roles

Closes #1798
Closes #1626

~~maybe, it is necessary to add `if(is_array($this->permissions))` for transition from `Collection` cache, to `array` cache~~, now auto upgrade to array cache after `expiration_time` or after manually `rebuild cache` 

Also, uses `$collection->first(...)` or `$collection->filter(...)` instead of `$collection->where(...); $collection->where(...);` to avoid creating two or more temporary arrays, now stop as soon as a match is found when uses first. This performance improvement is noticeable when they have many permissions