### PR TITLE
Teams/Groups feature

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -87,7 +87,24 @@ return [
          */
 
         'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
     ],
+
+    /*
+     * When set to true the package implements teams using the 'team_foreign_key'. If you want
+     * the migrations to register the 'team_foreign_key', you must set this to true
+     * before doing the migration. If you already did the migration then you must make a new
+     * migration to also add 'team_foreign_key' to 'roles', 'model_has_roles', and
+     * 'model_has_permissions'(view the latest version of package's migration file)
+     */
+
+    'teams' => false,
 
     /*
      * When set to true, the required permission names are added to the exception

--- a/database/migrations/add_teams_fields.php.stub
+++ b/database/migrations/add_teams_fields.php.stub
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTeamsFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+
+        if (! $teams) {
+            return;
+        }
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+        if (empty($columnNames['team_foreign_key'] ?? null)) {
+            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::table($tableNames['roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            if (! Schema::hasColumn($tableNames['roles'], $columnNames['team_foreign_key'])) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+        });
+
+        Schema::table($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            if (! Schema::hasColumn($tableNames['model_has_permissions'], $columnNames['team_foreign_key'])) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->default('1');;
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->dropPrimary();
+                $table->primary([$columnNames['team_foreign_key'], 'permission_id', $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+        });
+
+        Schema::table($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
+            if (! Schema::hasColumn($tableNames['model_has_roles'], $columnNames['team_foreign_key'])) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->default('1');;
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->dropPrimary();
+                $table->primary([$columnNames['team_foreign_key'], 'role_id', $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+}

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -16,9 +16,13 @@ class CreatePermissionTables extends Migration
     {
         $tableNames = config('permission.table_names');
         $columnNames = config('permission.column_names');
+        $teams = config('permission.teams');
 
         if (empty($tableNames)) {
             throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+        if ($teams && empty($columnNames['team_foreign_key'] ?? null)) {
+            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
         }
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
@@ -30,16 +34,23 @@ class CreatePermissionTables extends Migration
             $table->unique(['name', 'guard_name']);
         });
 
-        Schema::create($tableNames['roles'], function (Blueprint $table) {
+        Schema::create($tableNames['roles'], function (Blueprint $table) use ($teams, $columnNames) {
             $table->bigIncrements('id');
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
-
-            $table->unique(['name', 'guard_name']);
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
         });
 
-        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames, $teams) {
             $table->unsignedBigInteger(PermissionRegistrar::$pivotPermission);
 
             $table->string('model_type');
@@ -50,12 +61,20 @@ class CreatePermissionTables extends Migration
                 ->references('id')
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
 
-            $table->primary([PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
         });
 
-        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames, $teams) {
             $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
 
             $table->string('model_type');
@@ -66,9 +85,16 @@ class CreatePermissionTables extends Migration
                 ->references('id')
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
 
-            $table->primary([PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {

--- a/docs/basic-usage/artisan.md
+++ b/docs/basic-usage/artisan.md
@@ -31,6 +31,13 @@ When creating roles you can also create and link permissions at the same time:
 php artisan permission:create-role writer web "create articles|edit articles"
 ```
 
+When creating roles with teams enabled you can set the team id by adding the `--team-id` parameter:
+
+```bash
+php artisan permission:create-role --team-id=1 writer
+php artisan permission:create-role writer api --team-id=1
+```
+
 ## Displaying roles and permissions in the console
 
 There is also a `show` command to show a table of roles and permissions per guard:

--- a/docs/basic-usage/teams-permissions.md
+++ b/docs/basic-usage/teams-permissions.md
@@ -1,0 +1,68 @@
+---
+title: Teams permissions
+weight: 3
+---
+
+NOTE: Those changes must be made before performing the migration. If you have already run the migration and want to upgrade your solution, you can run the artisan console command `php artisan permission:setup-teams`, to create a new migration file named [xxxx_xx_xx_xx_add_teams_fields.php](https://github.com/spatie/laravel-permission/blob/master/database/migrations/add_teams_fields.php.stub) and then run `php artisan migrate` to upgrade your database tables.
+
+When enabled, teams permissions offers you a flexible control for a variety of scenarios. The idea behind teams permissions is inspired by the default permission implementation of [Laratrust](https://laratrust.santigarcor.me/).
+
+
+Teams permissions can be enabled in the permission config file:
+
+```php
+// config/permission.php
+'teams' => true,
+```
+
+Also, if you want to use a custom foreign key for teams you must change in the permission config file:
+```php
+// config/permission.php
+'team_foreign_key' => 'custom_team_id',
+```
+
+## Working with Teams Permissions
+
+After implements on login a solution for select a team on authentication (for example set `team_id` of the current selected team on **session**: `session(['team_id' => $team->team_id]);` ), 
+we can set global `team_id` from anywhere, but works better if you create a `Middleware`, example:
+
+```php
+namespace App\Http\Middleware;
+
+class TeamsPermission{
+    
+    public function handle($request, \Closure $next){
+        if(!empty(auth()->user())){
+            // session value set on login
+            app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(session('team_id'));
+        }
+        // other custom ways to get team_id
+        /*if(!empty(auth('api')->user())){
+            // `getTeamIdFromToken()` example of custom method for getting the set team_id 
+            app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(auth('api')->user()->getTeamIdFromToken());
+        }*/
+        
+        return $next($request);
+    }
+}
+```
+NOTE: You must add your custom `Middleware` to `$middlewarePriority` on `app/Http/Kernel.php`.
+ 
+## Roles Creating
+
+When creating a role you can pass the `team_id` as an optional parameter
+ 
+```php
+// with null team_id it creates a global role, global roles can be used from any team and they are unique
+Role::create(['name' => 'writer', 'team_id' => null]);
+
+// creates a role with team_id = 1, team roles can have the same name on different teams
+Role::create(['name' => 'reader', 'team_id' => 1]);
+
+// creating a role without team_id makes the role take the default global team_id
+Role::create(['name' => 'reviewer']);
+```
+
+## Roles/Permissions Assignment & Removal
+
+The role/permission assignment and removal are the same, but they take the global `team_id` set on login for sync.

--- a/docs/installation-laravel.md
+++ b/docs/installation-laravel.md
@@ -33,6 +33,7 @@ This package can be used with Laravel 6.0 or higher.
     ```
 
 6. NOTE: If you are using UUIDs, see the Advanced section of the docs on UUID steps, before you continue. It explains some changes you may want to make to the migrations and config file before continuing. It also mentions important considerations after extending this package's models for UUID capability.
+    If you are going to use teams feature, you have to update your [`config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/master/config/permission.php) and set `'teams' => true,`, if you want to use a custom foreign key for teams you must change `team_foreign_key`.
 
 7. Clear your config cache. This package requires access to the `permission` config. Generally it's bad practice to do config-caching in a development environment. If you've been caching configurations locally, clear your config cache with either of these commands:
 

--- a/docs/installation-lumen.md
+++ b/docs/installation-lumen.md
@@ -52,6 +52,8 @@ $app->register(App\Providers\AuthServiceProvider::class);
 
 Ensure the application's database name/credentials are set in your `.env` (or `config/database.php` if you have one), and that the database exists.
 
+NOTE: If you are going to use teams feature, you have to update your [`config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/master/config/permission.php) and set `'teams' => true,`, if you want to use a custom foreign key for teams you must change `team_foreign_key`.
+
 Run the migrations to create the tables for this package:
 
 ```bash

--- a/src/Commands/CreatePermission.php
+++ b/src/Commands/CreatePermission.php
@@ -19,6 +19,6 @@ class CreatePermission extends Command
 
         $permission = $permissionClass::findOrCreate($this->argument('name'), $this->argument('guard'));
 
-        $this->info("Permission `{$permission->name}` created");
+        $this->info("Permission `{$permission->name}` ".($permission->wasRecentlyCreated ? 'created' : 'already exists'));
     }
 }

--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -5,13 +5,15 @@ namespace Spatie\Permission\Commands;
 use Illuminate\Console\Command;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Contracts\Role as RoleContract;
+use Spatie\Permission\PermissionRegistrar;
 
 class CreateRole extends Command
 {
     protected $signature = 'permission:create-role
         {name : The name of the role}
         {guard? : The name of the guard}
-        {permissions? : A list of permissions to assign to the role, separated by | }';
+        {permissions? : A list of permissions to assign to the role, separated by | }
+        {--team-id=}';
 
     protected $description = 'Create a role';
 
@@ -19,11 +21,25 @@ class CreateRole extends Command
     {
         $roleClass = app(RoleContract::class);
 
+        $teamIdAux = app(PermissionRegistrar::class)->getPermissionsTeamId();
+        app(PermissionRegistrar::class)->setPermissionsTeamId($this->option('team-id') ?: null);
+
+        if (! PermissionRegistrar::$teams && $this->option('team-id')) {
+            $this->warn("Teams feature disabled, argument --team-id has no effect. Either enable it in permissions config file or remove --team-id parameter");
+            return;
+        }
+
         $role = $roleClass::findOrCreate($this->argument('name'), $this->argument('guard'));
+        app(PermissionRegistrar::class)->setPermissionsTeamId($teamIdAux);
+
+        $teams_key = PermissionRegistrar::$teamsKey;
+        if (PermissionRegistrar::$teams && $this->option('team-id') && is_null($role->$teams_key)) {
+            $this->warn("Role `{$role->name}` already exists on the global team; argument --team-id has no effect");
+        }
 
         $role->givePermissionTo($this->makePermissions($this->argument('permissions')));
 
-        $this->info("Role `{$role->name}` created");
+        $this->info("Role `{$role->name}` ".($role->wasRecentlyCreated ? 'created' : 'updated'));
     }
 
     /**

--- a/src/Commands/Show.php
+++ b/src/Commands/Show.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Contracts\Role as RoleContract;
+use Symfony\Component\Console\Helper\TableCell;
 
 class Show extends Command
 {
@@ -19,6 +20,7 @@ class Show extends Command
     {
         $permissionClass = app(PermissionContract::class);
         $roleClass = app(RoleContract::class);
+        $team_key = config('permission.column_names.team_foreign_key');
 
         $style = $this->argument('style') ?? 'default';
         $guard = $this->argument('guard');
@@ -32,20 +34,37 @@ class Show extends Command
         foreach ($guards as $guard) {
             $this->info("Guard: $guard");
 
-            $roles = $roleClass::whereGuardName($guard)->orderBy('name')->get()->mapWithKeys(function ($role) {
-                return [$role->name => $role->permissions->pluck('name')];
-            });
+            $roles = $roleClass::whereGuardName($guard)
+                ->when(config('permission.teams'), function ($q) use ($team_key) {
+                    $q->orderBy($team_key);
+                })
+                ->orderBy('name')->get()->mapWithKeys(function ($role) use ($team_key) {
+                    return [$role->name.'_'.($role->$team_key ?: '') => ['permissions' => $role->permissions->pluck('id'), $team_key => $role->$team_key ]];
+                });
 
-            $permissions = $permissionClass::whereGuardName($guard)->orderBy('name')->pluck('name');
+            $permissions = $permissionClass::whereGuardName($guard)->orderBy('name')->pluck('name', 'id');
 
-            $body = $permissions->map(function ($permission) use ($roles) {
-                return $roles->map(function (Collection $role_permissions) use ($permission) {
-                    return $role_permissions->contains($permission) ? ' ✔' : ' ·';
+            $body = $permissions->map(function ($permission, $id) use ($roles) {
+                return $roles->map(function (array $role_data) use ($id) {
+                    return $role_data['permissions']->contains($id) ? ' ✔' : ' ·';
                 })->prepend($permission);
             });
 
+            if (config('permission.teams')) {
+                $teams = $roles->groupBy($team_key)->values()->map(function ($group, $id) {
+                    return new TableCell('Team ID: '.($id ?: 'NULL'), ['colspan' => $group->count()]);
+                });
+            }
+
             $this->table(
-                $roles->keys()->prepend('')->toArray(),
+                array_merge([
+                    config('permission.teams') ? $teams->prepend('')->toArray() : [],
+                    $roles->keys()->map(function ($val) {
+                        $name = explode('_', $val);
+                        return $name[0];
+                    })
+                    ->prepend('')->toArray()
+                ]),
                 $body->toArray(),
                 $style
             );

--- a/src/Commands/UpgradeForTeams.php
+++ b/src/Commands/UpgradeForTeams.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Spatie\Permission\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+
+class UpgradeForTeams extends Command
+{
+
+    protected $signature = 'permission:setup-teams';
+
+    protected $description = 'Setup the teams feature by generating the associated migration.';
+
+    protected $migrationSuffix = 'add_teams_fields.php';
+
+    public function handle()
+    {
+        if (!Config::get('permission.teams')) {
+            $this->error('Teams feature is disabled in your permission.php file.');
+            $this->warn('Please enable the teams setting in your configuration.');
+            return;
+        }
+
+        $this->line('');
+        $this->info("The teams feature setup is going to add a migration and a model");
+
+        $existingMigrations = $this->alreadyExistingMigrations();
+
+        if ($existingMigrations) {
+            $this->line('');
+
+            $this->warn($this->getExistingMigrationsWarning($existingMigrations));
+        }
+
+        $this->line('');
+
+        if (! $this->confirm("Proceed with the migration creation?", "yes")) {
+            return;
+        }
+
+        $this->line('');
+
+        $this->line("Creating migration");
+
+        if ($this->createMigration()) {
+            $this->info("Migration created successfully.");
+        } else {
+            $this->error(
+                "Couldn't create migration.\n".
+                "Check the write permissions within the database/migrations directory."
+            );
+        }
+
+        $this->line('');
+    }
+
+    /**
+     * Create the migration.
+     *
+     * @return bool
+     */
+    protected function createMigration()
+    {
+        try {
+            $migrationStub = __DIR__."/../../database/migrations/{$this->migrationSuffix}.stub";
+            copy($migrationStub, $this->getMigrationPath());
+            return true;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Build a warning regarding possible duplication
+     * due to already existing migrations.
+     *
+     * @param  array $existingMigrations
+     * @return string
+     */
+    protected function getExistingMigrationsWarning(array $existingMigrations)
+    {
+        if (count($existingMigrations) > 1) {
+            $base = "Setup teams migrations already exist.\nFollowing files were found: ";
+        } else {
+            $base = "Setup teams migration already exists.\nFollowing file was found: ";
+        }
+
+        return $base . array_reduce($existingMigrations, function ($carry, $fileName) {
+            return $carry . "\n - " . $fileName;
+        });
+    }
+
+    /**
+     * Check if there is another migration
+     * with the same suffix.
+     *
+     * @return array
+     */
+    protected function alreadyExistingMigrations()
+    {
+        $matchingFiles = glob($this->getMigrationPath('*'));
+
+        return array_map(function ($path) {
+            return basename($path);
+        }, $matchingFiles);
+    }
+
+    /**
+     * Get the migration path.
+     *
+     * The date parameter is optional for ability
+     * to provide a custom value or a wildcard.
+     *
+     * @param  string|null $date
+     * @return string
+     */
+    protected function getMigrationPath($date = null)
+    {
+        $date = $date ?: date('Y_m_d_His');
+
+        return database_path("migrations/${date}_{$this->migrationSuffix}");
+    }
+}

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -35,6 +35,15 @@ class PermissionRegistrar
     /** @var \DateInterval|int */
     public static $cacheExpirationTime;
 
+    /** @var bool */
+    public static $teams;
+
+    /** @var string */
+    public static $teamsKey;
+
+    /** @var int */
+    protected $teamId = null;
+
     /** @var string */
     public static $cacheKey;
 
@@ -55,6 +64,9 @@ class PermissionRegistrar
     public function initializeCache()
     {
         self::$cacheExpirationTime = config('permission.cache.expiration_time') ?: \DateInterval::createFromDateString('24 hours');
+
+        self::$teams = config('permission.teams', false);
+        self::$teamsKey = config('permission.column_names.team_foreign_key');
 
         self::$cacheKey = config('permission.cache.key');
 
@@ -81,6 +93,21 @@ class PermissionRegistrar
         }
 
         return $this->cacheManager->store($cacheDriver);
+    }
+
+    /**
+     * Set the team id for teams/groups support, this id is used when querying permissions/roles
+     *
+     * @param int $id
+     */
+    public function setPermissionsTeamId(?int $id)
+    {
+        $this->teamId = $id;
+    }
+
+    public function getPermissionsTeamId(): ?int
+    {
+        return $this->teamId;
     }
 
     /**

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -63,6 +63,7 @@ class PermissionServiceProvider extends ServiceProvider
             Commands\CreateRole::class,
             Commands\CreatePermission::class,
             Commands\Show::class,
+            Commands\UpgradeForTeams::class,
         ]);
     }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -5,6 +5,7 @@ namespace Spatie\Permission\Traits;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
+use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -39,13 +40,24 @@ trait HasRoles
      */
     public function roles(): BelongsToMany
     {
+        $model_has_roles = config('permission.table_names.model_has_roles');
         return $this->morphToMany(
             config('permission.models.role'),
             'model',
-            config('permission.table_names.model_has_roles'),
+            $model_has_roles,
             config('permission.column_names.model_morph_key'),
             PermissionRegistrar::$pivotRole
-        );
+        )
+        ->where(function ($q) use ($model_has_roles) {
+            $q->when(PermissionRegistrar::$teams, function ($q) use ($model_has_roles) {
+                $teamId = app(PermissionRegistrar::class)->getPermissionsTeamId();
+                $q->where($model_has_roles.'.'.PermissionRegistrar::$teamsKey, $teamId)
+                    ->where(function ($q) use ($teamId) {
+                        $teamField = config('permission.table_names.roles').'.'.PermissionRegistrar::$teamsKey;
+                        $q->whereNull($teamField)->orWhere($teamField, $teamId);
+                    });
+            });
+        });
     }
 
     /**
@@ -107,13 +119,21 @@ trait HasRoles
             ->each(function ($role) {
                 $this->ensureModelSharesGuard($role);
             })
-            ->map->id
-            ->all();
+            ->map(function ($role) {
+                return ['id' => $role->id, 'values' => PermissionRegistrar::$teams && !is_a($this, Permission::class) ?
+                    [PermissionRegistrar::$teamsKey => app(PermissionRegistrar::class)->getPermissionsTeamId()] : []
+                ];
+            })
+            ->pluck('values', 'id')->toArray();
 
         $model = $this->getModel();
 
         if ($model->exists) {
-            $this->roles()->sync($roles, false);
+            if (PermissionRegistrar::$teams && !is_a($this, Permission::class)) {
+                $this->roles()->wherePivot(PermissionRegistrar::$teamsKey, app(PermissionRegistrar::class)->getPermissionsTeamId())->sync($roles, false);
+            } else {
+                $this->roles()->sync($roles, false);
+            }
             $model->load('roles');
         } else {
             $class = \get_class($model);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,3 +18,14 @@ if (! function_exists('getModelForGuard')) {
             })->get($guard);
     }
 }
+
+if (! function_exists('setPermissionsTeamId')) {
+    /**
+     * @param int $id
+     *
+     */
+    function setPermissionsTeamId(int $id)
+    {
+        app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId($id);
+    }
+}

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -516,8 +516,8 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo('edit-news', 'edit-articles');
         $this->assertEquals(
-            collect(['edit-news', 'edit-articles']),
-            $this->testUser->getPermissionNames()
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getPermissionNames()->sort()->values()
         );
     }
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -568,7 +568,7 @@ class HasRolesTest extends TestCase
 
         $this->assertEquals(
             collect(['testRole', 'testRole2']),
-            $this->testUser->getRoleNames()
+            $this->testUser->getRoleNames()->sort()->values()
         );
     }
 

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+class TeamHasPermissionsTest extends HasPermissionsTest
+{
+    /** @var bool */
+    protected $hasTeams=true;
+
+
+    /** @test */
+    public function it_can_assign_same_and_different_permission_on_same_user_on_different_teams()
+    {
+        $this->setPermissionsTeamId(1);
+        $this->testUser->load('permissions');
+        $this->testUser->givePermissionTo('edit-articles', 'edit-news');
+
+        $this->setPermissionsTeamId(2);
+        $this->testUser->load('permissions');
+        $this->testUser->givePermissionTo('edit-articles', 'edit-blog');
+
+        $this->setPermissionsTeamId(1);
+        $this->testUser->load('permissions');
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getPermissionNames()->sort()->values()
+        );
+        $this->assertTrue($this->testUser->hasAllDirectPermissions(['edit-articles', 'edit-news']));
+        $this->assertFalse($this->testUser->hasAllDirectPermissions(['edit-articles', 'edit-blog']));
+
+        $this->setPermissionsTeamId(2);
+        $this->testUser->load('permissions');
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-blog']),
+            $this->testUser->getPermissionNames()->sort()->values()
+        );
+        $this->assertTrue($this->testUser->hasAllDirectPermissions(['edit-articles', 'edit-blog']));
+        $this->assertFalse($this->testUser->hasAllDirectPermissions(['edit-articles', 'edit-news']));
+    }
+
+    /** @test */
+    public function it_can_list_all_the_coupled_permissions_both_directly_and_via_roles_on_same_user_on_different_teams()
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
+
+        $this->setPermissionsTeamId(1);
+        $this->testUser->load('permissions');
+        $this->testUser->assignRole('testRole');
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->setPermissionsTeamId(2);
+        $this->testUser->load('permissions');
+        $this->testUser->assignRole('testRole');
+        $this->testUser->givePermissionTo('edit-blog');
+
+        $this->setPermissionsTeamId(1);
+        $this->testUser->load('roles');
+        $this->testUser->load('permissions');
+
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-news']),
+            $this->testUser->getAllPermissions()->pluck('name')->sort()->values()
+        );
+
+        $this->setPermissionsTeamId(2);
+        $this->testUser->load('roles');
+        $this->testUser->load('permissions');
+
+        $this->assertEquals(
+            collect(['edit-articles', 'edit-blog']),
+            $this->testUser->getAllPermissions()->pluck('name')->sort()->values()
+        );
+    }
+}

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Contracts\Role;
+
+class TeamHasRolesTest extends HasRolesTest
+{
+    /** @var bool */
+    protected $hasTeams=true;
+
+    /** @test */
+    public function it_can_assign_same_and_different_roles_on_same_user_different_teams()
+    {
+        app(Role::class)->create(['name' => 'testRole3']); //team_test_id = 1 by main class
+        app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
+        app(Role::class)->create(['name' => 'testRole4', 'team_test_id' => null]); //global role
+
+        $testRole3Team1 = app(Role::class)->where(['name' => 'testRole3', 'team_test_id' => 1])->first();
+        $testRole3Team2 = app(Role::class)->where(['name' => 'testRole3', 'team_test_id' => 2])->first();
+        $testRole4NoTeam = app(Role::class)->where(['name' => 'testRole4', 'team_test_id' => null])->first();
+        $this->assertNotNull($testRole3Team1);
+        $this->assertNotNull($testRole4NoTeam);
+
+        $this->setPermissionsTeamId(1);
+        $this->testUser->load('roles');
+
+        $this->testUser->assignRole('testRole', 'testRole2');
+
+        $this->setPermissionsTeamId(2);
+        $this->testUser->load('roles');
+
+        $this->testUser->assignRole('testRole', 'testRole3');
+
+        $this->setPermissionsTeamId(1);
+        $this->testUser->load('roles');
+
+        $this->assertEquals(
+            collect(['testRole', 'testRole2']),
+            $this->testUser->getRoleNames()->sort()->values()
+        );
+        $this->assertTrue($this->testUser->hasExactRoles(['testRole', 'testRole2']));
+
+        $this->testUser->assignRole('testRole3', 'testRole4');
+        $this->assertTrue($this->testUser->hasExactRoles(['testRole', 'testRole2', 'testRole3', 'testRole4']));
+        $this->assertTrue($this->testUser->hasRole($testRole3Team1)); //testRole3 team=1
+        $this->assertTrue($this->testUser->hasRole($testRole4NoTeam)); // global role team=null
+
+        $this->setPermissionsTeamId(2);
+        $this->testUser->load('roles');
+
+        $this->assertEquals(
+            collect(['testRole', 'testRole3']),
+            $this->testUser->getRoleNames()->sort()->values()
+        );
+        $this->assertTrue($this->testUser->hasExactRoles(['testRole', 'testRole3']));
+        $this->assertTrue($this->testUser->hasRole($testRole3Team2)); //testRole3 team=2
+        $this->testUser->assignRole('testRole4');
+        $this->assertTrue($this->testUser->hasExactRoles(['testRole', 'testRole3', 'testRole4']));
+        $this->assertTrue($this->testUser->hasRole($testRole4NoTeam)); // global role team=null
+    }
+}


### PR DESCRIPTION
##TEAMS FEATURE
-------
**Usage in [docs](https://github.com/erikn69/laravel-permission/blob/teams_feature/docs/basic-usage/teams-permissions.md)**

A **fully backwards compatible** addition to for teams/groups functionality.  I have added the tests and docs for this PR, and i can help to bug's review around it. I have been using this code overriding the methods with custom models for 2 years without problems, now i want to share with everyone.

Teams table must be already migrated on db, and foreign key can be customizable by config file. `team_id` as default. ~~Also, i can improve the upgrade method with another `migration` if necessary~~ (done, added upgrade migration and command `setup-teams`, roles with teams support on command `create-role`).

**Example Communities #1782**:
```php
'teams' => true,
/*
  * Change this if you want to use teams feature and your related model
  * foreign key are other than `team_id`.
  */
'team_foreign_key' => 'community_id',

```
![image](https://user-images.githubusercontent.com/4933954/128248276-a9568a5c-affa-46d8-adb6-979347919ec9.png)
Where green tables(`users`, `community_user`, and `communities`) are handled by custom migrations. Only new pivot `community_id` is added to the package migration file.

Closes #1812
Closes #1782
Closes #1743
Closes #1744
Closes #1654
Closes #1629
Closes #1634
Closes #1499
Closes #1362
Closes #1353
Closes #1348
Closes #1187
Closes #1186
Closes #1135
Closes #1067
Closes #551
Closes #540
Closes #8
And many others

##BUGS FIX
-------
~~On tests `*_before_saving_object_doesnt_interfere_with_other_objects`, sqls from first object are executing on second object and try to sync and load relation again~~(#1819)

And other small fixes that i already forget