### PR TITLE
- Added load migration method to service provider boot

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -28,6 +28,8 @@ class PermissionServiceProvider extends ServiceProvider
         $this->app->singleton(PermissionRegistrar::class, function ($app) use ($permissionLoader) {
             return $permissionLoader;
         });
+
+        $this->loadMigrationsFrom([__DIR__ . '/../database/migrations']);
     }
 
     public function register()


### PR DESCRIPTION
Hi, with this you don't need to publish migrations for using it. Laravel will migrate it without any publish needed.