### PR TITLE
Change default-guard-lookup to prefer current user's guard

### DIFF
--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -529,4 +529,40 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($this->testUser->hasAnyDirectPermission('edit-news', 'edit-blog'));
         $this->assertFalse($this->testUser->hasAnyDirectPermission('edit-blog', 'Edit News', ['Edit News']));
     }
+
+    /** @test */
+    public function it_can_check_permission_based_on_logged_in_user_guard()
+    {
+        $this->testUser->givePermissionTo(app(Permission::class)::create([
+             'name' => 'do_that',
+             'guard_name' => 'api',
+         ]));
+        $response = $this->actingAs($this->testUser, 'api')
+             ->json('GET', '/check-api-guard-permission');
+        $response->assertJson([
+             'status' => true,
+         ]);
+    }
+
+    /** @test */
+    public function it_can_reject_permission_based_on_logged_in_user_guard()
+    {
+        $unassignedPermission = app(Permission::class)::create([
+             'name' => 'do_that',
+             'guard_name' => 'api',
+         ]);
+
+        $assignedPermission = app(Permission::class)::create([
+             'name' => 'do_that',
+             'guard_name' => 'web',
+         ]);
+
+        $this->testUser->givePermissionTo($assignedPermission);
+        $response = $this->withExceptionHandling()
+             ->actingAs($this->testUser, 'api')
+             ->json('GET', '/check-api-guard-permission');
+        $response->assertJson([
+             'status' => false,
+         ]);
+    }
 }

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -35,36 +35,36 @@ class PermissionMiddlewareTest extends TestCase
     {
         // These permissions are created fresh here in reverse order of guard being applied, so they are not "found first" in the db lookup when matching
         app(Permission::class)->create(['name' => 'admin-permission2', 'guard_name' => 'web']);
-        app(Permission::class)->create(['name' => 'admin-permission2', 'guard_name' => 'admin']);
+        $p1 = app(Permission::class)->create(['name' => 'admin-permission2', 'guard_name' => 'admin']);
         app(Permission::class)->create(['name' => 'edit-articles2', 'guard_name' => 'admin']);
-        app(Permission::class)->create(['name' => 'edit-articles2', 'guard_name' => 'web']);
+        $p2 = app(Permission::class)->create(['name' => 'edit-articles2', 'guard_name' => 'web']);
 
-        Auth::login($this->testAdmin);
+        Auth::guard('admin')->login($this->testAdmin);
 
-        $this->testAdmin->givePermissionTo('admin-permission2');
+        $this->testAdmin->givePermissionTo($p1);
 
         $this->assertEquals(
             200,
-            $this->runMiddleware($this->permissionMiddleware, 'admin-permission2')
+            $this->runMiddleware($this->permissionMiddleware, 'admin-permission2', 'admin')
         );
 
         $this->assertEquals(
             403,
-            $this->runMiddleware($this->permissionMiddleware, 'edit-articles2')
+            $this->runMiddleware($this->permissionMiddleware, 'edit-articles2', 'admin')
         );
 
         Auth::login($this->testUser);
 
-        $this->testUser->givePermissionTo('edit-articles2');
+        $this->testUser->givePermissionTo($p2);
 
         $this->assertEquals(
             200,
-            $this->runMiddleware($this->permissionMiddleware, 'edit-articles2')
+            $this->runMiddleware($this->permissionMiddleware, 'edit-articles2', 'web')
         );
 
         $this->assertEquals(
             403,
-            $this->runMiddleware($this->permissionMiddleware, 'admin-permission2')
+            $this->runMiddleware($this->permissionMiddleware, 'admin-permission2', 'web')
         );
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,9 @@
 namespace Spatie\Permission\Test;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Permission\Contracts\Permission;
@@ -45,6 +47,8 @@ abstract class TestCase extends Orchestra
         $this->testAdmin = Admin::first();
         $this->testAdminRole = app(Role::class)->find(3);
         $this->testAdminPermission = app(Permission::class)->find(4);
+
+        $this->setUpRoutes();
     }
 
     /**
@@ -140,6 +144,18 @@ abstract class TestCase extends Orchestra
             $table->string('key')->unique();
             $table->text('value');
             $table->integer('expiration');
+        });
+    }
+
+    /**
+     * Create routes to test authentication with guards.
+     */
+    public function setUpRoutes(): void
+    {
+        Route::middleware('auth:api')->get('/check-api-guard-permission', function (Request $request) {
+            return [
+                 'status' => $request->user()->hasPermissionTo('do_that'),
+             ];
         });
     }
 }


### PR DESCRIPTION
Historically, since v2.0.0, the "detected guard_name" that was applied during lookups was detected from the "first possible defined guard" for that model, even if the "current" guard wasn't "first in the list".
This has led to some confusion when expecting that the current user's guard would actually be used.

This PR changes things to **use the current user's guard** first, assuming it's in the list of potential guards acceptable for the current User model.
After that it will fallback to the old behavior of selecting the first available matchable guard for the current User model.

**THIS IS A BREAKING CHANGE, so be sure to test all authorization aspects of your application to ensure desired behavior.**
You MAY also be able to remove some old complex monkey-patching that you might have done to work around this issue in prior versions.

Fixes #1682
Fixes #1608
Fixes #1384
Fixes #1515
Fixes #1516
Fixes #1793 

Old refs: #298, #274, https://github.com/spatie/laravel-permission/issues/276#issuecomment-301477726