### PR TITLE
Avoid sync again other objects on Eloquent::saved

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -348,6 +348,9 @@ trait HasPermissions
 
             $class::saved(
                 function ($object) use ($permissions, $model) {
+                    if ($model->getKey() != $object->getKey()) {
+                       return;
+                    }
                     $model->permissions()->sync($permissions, false);
                     $model->load('permissions');
                 }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -120,6 +120,9 @@ trait HasRoles
 
             $class::saved(
                 function ($object) use ($roles, $model) {
+                    if ($model->getKey() != $object->getKey()) {
+                       return;
+                    }
                     $model->roles()->sync($roles, false);
                     $model->load('roles');
                 }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -474,13 +474,18 @@ class HasPermissionsTest extends TestCase
 
         $user2 = new User(['email' => 'test2@user.com']);
         $user2->givePermissionTo('edit-articles');
+
+        \DB::enableQueryLog();
         $user2->save();
+        $querys = \DB::getQueryLog();
+        \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
         $this->assertFalse($user->fresh()->hasPermissionTo('edit-articles'));
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
+        $this->assertSame(4, count($querys)); //avoid unnecessary sync
     }
 
     /** @test */
@@ -492,13 +497,18 @@ class HasPermissionsTest extends TestCase
 
         $user2 = new User(['email' => 'test2@user.com']);
         $user2->syncPermissions('edit-articles');
+
+        \DB::enableQueryLog();
         $user2->save();
+        $querys = \DB::getQueryLog();
+        \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
         $this->assertFalse($user->fresh()->hasPermissionTo('edit-articles'));
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
+        $this->assertSame(4, count($querys)); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -245,13 +245,18 @@ class HasRolesTest extends TestCase
 
         $user2 = new User(['email' => 'admin@user.com']);
         $user2->syncRoles('testRole2');
+
+        \DB::enableQueryLog();
         $user2->save();
+        $querys = \DB::getQueryLog();
+        \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasRole('testRole'));
         $this->assertFalse($user->fresh()->hasRole('testRole2'));
 
         $this->assertTrue($user2->fresh()->hasRole('testRole2'));
         $this->assertFalse($user2->fresh()->hasRole('testRole'));
+        $this->assertSame(4, count($querys)); //avoid unnecessary sync
     }
 
     /** @test */
@@ -263,13 +268,18 @@ class HasRolesTest extends TestCase
 
         $admin_user = new User(['email' => 'admin@user.com']);
         $admin_user->assignRole('testRole2');
+
+        \DB::enableQueryLog();
         $admin_user->save();
+        $querys = \DB::getQueryLog();
+        \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasRole('testRole'));
         $this->assertFalse($user->fresh()->hasRole('testRole2'));
 
         $this->assertTrue($admin_user->fresh()->hasRole('testRole2'));
         $this->assertFalse($admin_user->fresh()->hasRole('testRole'));
+        $this->assertSame(4, count($querys)); //avoid unnecessary sync
     }
 
     /** @test */


### PR DESCRIPTION
Sorry, the bugs were appearing while I was doing the other PR

On tests `*_before_saving_object_doesnt_interfere_with_other_objects`, sqls from first object are executing on second object and try to sync and load relation again

**First `->save()`:**
```sql
select * from "roles" where "name" = 'testRole' and "guard_name" = 'web' limit 1
insert into "users" ("email") values ('test@user.com')
select * from "model_has_roles" where "model_has_roles"."model_test_id" = 2 and ////....
insert into "model_has_roles" ("model_test_id", "model_type", "role_id") values (2, 'Spatie\Permission\Test\User', 1)
```

**Second `->save()`:**
Actual
```sql
select * from "roles" where "name" = 'testRole2' and "guard_name" = 'web' limit 1
insert into "users" ("email") values ('admin@user.com')
select * from "model_has_roles" where "model_has_roles"."model_test_id" = 2 and "m/// first object sql
select "id", "name", "guard_name", "model_has_roles"."model_test_id" as "pivot_model_test_id"// first object sql
select * from "model_has_roles" where "model_has_roles"."model_test_id" = 3 and "m///////......
insert into "model_has_roles" ("model_test_id", "model_type", "role_id") values (3, 'Spatie\Permission\Test\User', 2)
```
Expected
```sql
select * from "roles" where "name" = 'testRole2' and "guard_name" = 'web' limit 1
insert into "users" ("email") values ('admin@user.com')
select * from "model_has_roles" where "model_has_roles"."model_test_id" = 3 and "m
insert into "model_has_roles" ("model_test_id", "model_type", "role_id") values (3, 'Spatie\Permission\Test\User', 2)
```
`FIX`: Match ids on `$class::saved`
```php
$class::saved(
    function ($object) use ($roles, $model) {
        if ($model->getKey() != $object->getKey()) {
           return;
        }
```