### PR TITLE
Customized pivots instead of `role_id`,`permission_id`

### DIFF
--- a/.github/workflows/run-tests-L7.yml
+++ b/.github/workflows/run-tests-L7.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [8.0, 7.4, 7.3, 7.2]
         laravel: [7.*, 6.*]
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/run-tests-L8.yml
+++ b/.github/workflows/run-tests-L8.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [8.0, 7.4, 7.3]
         laravel: [8.*]
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/config/permission.php
+++ b/config/permission.php
@@ -72,6 +72,11 @@ return [
     ],
 
     'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, //default 'role_id',
+        'permission_pivot_key' => null, //default 'permission_id',
 
         /*
          * Change this if you want to name the related model primary key other than

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\PermissionRegistrar;
 
 class CreatePermissionTables extends Migration
 {
@@ -39,52 +40,52 @@ class CreatePermissionTables extends Migration
         });
 
         Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
-            $table->unsignedBigInteger('permission_id');
+            $table->unsignedBigInteger(PermissionRegistrar::$pivotPermission);
 
             $table->string('model_type');
             $table->unsignedBigInteger($columnNames['model_morph_key']);
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
 
-            $table->foreign('permission_id')
+            $table->foreign(PermissionRegistrar::$pivotPermission)
                 ->references('id')
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->primary(['permission_id', $columnNames['model_morph_key'], 'model_type'],
+            $table->primary([PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_permissions_permission_model_type_primary');
         });
 
         Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
-            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
 
             $table->string('model_type');
             $table->unsignedBigInteger($columnNames['model_morph_key']);
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
 
-            $table->foreign('role_id')
+            $table->foreign(PermissionRegistrar::$pivotRole)
                 ->references('id')
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->primary(['role_id', $columnNames['model_morph_key'], 'model_type'],
+            $table->primary([PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary');
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
-            $table->unsignedBigInteger('permission_id');
-            $table->unsignedBigInteger('role_id');
+            $table->unsignedBigInteger(PermissionRegistrar::$pivotPermission);
+            $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
 
-            $table->foreign('permission_id')
+            $table->foreign(PermissionRegistrar::$pivotPermission)
                 ->references('id')
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->foreign('role_id')
+            $table->foreign(PermissionRegistrar::$pivotRole)
                 ->references('id')
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->primary(['permission_id', 'role_id'], 'role_has_permissions_permission_id_role_id_primary');
+            $table->primary([PermissionRegistrar::$pivotPermission, PermissionRegistrar::$pivotRole], 'role_has_permissions_permission_id_role_id_primary');
         });
 
         app('cache')

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -53,8 +53,8 @@ class Permission extends Model implements PermissionContract
         return $this->belongsToMany(
             config('permission.models.role'),
             config('permission.table_names.role_has_permissions'),
-            'permission_id',
-            'role_id'
+            PermissionRegistrar::$pivotPermission,
+            PermissionRegistrar::$pivotRole
         );
     }
 
@@ -67,7 +67,7 @@ class Permission extends Model implements PermissionContract
             getModelForGuard($this->attributes['guard_name']),
             'model',
             config('permission.table_names.model_has_permissions'),
-            'permission_id',
+            PermissionRegistrar::$pivotPermission,
             config('permission.column_names.model_morph_key')
         );
     }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -9,6 +9,7 @@ use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Guard;
+use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 
@@ -50,8 +51,8 @@ class Role extends Model implements RoleContract
         return $this->belongsToMany(
             config('permission.models.permission'),
             config('permission.table_names.role_has_permissions'),
-            'role_id',
-            'permission_id'
+            PermissionRegistrar::$pivotRole,
+            PermissionRegistrar::$pivotPermission
         );
     }
 
@@ -64,7 +65,7 @@ class Role extends Model implements RoleContract
             getModelForGuard($this->attributes['guard_name']),
             'model',
             config('permission.table_names.model_has_roles'),
-            'role_id',
+            PermissionRegistrar::$pivotRole,
             config('permission.column_names.model_morph_key')
         );
     }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -26,6 +26,12 @@ class PermissionRegistrar
     /** @var \Illuminate\Database\Eloquent\Collection */
     protected $permissions;
 
+    /** @var string */
+    public static $pivotRole;
+
+    /** @var string */
+    public static $pivotPermission;
+
     /** @var \DateInterval|int */
     public static $cacheExpirationTime;
 
@@ -51,6 +57,9 @@ class PermissionRegistrar
         self::$cacheExpirationTime = config('permission.cache.expiration_time') ?: \DateInterval::createFromDateString('24 hours');
 
         self::$cacheKey = config('permission.cache.key');
+
+        self::$pivotRole = config('permission.column_names.role_pivot_key') ?: 'role_id';
+        self::$pivotPermission = config('permission.column_names.permission_pivot_key') ?: 'permission_id';
 
         $this->cache = $this->getCacheStoreFromConfig();
     }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -47,7 +47,7 @@ trait HasPermissions
             'model',
             config('permission.table_names.model_has_permissions'),
             config('permission.column_names.model_morph_key'),
-            'permission_id'
+            PermissionRegistrar::$pivotPermission
         );
     }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -44,7 +44,7 @@ trait HasRoles
             'model',
             config('permission.table_names.model_has_roles'),
             config('permission.column_names.model_morph_key'),
-            'role_id'
+            PermissionRegistrar::$pivotRole
         );
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -72,7 +72,8 @@ abstract class TestCase extends Orchestra
             'database' => ':memory:',
             'prefix' => '',
         ]);
-
+        $app['config']->set('permission.column_names.role_pivot_key', 'role_test_id');
+        $app['config']->set('permission.column_names.permission_pivot_key', 'permission_test_id');
         $app['config']->set('view.paths', [__DIR__.'/resources/views']);
 
         // Set-up admin guard


### PR DESCRIPTION
Acordding #1805 (**How I implement "Spatie/laravel-permission" in a completed project**)

>How would I implement the spatie/laravel-permission in a project that I already have almost complete? I only need to define the permissions of the roles.
>I already have the role, permission and user tables, their relationships and their columns defined (with another name), I don't need to run the library migration

A **fully backwards compatible** addition that allows you to customize the pivots, by default will be `role_id`,`permission_id`