### PR TITLE
No longer flush cache on User role/perm assignment changes

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -371,7 +371,9 @@ trait HasPermissions
             );
         }
 
-        $this->forgetCachedPermissions();
+        if (is_a($this, get_class(app(PermissionRegistrar::class)->getRoleClass()))) {
+            $this->forgetCachedPermissions();
+        }
 
         return $this;
     }
@@ -401,7 +403,9 @@ trait HasPermissions
     {
         $this->permissions()->detach($this->getStoredPermission($permission));
 
-        $this->forgetCachedPermissions();
+        if (is_a($this, get_class(app(PermissionRegistrar::class)->getRoleClass()))) {
+            $this->forgetCachedPermissions();
+        }
 
         $this->load('permissions');
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -150,7 +150,9 @@ trait HasRoles
             );
         }
 
-        $this->forgetCachedPermissions();
+        if (is_a($this, get_class($this->getPermissionClass()))) {
+            $this->forgetCachedPermissions();
+        }
 
         return $this;
     }
@@ -166,7 +168,9 @@ trait HasRoles
 
         $this->load('roles');
 
-        $this->forgetCachedPermissions();
+        if (is_a($this, get_class($this->getPermissionClass()))) {
+            $this->forgetCachedPermissions();
+        }
 
         return $this;
     }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -104,13 +104,57 @@ class CacheTest extends TestCase
     }
 
     /** @test */
-    public function it_flushes_the_cache_when_removing_a_role_from_a_user()
+    public function removing_a_permission_from_a_user_should_not_flush_the_cache()
+    {
+        $this->testUser->givePermissionTo('edit-articles');
+
+        $this->registrar->getPermissions();
+
+        $this->testUser->revokePermissionTo('edit-articles');
+
+        $this->resetQueryCount();
+
+        $this->registrar->getPermissions();
+
+        $this->assertQueryCount(0);
+    }
+
+    /** @test */
+    public function removing_a_role_from_a_user_should_not_flush_the_cache()
     {
         $this->testUser->assignRole('testRole');
 
         $this->registrar->getPermissions();
 
         $this->testUser->removeRole('testRole');
+
+        $this->resetQueryCount();
+
+        $this->registrar->getPermissions();
+
+        $this->assertQueryCount(0);
+    }
+
+    /** @test */
+    public function it_flushes_the_cache_when_removing_a_role_from_a_permission()
+    {
+        $this->testUserPermission->assignRole('testRole');
+
+        $this->registrar->getPermissions();
+
+        $this->testUserPermission->removeRole('testRole');
+
+        $this->resetQueryCount();
+
+        $this->registrar->getPermissions();
+
+        $this->assertQueryCount($this->cache_init_count + $this->cache_load_count + $this->cache_run_count);
+    }
+
+    /** @test */
+    public function it_flushes_the_cache_when_assign_a_permission_to_a_role()
+    {
+        $this->testUserRole->givePermissionTo('edit-articles');
 
         $this->resetQueryCount();
 


### PR DESCRIPTION
When `User.php` model uses `removeRole`, `assignRole`, `revokePermissionTo`, `givePermissionTo`, `forgetCachedPermissions()` is unnecessary because `User` is in memory, and it does not affect the cache data