### PR TITLE
[V4] Avoid Roles over-hydration

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -32,6 +32,9 @@ class PermissionRegistrar
     /** @var string */
     public static $cacheKey;
 
+    /** @var array */
+    private $cachedRoles = [];
+
     /**
      * PermissionRegistrar constructor.
      *
@@ -117,30 +120,36 @@ class PermissionRegistrar
      */
     private function loadPermissions()
     {
-        if ($this->permissions === null) {
-            $this->permissions = $this->cache->remember(self::$cacheKey, self::$cacheExpirationTime, function () {
-                // make the cache smaller using an array with only required fields
-                return $this->getPermissionClass()->select('id', 'id as i', 'name as n', 'guard_name as g')
-                    ->with('roles:id,id as i,name as n,guard_name as g')->get()
-                    ->map(function ($permission) {
-                        return $permission->only('i', 'n', 'g') +
-                            ['r' => $permission->roles->map->only('i', 'n', 'g')->all()];
-                    })->all();
+        if ($this->permissions !== null) {
+            return;
+        }
+
+        $this->permissions = $this->cache->remember(self::$cacheKey, self::$cacheExpirationTime, function () {
+            // make the cache smaller using an array with only required fields
+            return $this->getPermissionClass()->select('id', 'id as i', 'name as n', 'guard_name as g')
+                ->with('roles:id,id as i,name as n,guard_name as g')->get()
+                ->map(function ($permission) {
+                    return $permission->only('i', 'n', 'g') +
+                        ['r' => $permission->roles->map->only('i', 'n', 'g')->all()];
+                })->all();
+        });
+
+        if (is_array($this->permissions)) {
+            $this->permissions = $this->getPermissionClass()::hydrate(
+                collect($this->permissions)->map(function ($item) {
+                    return ['id' => $item['i'] ?? $item['id'], 'name' => $item['n'] ?? $item['name'], 'guard_name' => $item['g'] ?? $item['guard_name']];
+                })->all()
+            )
+            ->each(function ($permission, $i) {
+                $roles = Collection::make($this->permissions[$i]['r'] ?? $this->permissions[$i]['roles'] ?? [])
+                        ->map(function ($item) {
+                            return $this->getHydratedRole($item);
+                        });
+
+                $permission->setRelation('roles', $roles);
             });
-            if (is_array($this->permissions)) {
-                $this->permissions = $this->getPermissionClass()::hydrate(
-                    collect($this->permissions)->map(function ($item) {
-                        return ['id' => $item['i'] ?? $item['id'], 'name' => $item['n'] ?? $item['name'], 'guard_name' => $item['g'] ?? $item['guard_name']];
-                    })->all()
-                )
-                ->each(function ($permission, $i) {
-                    $permission->setRelation('roles', $this->getRoleClass()::hydrate(
-                        collect($this->permissions[$i]['r'] ?? $this->permissions[$i]['roles'] ?? [])->map(function ($item) {
-                            return ['id' => $item['i'] ?? $item['id'], 'name' => $item['n'] ?? $item['name'], 'guard_name' => $item['g'] ?? $item['guard_name']];
-                        })->all()
-                    ));
-                });
-            }
+
+            $this->cachedRoles = [];
         }
     }
 
@@ -210,5 +219,23 @@ class PermissionRegistrar
     public function getCacheStore(): \Illuminate\Contracts\Cache\Store
     {
         return $this->cache->getStore();
+    }
+
+    private function getHydratedRole(array $item)
+    {
+        $roleId = $item['i'] ?? $item['id'];
+
+        if (isset($this->cachedRoles[$roleId])) {
+            return $this->cachedRoles[$roleId];
+        }
+
+        $roleClass = $this->getRoleClass();
+        $roleInstance = new $roleClass;
+        return $this->cachedRoles[$roleId] = $roleInstance->newFromBuilder([
+            'id' => $roleId,
+            'name' => $item['n'] ?? $item['name'],
+            'guard_name' => $item['g'] ?? $item['guard_name'],
+        ]);
+
     }
 }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -204,6 +204,17 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    public function get_all_permissions_should_not_over_hydrate_roles()
+    {
+        $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news']);
+        $permissions = $this->registrar->getPermissions();
+        $roles = $permissions->flatMap->roles;
+
+        // Should have same object reference
+        $this->assertSame($roles[0], $roles[1]);
+    }
+
+    /** @test */
     public function it_can_reset_the_cache_with_artisan_command()
     {
         Artisan::call('permission:create-permission', ['name' => 'new-permission']);


### PR DESCRIPTION
When we using this lib in an application with a lot of permissions and roles, we can observe that it has an over-hydration of "Role" model on loading permissions.

![image](https://user-images.githubusercontent.com/11338999/131688132-fa14e30b-ad77-4532-8b6c-cc3873a45c2c.png)
RAM usage: ![image](https://user-images.githubusercontent.com/11338999/131688171-344144ec-a06f-4ba5-aa33-697935838974.png)

After this PR, It reduces dramatically:
![image](https://user-images.githubusercontent.com/11338999/131688311-ff5e25f7-fc94-451e-8de1-8fc1fd2280be.png)
RAM usage: ![image](https://user-images.githubusercontent.com/11338999/131688385-46f7f2ef-2776-4ad2-b7b1-8167fa4531fa.png)

The execution time average is reduced too.
From ~330ms to ~270ms