### PR TITLE
[V4] Avoid BC break on extra custom fields (on smaller cache)

### DIFF
--- a/src/PermissionLoaderTrait.php
+++ b/src/PermissionLoaderTrait.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Spatie\Permission;
+
+use Illuminate\Database\Eloquent\Collection;
+
+trait PermissionLoaderTrait
+{
+    /**
+     * Array for cache alias
+     */
+    private function aliasModelFields(array &$keys, array $newKeys = [], array $except = []): void
+    {
+        $alphas = ! count($keys) ? range('a', 'n') : range('o', 'z');
+
+        foreach ($newKeys as $i => $value) {
+            $keys[$value] = $alphas[$i] ?? $value;
+        }
+
+        $keys = collect($keys)->except($except)->all();
+    }
+
+    /**
+     * Changes array keys with alias
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    private function aliasedFromArray(array $item, array $alias): \Illuminate\Support\Collection
+    {
+        return collect($item)->keyBy(function ($value, $key) use ($alias) {
+            return $alias[$key] ?? $key;
+        });
+    }
+
+    /**
+     * Load permissions from cache
+     * This get cache and turns array into \Illuminate\Database\Eloquent\Collection
+     */
+    private function loadPermissionsFromCache(): void
+    {
+        $roleClass = $this->getRoleClass();
+        $permissionClass = $this->getPermissionClass();
+
+        $this->permissions = $this->cache->remember(self::$cacheKey, self::$cacheExpirationTime, function () use ($permissionClass) {
+            // make the cache smaller using an array with only aliased fields
+            $alias = [];
+            $roles = [];
+            $roleAliasFlag = false;
+            $except = config('permission.cache.column_names_except', ['created_at','updated_at', 'deleted_at']);
+            $permissions = $permissionClass->with('roles')->get()->map(function ($permission) use (&$roles, &$alias, &$roleAliasFlag, $except) {
+                if (! count($alias)) {
+                    $this->aliasModelFields($alias, array_merge(array_keys($permission->getAttributes()), ['roles']), $except);
+                }
+
+                return $this->aliasedFromArray($permission->getAttributes(), $alias)->except($except)->all() +
+                    [
+                        $alias['roles'] => $permission->roles->map(function ($role) use (&$roles, &$alias, &$roleAliasFlag, $except) {
+                            if (! $roleAliasFlag) {
+                                $this->aliasModelFields($alias, array_values(array_diff(array_keys($role->getAttributes()), array_keys($alias))), $except);
+                                $roleAliasFlag = true;
+                            }
+                            $id = $role->getKey();
+                            $roles[$id] = $roles[$id] ?? $this->aliasedFromArray($role->getAttributes(), $alias)->except($except)->all();
+
+                            return $id;
+                        })->all()
+                    ];
+            })->all();
+            $alias = collect($alias)->except($except)->flip()->except($except)->all();
+
+            return compact('alias', 'roles', 'permissions');
+        });
+        // temporary, only to allow upgrade from previous versions
+        if (! is_array($this->permissions) || ! isset($this->permissions['permissions'])) {
+            $this->forgetCachedPermissions();
+            $this->loadPermissionsFromCache();
+
+            return;
+        }
+
+        $this->permissions['roles'] = array_map(function ($item) use ($roleClass) {
+            return (new $roleClass)->newFromBuilder($this->aliasedFromArray($item, $this->permissions['alias'])->all());
+        }, $this->permissions['roles']);
+
+        $this->permissions = Collection::make($this->permissions['permissions'])
+            ->map(function ($item) use ($permissionClass) {
+                $aliased_item = $this->aliasedFromArray($item, $this->permissions['alias']);
+                $permission = (new $permissionClass)->newFromBuilder($aliased_item->except('roles')->all());
+                $permission->setRelation('roles', Collection::make($aliased_item['roles'])
+                    ->map(function ($id) {
+                        return $this->permissions['roles'][$id];
+                    }));
+
+                return $permission;
+            });
+    }
+}

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -493,7 +493,6 @@ class HasPermissionsTest extends TestCase
 
         \DB::enableQueryLog();
         $user2->save();
-        $querys = \DB::getQueryLog();
         \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
@@ -501,7 +500,7 @@ class HasPermissionsTest extends TestCase
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(\DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */
@@ -516,7 +515,6 @@ class HasPermissionsTest extends TestCase
 
         \DB::enableQueryLog();
         $user2->save();
-        $querys = \DB::getQueryLog();
         \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
@@ -524,7 +522,7 @@ class HasPermissionsTest extends TestCase
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(\DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/HasPermissionsWithCustomModelsTest.php
+++ b/tests/HasPermissionsWithCustomModelsTest.php
@@ -2,15 +2,34 @@
 
 namespace Spatie\Permission\Test;
 
+use DB;
+use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Test\Permission;
+use Spatie\Permission\Test\Role;
+
 class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
 {
     /** @var bool */
     protected $useCustomModels = true;
-    
+
     /** @test */
     public function it_can_use_custom_models()
     {
-        $this->assertSame(get_class($this->testUserPermission), \Spatie\Permission\Test\Permission::class);
-        $this->assertSame(get_class($this->testUserRole), \Spatie\Permission\Test\Role::class);
+        $this->assertSame(get_class($this->testUserPermission), Permission::class);
+        $this->assertSame(get_class($this->testUserRole), Role::class);
+    }
+
+    /** @test */
+    public function it_can_use_custom_fields_from_cache()
+    {
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+        app(PermissionRegistrar::class)->getPermissions();
+
+        DB::enableQueryLog();
+        $this->assertSame('P', Permission::findByName('edit-articles')->type);
+        $this->assertSame('R', Permission::findByName('edit-articles')->roles[0]->type);
+        DB::disableQueryLog();
+
+        $this->assertSame(0, count(DB::getQueryLog()));
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -248,7 +248,6 @@ class HasRolesTest extends TestCase
 
         \DB::enableQueryLog();
         $user2->save();
-        $querys = \DB::getQueryLog();
         \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasRole('testRole'));
@@ -256,7 +255,7 @@ class HasRolesTest extends TestCase
 
         $this->assertTrue($user2->fresh()->hasRole('testRole2'));
         $this->assertFalse($user2->fresh()->hasRole('testRole'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(\DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */
@@ -271,7 +270,6 @@ class HasRolesTest extends TestCase
 
         \DB::enableQueryLog();
         $admin_user->save();
-        $querys = \DB::getQueryLog();
         \DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasRole('testRole'));
@@ -279,7 +277,7 @@ class HasRolesTest extends TestCase
 
         $this->assertTrue($admin_user->fresh()->hasRole('testRole2'));
         $this->assertFalse($admin_user->fresh()->hasRole('testRole'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(\DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -120,6 +120,15 @@ abstract class TestCase extends Orchestra
 
         (new \CreatePermissionTables())->up();
 
+        if ($this->useCustomModels) {
+            $app['db']->connection()->getSchemaBuilder()->table($app['config']->get('permission.table_names.roles'), function (Blueprint $table) {
+                $table->string('type')->default('R');
+            });
+            $app['db']->connection()->getSchemaBuilder()->table($app['config']->get('permission.table_names.permissions'), function (Blueprint $table) {
+                $table->string('type')->default('P');
+            });
+        }
+
         User::create(['email' => 'test@user.com']);
         Admin::create(['email' => 'admin@user.com']);
         $app[Role::class]->create(['name' => 'testRole']);


### PR DESCRIPTION
Closes #1836
Closes #2046
Closes #2016

Set all models fields on cache, still using alias and arrays for smaller cache, added alias for most common field names([#1827](https://github.com/spatie/laravel-permission/discussions/1827#discussioncomment-1234029)).

Example 
```php
array:358 [▼
  0 => array:8 [▼
    "i" => 197
    "n" => "view_audit"
    "g" => "web"
    "l" => "Audit"
    "e" => null
    "y" => "A"
    "r" => array:3 [▼
      0 => array:5 [▼
        "i" => 0
        "t" => null
        "n" => "System"
        "g" => "web"
        "y" => "A"
      ]
```
`1631207353a:358:{i:0;a:8:{s:1:"i";i:197;s:1:"n";s:10:"view_audit";s:1:"g";s:3:"web";s:1:"l";s:10:"Audit";s:1:"e";N;s:1:"y";s:1:"A";s:1:"r";a:3:{i:0;a:5:{s:1:"i";i:0;s:1:"t";N;s:1:"n";s:8:"System";s:1:"g";s:3:"web";s:1:"y";s:1:"A";}i:`

Added test `it_can_use_custom_fields_from_cache`, checked not over hydration

![image](https://user-images.githubusercontent.com/4933954/131908094-501b50f3-e5e4-4a89-afad-cf78ad125985.png)


## UPDATE:
Inspired by @danilopinotti on #1834, now cache avoid duplicate roles on each permissions, only save ids, and roles are saved on different array, this makes cache even smaller
