### PR TITLE
Ability to manually register all permissions on Laravel's gate

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -97,6 +97,14 @@ return [
     ],
 
     /*
+     * When set to true, all permissions will be registered on Laravel's gate.
+     * 
+     * Set this to false, if you want to manually register the permissions on the gate.
+     */
+
+    'register_permissions_on_gate' => true,
+
+    /*
      * When set to true the package implements teams using the 'team_foreign_key'. If you want
      * the migrations to register the 'team_foreign_key', you must set this to true
      * before doing the migration. If you already did the migration then you must make a new

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -22,8 +22,10 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerModelBindings();
 
-        $permissionLoader->clearClassPermissions();
-        $permissionLoader->registerPermissions();
+        if ($this->app->config['permission.register_permissions_on_gate']) {
+            $permissionLoader->clearClassPermissions();
+            $permissionLoader->registerPermissions();
+        }
 
         $this->app->singleton(PermissionRegistrar::class, function ($app) use ($permissionLoader) {
             return $permissionLoader;
@@ -33,7 +35,7 @@ class PermissionServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/permission.php',
+            __DIR__ . '/../config/permission.php',
             'permission'
         );
 
@@ -42,17 +44,17 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function offerPublishing()
     {
-        if (! function_exists('config_path')) {
+        if (!function_exists('config_path')) {
             // function not available and 'publish' not relevant in Lumen
             return;
         }
 
         $this->publishes([
-            __DIR__.'/../config/permission.php' => config_path('permission.php'),
+            __DIR__ . '/../config/permission.php' => config_path('permission.php'),
         ], 'config');
 
         $this->publishes([
-            __DIR__.'/../database/migrations/create_permission_tables.php.stub' => $this->getMigrationFileName('create_permission_tables.php'),
+            __DIR__ . '/../database/migrations/create_permission_tables.php.stub' => $this->getMigrationFileName('create_permission_tables.php'),
         ], 'migrations');
     }
 
@@ -71,7 +73,7 @@ class PermissionServiceProvider extends ServiceProvider
     {
         $config = $this->app->config['permission.models'];
 
-        if (! $config) {
+        if (!$config) {
             return;
         }
 
@@ -83,12 +85,12 @@ class PermissionServiceProvider extends ServiceProvider
     {
         $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
             $bladeCompiler->directive('role', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+                list($role, $guard) = explode(',', $arguments . ',');
 
                 return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
             });
             $bladeCompiler->directive('elserole', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+                list($role, $guard) = explode(',', $arguments . ',');
 
                 return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
             });
@@ -97,7 +99,7 @@ class PermissionServiceProvider extends ServiceProvider
             });
 
             $bladeCompiler->directive('hasrole', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+                list($role, $guard) = explode(',', $arguments . ',');
 
                 return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
             });
@@ -106,7 +108,7 @@ class PermissionServiceProvider extends ServiceProvider
             });
 
             $bladeCompiler->directive('hasanyrole', function ($arguments) {
-                list($roles, $guard) = explode(',', $arguments.',');
+                list($roles, $guard) = explode(',', $arguments . ',');
 
                 return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyRole({$roles})): ?>";
             });
@@ -115,7 +117,7 @@ class PermissionServiceProvider extends ServiceProvider
             });
 
             $bladeCompiler->directive('hasallroles', function ($arguments) {
-                list($roles, $guard) = explode(',', $arguments.',');
+                list($roles, $guard) = explode(',', $arguments . ',');
 
                 return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
             });
@@ -124,7 +126,7 @@ class PermissionServiceProvider extends ServiceProvider
             });
 
             $bladeCompiler->directive('unlessrole', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+                list($role, $guard) = explode(',', $arguments . ',');
 
                 return "<?php if(!auth({$guard})->check() || ! auth({$guard})->user()->hasRole({$role})): ?>";
             });
@@ -133,7 +135,7 @@ class PermissionServiceProvider extends ServiceProvider
             });
 
             $bladeCompiler->directive('hasexactroles', function ($arguments) {
-                list($roles, $guard) = explode(',', $arguments.',');
+                list($roles, $guard) = explode(',', $arguments . ',');
 
                 return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasExactRoles({$roles})): ?>";
             });
@@ -145,12 +147,12 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerMacroHelpers()
     {
-        if (! method_exists(Route::class, 'macro')) { // Lumen
+        if (!method_exists(Route::class, 'macro')) { // Lumen
             return;
         }
 
         Route::macro('role', function ($roles = []) {
-            if (! is_array($roles)) {
+            if (!is_array($roles)) {
                 $roles = [$roles];
             }
 
@@ -162,7 +164,7 @@ class PermissionServiceProvider extends ServiceProvider
         });
 
         Route::macro('permission', function ($permissions = []) {
-            if (! is_array($permissions)) {
+            if (!is_array($permissions)) {
                 $permissions = [$permissions];
             }
 
@@ -185,11 +187,11 @@ class PermissionServiceProvider extends ServiceProvider
 
         $filesystem = $this->app->make(Filesystem::class);
 
-        return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
+        return Collection::make($this->app->databasePath() . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR)
             ->flatMap(function ($path) use ($filesystem, $migrationFileName) {
-                return $filesystem->glob($path.'*_'.$migrationFileName);
+                return $filesystem->glob($path . '*_' . $migrationFileName);
             })
-            ->push($this->app->databasePath()."/migrations/{$timestamp}_{$migrationFileName}")
+            ->push($this->app->databasePath() . "/migrations/{$timestamp}_{$migrationFileName}")
             ->first();
     }
 }


### PR DESCRIPTION
This could be useful in cases where we don't need to retrieve the permissions from the database on every request.
For example, when permissions are stored and retrieved from an access token.