### PR TITLE
[V5] Fix hints, support int on `scopePermission()` (#1863)

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -15,6 +15,7 @@ use Spatie\Permission\WildcardPermission;
 
 trait HasPermissions
 {
+    /** @var string */
     private $permissionClass;
 
     public static function bootHasPermissions()
@@ -55,7 +56,7 @@ trait HasPermissions
      * Scope the model query to certain permissions only.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
@@ -80,9 +81,10 @@ trait HasPermissions
     }
 
     /**
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
      *
      * @return array
+     * @throws \Spatie\Permission\Exceptions\PermissionDoesNotExist
      */
     protected function convertToPermissionModels($permissions): array
     {
@@ -96,8 +98,9 @@ trait HasPermissions
             if ($permission instanceof Permission) {
                 return $permission;
             }
+            $method = is_string($permission) ? 'findByName' : 'findById';
 
-            return $this->getPermissionClass()->findByName($permission, $this->getDefaultGuardName());
+            return $this->getPermissionClass()->{$method}($permission, $this->getDefaultGuardName());
         }, $permissions);
     }
 
@@ -179,15 +182,6 @@ trait HasPermissions
     }
 
     /**
-     * @deprecated since 2.35.0
-     * @alias of hasPermissionTo()
-     */
-    public function hasUncachedPermissionTo($permission, $guardName = null): bool
-    {
-        return $this->hasPermissionTo($permission, $guardName);
-    }
-
-    /**
      * An alias to hasPermissionTo(), but avoids throwing an exception.
      *
      * @param string|int|\Spatie\Permission\Contracts\Permission $permission
@@ -207,10 +201,9 @@ trait HasPermissions
     /**
      * Determine if the model has any of the given permissions.
      *
-     * @param array ...$permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      *
      * @return bool
-     * @throws \Exception
      */
     public function hasAnyPermission(...$permissions): bool
     {
@@ -228,7 +221,7 @@ trait HasPermissions
     /**
      * Determine if the model has all of the given permissions.
      *
-     * @param array ...$permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      *
      * @return bool
      * @throws \Exception
@@ -314,7 +307,7 @@ trait HasPermissions
     /**
      * Grant the given permission(s) to a role.
      *
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
      *
      * @return $this
      */
@@ -365,7 +358,7 @@ trait HasPermissions
     /**
      * Remove all current permissions and set the given ones.
      *
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
      *
      * @return $this
      */
@@ -400,7 +393,7 @@ trait HasPermissions
     }
 
     /**
-     * @param string|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
      *
      * @return \Spatie\Permission\Contracts\Permission|\Spatie\Permission\Contracts\Permission[]|\Illuminate\Support\Collection
      */
@@ -458,7 +451,7 @@ trait HasPermissions
 
     /**
      * Check if the model has All of the requested Direct permissions.
-     * @param array ...$permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      * @return bool
      */
     public function hasAllDirectPermissions(...$permissions): bool
@@ -476,7 +469,7 @@ trait HasPermissions
 
     /**
      * Check if the model has Any of the requested Direct permissions.
-     * @param array ...$permissions
+     * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      * @return bool
      */
     public function hasAnyDirectPermission(...$permissions): bool

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -12,6 +12,7 @@ trait HasRoles
 {
     use HasPermissions;
 
+    /** @var string */
     private $roleClass;
 
     public static function bootHasRoles()
@@ -73,9 +74,8 @@ trait HasRoles
             }
 
             $method = is_numeric($role) ? 'findById' : 'findByName';
-            $guard = $guard ?: $this->getDefaultGuardName();
 
-            return $this->getRoleClass()->{$method}($role, $guard);
+            return $this->getRoleClass()->{$method}($role, $guard ?: $this->getDefaultGuardName());
         }, $roles);
 
         return $query->whereHas('roles', function (Builder $subQuery) use ($roles) {
@@ -86,7 +86,7 @@ trait HasRoles
     /**
      * Assign the given role to the model.
      *
-     * @param array|string|int|\Spatie\Permission\Contracts\Role ...$roles
+     * @param array|string|int|\Spatie\Permission\Contracts\Role|\Illuminate\Support\Collection ...$roles
      *
      * @return $this
      */
@@ -153,7 +153,7 @@ trait HasRoles
     /**
      * Remove all current roles and set the given ones.
      *
-     * @param  array|\Spatie\Permission\Contracts\Role|string|int  ...$roles
+     * @param  array|\Spatie\Permission\Contracts\Role|\Illuminate\Support\Collection|string|int  ...$roles
      *
      * @return $this
      */

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -66,6 +66,22 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    public function it_can_scope_users_using_a_int()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user1->givePermissionTo([1, 2]);
+        $this->testUserRole->givePermissionTo(1);
+        $user2->assignRole('testRole');
+
+        $scopedUsers1 = User::permission(1)->get();
+        $scopedUsers2 = User::permission([2])->get();
+
+        $this->assertEquals(2, $scopedUsers1->count());
+        $this->assertEquals(1, $scopedUsers2->count());
+    }
+
+    /** @test */
     public function it_can_scope_users_using_an_array()
     {
         $user1 = User::create(['email' => 'user1@test.com']);


### PR DESCRIPTION
Bring V4 fixes to V5