### PR TITLE
[V5] UUID full support, support for custom key names on Role,Permission model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         }
     ],
     "require": {
-        "php" : "^7.2.5|^8.0",
-        "illuminate/auth": "^6.0|^7.0|^8.0",
-        "illuminate/container": "^6.0|^7.0|^8.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0"
+        "php": "^7.2.5|^8.0",
+        "illuminate/auth": "^6.20.3|^7.30.0|^8.13.0",
+        "illuminate/container": "^6.20.3|^7.30.0|^8.13.0",
+        "illuminate/contracts": "^6.20.3|^7.30.0|^8.13.0",
+        "illuminate/database": "^6.20.3|^7.30.0|^8.13.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0|^6.0",

--- a/docs/basic-usage/teams-permissions.md
+++ b/docs/basic-usage/teams-permissions.md
@@ -34,12 +34,12 @@ class TeamsPermission{
     public function handle($request, \Closure $next){
         if(!empty(auth()->user())){
             // session value set on login
-            app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(session('team_id'));
+            setPermissionsTeamId(session('team_id'));
         }
         // other custom ways to get team_id
         /*if(!empty(auth('api')->user())){
             // `getTeamIdFromToken()` example of custom method for getting the set team_id 
-            app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(auth('api')->user()->getTeamIdFromToken());
+            setPermissionsTeamId(auth('api')->user()->getTeamIdFromToken());
         }*/
         
         return $next($request);

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -18,13 +18,15 @@ class Permission extends Model implements PermissionContract
     use HasRoles;
     use RefreshesPermissionCache;
 
-    protected $guarded = ['id'];
+    protected $guarded = [];
 
     public function __construct(array $attributes = [])
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
+        
+        $this->guarded[] = $this->primaryKey;
     }
 
     public function getTable()
@@ -96,17 +98,17 @@ class Permission extends Model implements PermissionContract
     /**
      * Find a permission by its id (and optionally guardName).
      *
-     * @param int $id
+     * @param int|string $id
      * @param string|null $guardName
      *
      * @throws \Spatie\Permission\Exceptions\PermissionDoesNotExist
      *
      * @return \Spatie\Permission\Contracts\Permission
      */
-    public static function findById(int $id, $guardName = null): PermissionContract
+    public static function findById($id, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermission(['id' => $id, 'guard_name' => $guardName]);
+        $permission = static::getPermission([app(PermissionRegistrar::class)->getPermissionKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -75,11 +75,13 @@ trait HasPermissions
 
         return $query->where(function (Builder $query) use ($permissions, $rolesWithPermissions) {
             $query->whereHas('permissions', function (Builder $subQuery) use ($permissions) {
-                $subQuery->whereIn(config('permission.table_names.permissions').'.id', \array_column($permissions, 'id'));
+                $key = app(PermissionRegistrar::class)->getPermissionKeyName();
+                $subQuery->whereIn(config('permission.table_names.permissions').'.'.$key, \array_column($permissions, $key));
             });
             if (count($rolesWithPermissions) > 0) {
                 $query->orWhereHas('roles', function (Builder $subQuery) use ($rolesWithPermissions) {
-                    $subQuery->whereIn(config('permission.table_names.roles').'.id', \array_column($rolesWithPermissions, 'id'));
+                    $key = app(PermissionRegistrar::class)->getRoleKeyName();
+                    $subQuery->whereIn(config('permission.table_names.roles').'.'.$key, \array_column($rolesWithPermissions, $key));
                 });
             }
         });
@@ -103,7 +105,9 @@ trait HasPermissions
                 return $permission;
             }
 
-            return $this->getPermissionClass()->findByName($permission, $this->getDefaultGuardName());
+            $method = is_string($permission) && ! \Str::isUuid($permission) ? 'findByName' : 'findById';
+
+            return $this->getPermissionClass()->{$method}($permission, $this->getDefaultGuardName());
         }, $permissions);
     }
 
@@ -124,14 +128,14 @@ trait HasPermissions
 
         $permissionClass = $this->getPermissionClass();
 
-        if (is_string($permission)) {
+        if (is_string($permission) && ! \Str::isUuid($permission)) {
             $permission = $permissionClass->findByName(
                 $permission,
                 $guardName ?? $this->getDefaultGuardName()
             );
         }
 
-        if (is_int($permission)) {
+        if (is_int($permission) || is_string($permission)) {
             $permission = $permissionClass->findById(
                 $permission,
                 $guardName ?? $this->getDefaultGuardName()
@@ -157,7 +161,7 @@ trait HasPermissions
     {
         $guardName = $guardName ?? $this->getDefaultGuardName();
 
-        if (is_int($permission)) {
+        if (is_int($permission) || \Str::isUuid($permission)) {
             $permission = $this->getPermissionClass()->findById($permission, $guardName);
         }
 
@@ -276,11 +280,11 @@ trait HasPermissions
     {
         $permissionClass = $this->getPermissionClass();
 
-        if (is_string($permission)) {
+        if (is_string($permission) && ! \Str::isUuid($permission)) {
             $permission = $permissionClass->findByName($permission, $this->getDefaultGuardName());
         }
 
-        if (is_int($permission)) {
+        if (is_int($permission) || is_string($permission)) {
             $permission = $permissionClass->findById($permission, $this->getDefaultGuardName());
         }
 
@@ -288,7 +292,7 @@ trait HasPermissions
             throw new PermissionDoesNotExist();
         }
 
-        return $this->permissions->contains('id', $permission->id);
+        return $this->permissions->contains($permission->getKeyName(), $permission->getKey());
     }
 
     /**
@@ -357,11 +361,11 @@ trait HasPermissions
                 $this->ensureModelSharesGuard($permission);
             })
             ->map(function ($permission) {
-                return ['id' => $permission->id, 'values' => PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
+                return [$permission->getKeyName() => $permission->getKey(), 'values' => PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
                     [PermissionRegistrar::$teamsKey => app(PermissionRegistrar::class)->getPermissionsTeamId()] : [],
                 ];
             })
-            ->pluck('values', 'id')->toArray();
+            ->pluck('values', app(PermissionRegistrar::class)->getPermissionKeyName())->toArray();
 
         $model = $this->getModel();
 
@@ -437,7 +441,7 @@ trait HasPermissions
     {
         $permissionClass = $this->getPermissionClass();
 
-        if (is_numeric($permissions)) {
+        if (is_numeric($permissions) || \Str::isUuid($permissions)) {
             return $permissionClass->findById($permissions, $this->getDefaultGuardName());
         }
 

--- a/tests/CreatePermissionCustomTables.php
+++ b/tests/CreatePermissionCustomTables.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\PermissionRegistrar;
+
+class CreatePermissionCustomTables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $teams = config('permission.teams');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+        if ($teams && empty($columnNames['team_foreign_key'] ?? null)) {
+            throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
+        }
+
+        Schema::create($tableNames['permissions'], function (Blueprint $table) {
+            $table->uuid('permission_test_id');
+            $table->primary('permission_test_id');
+            $table->string('name');       // For MySQL 8.0 use string('name', 125);
+            $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
+            $table->string('type')->default('P');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], function (Blueprint $table) use ($teams, $columnNames) {
+            $table->uuid('role_test_id');
+            $table->primary('role_test_id');
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MySQL 8.0 use string('name', 125);
+            $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
+            $table->string('type')->default('R');
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames, $teams) {
+            $table->uuid(PermissionRegistrar::$pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign(PermissionRegistrar::$pivotPermission)
+                ->references('permission_test_id')
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames, $teams) {
+            $table->uuid(PermissionRegistrar::$pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign(PermissionRegistrar::$pivotRole)
+                ->references('role_test_id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
+            $table->uuid(PermissionRegistrar::$pivotPermission);
+            $table->uuid(PermissionRegistrar::$pivotRole);
+
+            $table->foreign(PermissionRegistrar::$pivotPermission)
+                ->references('role_test_id')
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign(PermissionRegistrar::$pivotRole)
+                ->references('permission_test_id')
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([PermissionRegistrar::$pivotPermission, PermissionRegistrar::$pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+}

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Test;
 
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
@@ -364,8 +365,8 @@ class HasPermissionsTest extends TestCase
         $this->testUser->assignRole('testRole', 'testRole2');
 
         $this->assertEquals(
-            collect(['edit-articles', 'edit-news']),
-            $this->testUser->getPermissionsViaRoles()->pluck('name')
+            collect(['edit-articles', 'edit-news'])->sort()->values(),
+            $this->testUser->getPermissionsViaRoles()->pluck('name')->sort()->values()
         );
     }
 
@@ -402,7 +403,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo('edit-news');
 
-        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck('id');
+        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck(app(PermissionRegistrar::class)->getPermissionKeyName());
 
         $this->testUser->syncPermissions($ids);
 
@@ -418,7 +419,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo('edit-news');
 
-        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck('id');
+        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck(app(PermissionRegistrar::class)->getPermissionKeyName());
 
         $ids->push(null);
 

--- a/tests/HasPermissionsWithCustomModelsTest.php
+++ b/tests/HasPermissionsWithCustomModelsTest.php
@@ -8,9 +8,8 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     protected $useCustomModels = true;
 
     /** @test */
-    public function it_can_use_custom_models()
+    public function it_can_use_custom_model_permission()
     {
         $this->assertSame(get_class($this->testUserPermission), \Spatie\Permission\Test\Permission::class);
-        $this->assertSame(get_class($this->testUserRole), \Spatie\Permission\Test\Role::class);
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -22,13 +22,13 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUser->hasRole($role->name));
         $this->assertTrue($this->testUser->hasRole($role->name, $role->guard_name));
         $this->assertTrue($this->testUser->hasRole([$role->name, 'fakeRole'], $role->guard_name));
-        $this->assertTrue($this->testUser->hasRole($role->id, $role->guard_name));
-        $this->assertTrue($this->testUser->hasRole([$role->id, 'fakeRole'], $role->guard_name));
+        $this->assertTrue($this->testUser->hasRole($role->getKey(), $role->guard_name));
+        $this->assertTrue($this->testUser->hasRole([$role->getKey(), 'fakeRole'], $role->guard_name));
 
         $this->assertFalse($this->testUser->hasRole($role->name, 'fakeGuard'));
         $this->assertFalse($this->testUser->hasRole([$role->name, 'fakeRole'], 'fakeGuard'));
-        $this->assertFalse($this->testUser->hasRole($role->id, 'fakeGuard'));
-        $this->assertFalse($this->testUser->hasRole([$role->id, 'fakeRole'], 'fakeGuard'));
+        $this->assertFalse($this->testUser->hasRole($role->getKey(), 'fakeGuard'));
+        $this->assertFalse($this->testUser->hasRole([$role->getKey(), 'fakeRole'], 'fakeGuard'));
 
         $role = app(Role::class)->findOrCreate('testRoleInWebGuard2', 'web');
         $this->assertFalse($this->testUser->hasRole($role));
@@ -87,7 +87,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_a_role_using_an_id()
     {
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->assertTrue($this->testUser->hasRole($this->testUserRole));
     }
@@ -95,7 +95,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_multiple_roles_at_once()
     {
-        $this->testUser->assignRole($this->testUserRole->id, 'testRole2');
+        $this->testUser->assignRole($this->testUserRole->getKey(), 'testRole2');
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
@@ -105,7 +105,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_multiple_roles_using_an_array()
     {
-        $this->testUser->assignRole([$this->testUserRole->id, 'testRole2']);
+        $this->testUser->assignRole([$this->testUserRole->getKey(), 'testRole2']);
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
@@ -115,7 +115,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_does_not_remove_already_associated_roles_when_assigning_new_roles()
     {
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->testUser->assignRole('testRole2');
 
@@ -125,9 +125,9 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_does_not_throw_an_exception_when_assigning_a_role_that_is_already_assigned()
     {
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->assertTrue($this->testUser->fresh()->hasRole('testRole'));
     }
@@ -352,7 +352,7 @@ class HasRolesTest extends TestCase
 
         $roleName = $this->testUserRole->name;
 
-        $otherRoleId = app(Role::class)->find(2)->id;
+        $otherRoleId = app(Role::class)->findByName('testRole2')->getKey();
 
         $scopedUsers = User::role([$roleName, $otherRoleId])->get();
 

--- a/tests/HasRolesWithCustomModelsTest.php
+++ b/tests/HasRolesWithCustomModelsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Exceptions\GuardDoesNotMatch;
+use Spatie\Permission\Exceptions\RoleDoesNotExist;
+
+class HasRolesWithCustomModelsTest extends HasRolesTest
+{
+    /** @var bool */
+    protected $useCustomModels=true;
+
+    /** @test */
+    public function it_can_use_custom_model_role()
+    {
+        $this->assertSame(get_class($this->testUserRole), \Spatie\Permission\Test\Role::class);
+    }
+}

--- a/tests/Permission.php
+++ b/tests/Permission.php
@@ -4,8 +4,30 @@ namespace Spatie\Permission\Test;
 
 class Permission extends \Spatie\Permission\Models\Permission
 {
+    protected $primaryKey = 'permission_test_id';
+    
     protected $visible = [
-      'id',
+      'permission_test_id',
       'name',
     ];
+    
+    protected static function boot()
+    {
+        parent::boot();
+        static::creating(function ($model) {
+            if (empty($model->{$model->getKeyName()})) {
+                $model->{$model->getKeyName()} = \Str::uuid()->toString();
+            }
+        });
+    }
+
+    public function getIncrementing()
+    {
+        return false;
+    }
+
+    public function getKeyType()
+    {
+        return 'string';
+    }
 }

--- a/tests/Role.php
+++ b/tests/Role.php
@@ -4,8 +4,31 @@ namespace Spatie\Permission\Test;
 
 class Role extends \Spatie\Permission\Models\Role
 {
+    protected $primaryKey = 'role_test_id';
+    protected $guarded = ['role_test_id'];
+
     protected $visible = [
-      'id',
+      'role_test_id',
       'name',
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+        static::creating(function ($model) {
+            if (empty($model->{$model->getKeyName()})) {
+                $model->{$model->getKeyName()} = \Str::uuid()->toString();
+            }
+        });
+    }
+
+    public function getIncrementing()
+    {
+        return false;
+    }
+
+    public function getKeyType()
+    {
+        return 'string';
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,14 +49,6 @@ abstract class TestCase extends Orchestra
             $this->setPermissionsTeamId(1);
         }
 
-        $this->testUser = User::first();
-        $this->testUserRole = app(Role::class)->find(1);
-        $this->testUserPermission = app(Permission::class)->find(1);
-
-        $this->testAdmin = Admin::first();
-        $this->testAdminRole = app(Role::class)->find(3);
-        $this->testAdminPermission = app(Permission::class)->find(4);
-
         $this->setUpRoutes();
     }
 
@@ -133,19 +125,25 @@ abstract class TestCase extends Orchestra
             $this->createCacheTable();
         }
 
-        include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
+        if (! $this->useCustomModels) {
+            include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
 
-        (new \CreatePermissionTables())->up();
+            (new \CreatePermissionTables())->up();
+        } else {
+            include_once __DIR__.'/CreatePermissionCustomTables.php';
+            
+            (new CreatePermissionCustomTables())->up();
+        }
 
-        User::create(['email' => 'test@user.com']);
-        Admin::create(['email' => 'admin@user.com']);
-        $app[Role::class]->create(['name' => 'testRole']);
+        $this->testUser = User::create(['email' => 'test@user.com']);
+        $this->testAdmin = Admin::create(['email' => 'admin@user.com']);
+        $this->testUserRole = $app[Role::class]->create(['name' => 'testRole']);
         $app[Role::class]->create(['name' => 'testRole2']);
-        $app[Role::class]->create(['name' => 'testAdminRole', 'guard_name' => 'admin']);
-        $app[Permission::class]->create(['name' => 'edit-articles']);
+        $this->testAdminRole = $app[Role::class]->create(['name' => 'testAdminRole', 'guard_name' => 'admin']);
+        $this->testUserPermission = $app[Permission::class]->create(['name' => 'edit-articles']);
         $app[Permission::class]->create(['name' => 'edit-news']);
         $app[Permission::class]->create(['name' => 'edit-blog']);
-        $app[Permission::class]->create(['name' => 'admin-permission', 'guard_name' => 'admin']);
+        $this->testAdminPermission = $app[Permission::class]->create(['name' => 'admin-permission', 'guard_name' => 'admin']);
         $app[Permission::class]->create(['name' => 'Edit News']);
     }
 


### PR DESCRIPTION
- UUID full support on all methods
- Support for custom key names on Role,Permission model instead of defaut one.(`'id'`)
- Other small fixes

keeps the same operation as always