### PR TITLE
[V5] Teams fixes, added scopeTeam

### DIFF
--- a/src/Exceptions/TeamsNotAllowed.php
+++ b/src/Exceptions/TeamsNotAllowed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class TeamsNotAllowed extends InvalidArgumentException
+{
+    public static function create(string $permissionName, string $guardName = '')
+    {
+        return new static("Teams feature not available on model.");
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -36,6 +36,6 @@ if (! function_exists('getPermissionsTeamId')) {
      */
     function getPermissionsTeamId()
     {
-        app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();
+        return app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Permission\Test;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
+use Spatie\Permission\Exceptions\TeamsNotAllowed;
 
 class HasRolesTest extends TestCase
 {
@@ -582,5 +583,16 @@ class HasRolesTest extends TestCase
         $user = SoftDeletingUser::withTrashed()->find($user->id);
 
         $this->assertTrue($user->hasRole('testRole'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_scope_user_with_team_feature_not_available()
+    {
+        if (! $this->hasTeams) {
+            $this->expectException(TeamsNotAllowed::class);
+        } else {
+            $this->assertTrue(true);
+        }
+        $users = User::team(1)->get();
     }
 }

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -103,4 +103,33 @@ class TeamHasPermissionsTest extends HasPermissionsTest
             $this->testUser->getPermissionNames()->sort()->values()
         );
     }
+
+    /** @test */
+    public function it_can_scope_users_on_different_teams()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+
+        $this->setPermissionsTeamId(2);
+        $user1->givePermissionTo(['edit-articles', 'edit-news']);
+        $this->testUserRole->givePermissionTo('edit-articles');
+        $user2->assignRole('testRole');
+
+        $this->setPermissionsTeamId(1);
+        $user1->givePermissionTo(['edit-articles']);
+
+        $this->setPermissionsTeamId(2);
+        $scopedUsers1Team2 = User::permission(['edit-articles', 'edit-news'])->get();
+        $scopedUsers2Team2 = User::permission('edit-news')->get();
+
+        $this->assertEquals(2, $scopedUsers1Team2->count());
+        $this->assertEquals(1, $scopedUsers2Team2->count());
+
+        $this->setPermissionsTeamId(1);
+        $scopedUsers1Team1 = User::permission(['edit-articles', 'edit-news'])->get();
+        $scopedUsers2Team1 = User::permission('edit-news')->get();
+
+        $this->assertEquals(1, $scopedUsers1Team1->count());
+        $this->assertEquals(0, $scopedUsers2Team1->count());
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -165,6 +165,14 @@ abstract class TestCase extends Orchestra
         app(PermissionRegistrar::class)->setPermissionsTeamId($id);
     }
 
+    /**
+     * Get the team_id
+     */
+    protected function getPermissionsTeamId()
+    {
+        return app(PermissionRegistrar::class)->getPermissionsTeamId();
+    }
+
     public function createCacheTable()
     {
         Schema::create('cache', function ($table) {


### PR DESCRIPTION
- Possibility to retrieve Users that belong to a Team, based on roles/permissions assigned. #1905
- ~Better testing for scopes on teams~
- ~Fixed missing return on `getPermissionsTeamId()` helper~