### PR TITLE
[V5] Teams fixes(Only tests)

### DIFF
--- a/docs/basic-usage/teams-permissions.md
+++ b/docs/basic-usage/teams-permissions.md
@@ -34,12 +34,12 @@ class TeamsPermission{
     public function handle($request, \Closure $next){
         if(!empty(auth()->user())){
             // session value set on login
-            app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(session('team_id'));
+            setPermissionsTeamId(session('team_id'));
         }
         // other custom ways to get team_id
         /*if(!empty(auth('api')->user())){
             // `getTeamIdFromToken()` example of custom method for getting the set team_id 
-            app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId(auth('api')->user()->getTeamIdFromToken());
+            setPermissionsTeamId(auth('api')->user()->getTeamIdFromToken());
         }*/
         
         return $next($request);

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -41,7 +41,7 @@ class PermissionRegistrar
     /** @var string */
     public static $teamsKey;
 
-    /** @var int */
+    /** @var int|string */
     protected $teamId = null;
 
     /** @var string */
@@ -163,7 +163,7 @@ class PermissionRegistrar
      */
     private function loadPermissions()
     {
-        if ($this->permissions !== null) {
+        if ($this->permissions) {
             return;
         }
 

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Test;
 
+use DB;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -381,7 +382,7 @@ class HasPermissionsTest extends TestCase
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-news']),
-            $this->testUser->getPermissionsViaRoles()->pluck('name')
+            $this->testUser->getPermissionsViaRoles()->pluck('name')->sort()->values()
         );
     }
 
@@ -491,17 +492,16 @@ class HasPermissionsTest extends TestCase
         $user2 = new User(['email' => 'test2@user.com']);
         $user2->givePermissionTo('edit-articles');
 
-        \DB::enableQueryLog();
+        DB::enableQueryLog();
         $user2->save();
-        $querys = \DB::getQueryLog();
-        \DB::disableQueryLog();
+        DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
         $this->assertFalse($user->fresh()->hasPermissionTo('edit-articles'));
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */
@@ -514,17 +514,16 @@ class HasPermissionsTest extends TestCase
         $user2 = new User(['email' => 'test2@user.com']);
         $user2->syncPermissions('edit-articles');
 
-        \DB::enableQueryLog();
+        DB::enableQueryLog();
         $user2->save();
-        $querys = \DB::getQueryLog();
-        \DB::disableQueryLog();
+        DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasPermissionTo('edit-news'));
         $this->assertFalse($user->fresh()->hasPermissionTo('edit-articles'));
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/HasPermissionsWithCustomModelsTest.php
+++ b/tests/HasPermissionsWithCustomModelsTest.php
@@ -8,9 +8,8 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     protected $useCustomModels = true;
 
     /** @test */
-    public function it_can_use_custom_models()
+    public function it_can_use_custom_model_permission()
     {
-        $this->assertSame(get_class($this->testUserPermission), \Spatie\Permission\Test\Permission::class);
-        $this->assertSame(get_class($this->testUserRole), \Spatie\Permission\Test\Role::class);
+        $this->assertSame(get_class($this->testUserPermission), Permission::class);
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Test;
 
+use DB;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
@@ -246,17 +247,16 @@ class HasRolesTest extends TestCase
         $user2 = new User(['email' => 'admin@user.com']);
         $user2->syncRoles('testRole2');
 
-        \DB::enableQueryLog();
+        DB::enableQueryLog();
         $user2->save();
-        $querys = \DB::getQueryLog();
-        \DB::disableQueryLog();
+        DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasRole('testRole'));
         $this->assertFalse($user->fresh()->hasRole('testRole2'));
 
         $this->assertTrue($user2->fresh()->hasRole('testRole2'));
         $this->assertFalse($user2->fresh()->hasRole('testRole'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */
@@ -269,17 +269,16 @@ class HasRolesTest extends TestCase
         $admin_user = new User(['email' => 'admin@user.com']);
         $admin_user->assignRole('testRole2');
 
-        \DB::enableQueryLog();
+        DB::enableQueryLog();
         $admin_user->save();
-        $querys = \DB::getQueryLog();
-        \DB::disableQueryLog();
+        DB::disableQueryLog();
 
         $this->assertTrue($user->fresh()->hasRole('testRole'));
         $this->assertFalse($user->fresh()->hasRole('testRole2'));
 
         $this->assertTrue($admin_user->fresh()->hasRole('testRole2'));
         $this->assertFalse($admin_user->fresh()->hasRole('testRole'));
-        $this->assertSame(4, count($querys)); //avoid unnecessary sync
+        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/HasRolesWithCustomModelsTest.php
+++ b/tests/HasRolesWithCustomModelsTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+class HasRolesWithCustomModelsTest extends HasRolesTest
+{
+    /** @var bool */
+    protected $useCustomModels = true;
+
+    /** @test */
+    public function it_can_use_custom_model_role()
+    {
+        $this->assertSame(get_class($this->testUserRole), Role::class);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -46,16 +46,8 @@ abstract class TestCase extends Orchestra
         // Note: this also flushes the cache from within the migration
         $this->setUpDatabase($this->app);
         if ($this->hasTeams) {
-            $this->setPermissionsTeamId(1);
+            setPermissionsTeamId(1);
         }
-
-        $this->testUser = User::first();
-        $this->testUserRole = app(Role::class)->find(1);
-        $this->testUserPermission = app(Permission::class)->find(1);
-
-        $this->testAdmin = Admin::first();
-        $this->testAdminRole = app(Role::class)->find(3);
-        $this->testAdminPermission = app(Permission::class)->find(4);
 
         $this->setUpRoutes();
     }
@@ -137,32 +129,21 @@ abstract class TestCase extends Orchestra
 
         (new \CreatePermissionTables())->up();
 
-        User::create(['email' => 'test@user.com']);
-        Admin::create(['email' => 'admin@user.com']);
-        $app[Role::class]->create(['name' => 'testRole']);
+        $this->testUser = User::create(['email' => 'test@user.com']);
+        $this->testAdmin = Admin::create(['email' => 'admin@user.com']);
+        $this->testUserRole = $app[Role::class]->create(['name' => 'testRole']);
         $app[Role::class]->create(['name' => 'testRole2']);
-        $app[Role::class]->create(['name' => 'testAdminRole', 'guard_name' => 'admin']);
-        $app[Permission::class]->create(['name' => 'edit-articles']);
+        $this->testAdminRole = $app[Role::class]->create(['name' => 'testAdminRole', 'guard_name' => 'admin']);
+        $this->testUserPermission = $app[Permission::class]->create(['name' => 'edit-articles']);
         $app[Permission::class]->create(['name' => 'edit-news']);
         $app[Permission::class]->create(['name' => 'edit-blog']);
-        $app[Permission::class]->create(['name' => 'admin-permission', 'guard_name' => 'admin']);
+        $this->testAdminPermission = $app[Permission::class]->create(['name' => 'admin-permission', 'guard_name' => 'admin']);
         $app[Permission::class]->create(['name' => 'Edit News']);
     }
 
-    /**
-     * Reload the permissions.
-     */
     protected function reloadPermissions()
     {
         app(PermissionRegistrar::class)->forgetCachedPermissions();
-    }
-
-    /**
-     * Change the team_id
-     */
-    protected function setPermissionsTeamId(int $id)
-    {
-        app(PermissionRegistrar::class)->setPermissionsTeamId($id);
     }
 
     public function createCacheTable()


### PR DESCRIPTION
https://github.com/spatie/laravel-permission/pull/1910#issuecomment-960653613
>Could you create separate PRs for the other fixes?

Same as #1910, only without team scope
>To keep the package simple, I'd like to not pull in any new scope for now.

------

- Doc on team update using helper
- Better testing for scopes on teams
- Less querys on testing changing `$this->testUser = User::first();` for `$this->testUser = User::create()`(quickly)
- Small changes on test(only aesthetic and superficial)
- Use global helper `setPermissionsTeamId` on Tests
- ~~[**IMPORTANT**] Fixed missing return on `getPermissionsTeamId()` helper~~(Fixed on other PR)