### PR TITLE
[V5] Support for custom key names on Role,Permission

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -18,13 +18,15 @@ class Permission extends Model implements PermissionContract
     use HasRoles;
     use RefreshesPermissionCache;
 
-    protected $guarded = ['id'];
+    protected $guarded = [];
 
     public function __construct(array $attributes = [])
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
+
+        $this->guarded[] = $this->primaryKey;
     }
 
     public function getTable()

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -18,13 +18,15 @@ class Role extends Model implements RoleContract
     use HasPermissions;
     use RefreshesPermissionCache;
 
-    protected $guarded = ['id'];
+    protected $guarded = [];
 
     public function __construct(array $attributes = [])
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
 
         parent::__construct($attributes);
+
+        $this->guarded[] = $this->primaryKey;
     }
 
     public function getTable()

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -418,7 +418,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo('edit-news');
 
-        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck('id');
+        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck($this->testUserPermission->getKeyName());
 
         $this->testUser->syncPermissions($ids);
 
@@ -434,7 +434,7 @@ class HasPermissionsTest extends TestCase
     {
         $this->testUser->givePermissionTo('edit-news');
 
-        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck('id');
+        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-blog'])->pluck($this->testUserPermission->getKeyName());
 
         $ids->push(null);
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -22,13 +22,13 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUser->hasRole($role->name));
         $this->assertTrue($this->testUser->hasRole($role->name, $role->guard_name));
         $this->assertTrue($this->testUser->hasRole([$role->name, 'fakeRole'], $role->guard_name));
-        $this->assertTrue($this->testUser->hasRole($role->id, $role->guard_name));
-        $this->assertTrue($this->testUser->hasRole([$role->id, 'fakeRole'], $role->guard_name));
+        $this->assertTrue($this->testUser->hasRole($role->getKey(), $role->guard_name));
+        $this->assertTrue($this->testUser->hasRole([$role->getKey(), 'fakeRole'], $role->guard_name));
 
         $this->assertFalse($this->testUser->hasRole($role->name, 'fakeGuard'));
         $this->assertFalse($this->testUser->hasRole([$role->name, 'fakeRole'], 'fakeGuard'));
-        $this->assertFalse($this->testUser->hasRole($role->id, 'fakeGuard'));
-        $this->assertFalse($this->testUser->hasRole([$role->id, 'fakeRole'], 'fakeGuard'));
+        $this->assertFalse($this->testUser->hasRole($role->getKey(), 'fakeGuard'));
+        $this->assertFalse($this->testUser->hasRole([$role->getKey(), 'fakeRole'], 'fakeGuard'));
 
         $role = app(Role::class)->findOrCreate('testRoleInWebGuard2', 'web');
         $this->assertFalse($this->testUser->hasRole($role));
@@ -87,7 +87,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_a_role_using_an_id()
     {
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->assertTrue($this->testUser->hasRole($this->testUserRole));
     }
@@ -95,7 +95,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_multiple_roles_at_once()
     {
-        $this->testUser->assignRole($this->testUserRole->id, 'testRole2');
+        $this->testUser->assignRole($this->testUserRole->getKey(), 'testRole2');
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
@@ -105,7 +105,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_can_assign_multiple_roles_using_an_array()
     {
-        $this->testUser->assignRole([$this->testUserRole->id, 'testRole2']);
+        $this->testUser->assignRole([$this->testUserRole->getKey(), 'testRole2']);
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
@@ -115,7 +115,7 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_does_not_remove_already_associated_roles_when_assigning_new_roles()
     {
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->testUser->assignRole('testRole2');
 
@@ -125,9 +125,9 @@ class HasRolesTest extends TestCase
     /** @test */
     public function it_does_not_throw_an_exception_when_assigning_a_role_that_is_already_assigned()
     {
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
-        $this->testUser->assignRole($this->testUserRole->id);
+        $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->assertTrue($this->testUser->fresh()->hasRole('testRole'));
     }
@@ -352,7 +352,7 @@ class HasRolesTest extends TestCase
 
         $roleName = $this->testUserRole->name;
 
-        $otherRoleId = app(Role::class)->find(2)->id;
+        $otherRoleId = app(Role::class)->findByName('testRole2')->getKey();
 
         $scopedUsers = User::role([$roleName, $otherRoleId])->get();
 


### PR DESCRIPTION
https://github.com/spatie/laravel-permission/pull/1909#issuecomment-960652059
>Could you please break this PR up in smaller ones that are easier to review?

First part only changes propertie `id` to `getKey()` or `getKeyName()`
- Support for custom key names on Role,Permission model instead of defaut one.