### PR TITLE
[V5] Teams trait for adding relations and added team deleting logic

### DIFF
--- a/docs/basic-usage/teams-permissions.md
+++ b/docs/basic-usage/teams-permissions.md
@@ -72,8 +72,6 @@ The role/permission assignment and removal are the same, but they take the globa
 Global roles can be assigned to different teams, `team_id` as the primary key of the relationships is always required. If you want a "Super Admin" global role for a user, when you creates a new team you must assign it to your user. Example:
 
 ```php
-namespace App\Models;
-
 class YourTeamModel extends \Illuminate\Database\Eloquent\Model
 {
     // ...
@@ -96,3 +94,25 @@ class YourTeamModel extends \Illuminate\Database\Eloquent\Model
     // ...
 }
 ```
+
+## Optional Trait for Teams
+
+`TeamHasRoles` trait must be added to the Team model to enable features like cascade deleting.
+
+Thus, a typical basic Team model would have these basic minimum requirements:
+
+```php
+use Spatie\Permission\Traits\TeamHasRoles;
+
+class YourTeamModel extends \Illuminate\Database\Eloquent\Model
+{
+    use TeamHasRoles;
+
+    // ...
+}
+```
+
+**Prerequisites for `TeamHasRoles`**
+- Team model must not have a `permission` or `permissions` property, nor a `permissions()` method
+- Team model must not have a `role` or `roles` property, nor a `roles()` method
+- Team model must not have a `specific_role` or `specific_roles` property, nor a `specific_roles()` method

--- a/src/Traits/TeamHasRoles.php
+++ b/src/Traits/TeamHasRoles.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Spatie\Permission\Traits;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Permission\PermissionRegistrar;
+
+trait TeamHasRoles
+{
+    public static function bootTeamHasRoles()
+    {
+        static::deleting(function ($model) {
+            $modelHasSoftDeleting = method_exists($model, 'isForceDeleting');
+            $roleHasSoftDeleting = method_exists(app(PermissionRegistrar::class)->getRoleClass(), 'isForceDeleting');
+
+            if ($modelHasSoftDeleting && ! $model->isForceDeleting()) {
+                if ($roleHasSoftDeleting) {
+                    $model->specific_roles()->delete();
+                }
+
+                return;
+            }
+
+            $model->roles()->detach();
+            $model->permissions()->detach();
+
+            $roleDelete = $roleHasSoftDeleting && $modelHasSoftDeleting && $model->isForceDeleting() ? 'forceDelete' : 'delete';
+            $model->specific_roles()->$roleDelete();
+        });
+    }
+
+    /**
+     * A team may have multiple roles on multiple models.
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            app(PermissionRegistrar::class)->getRoleClass(),
+            config('permission.table_names.model_has_roles'),
+            PermissionRegistrar::$teamsKey,
+            PermissionRegistrar::$pivotRole
+        );
+    }
+
+    /**
+     * A team may have multiple specific roles.
+     */
+    public function specific_roles(): HasMany
+    {
+        return $this->hasMany(
+            app(PermissionRegistrar::class)->getRoleClass(),
+            PermissionRegistrar::$teamsKey
+        );
+    }
+
+    /**
+     * A team may have multiple direct permissions on multiple models.
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            app(PermissionRegistrar::class)->getPermissionClass(),
+            config('permission.table_names.model_has_permissions'),
+            PermissionRegistrar::$teamsKey,
+            PermissionRegistrar::$pivotPermission
+        );
+    }
+}

--- a/tests/SoftDeletingTeam.php
+++ b/tests/SoftDeletingTeam.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\Permission\Traits\TeamHasRoles;
+
+class SoftDeletingTeam extends Model
+{
+    use SoftDeletes;
+    use TeamHasRoles;
+
+    public $timestamps = false;
+
+    protected $table = 'teams';
+}

--- a/tests/Team.php
+++ b/tests/Team.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Traits\TeamHasRoles;
+
+class Team extends Model
+{
+    use TeamHasRoles;
+
+    public $timestamps = false;
+
+    protected $table = 'teams';
+}

--- a/tests/TeamTraitTest.php
+++ b/tests/TeamTraitTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Database\Schema\Blueprint;
+use Spatie\Permission\Contracts\Role;
+
+class TeamHasRolesTraitTest extends TestCase
+{
+    /** @var bool */
+    protected $hasTeams = true;
+
+    /** @var \Spatie\Permission\Test\Team */
+    protected $testTeam1;
+
+    /** @var \Spatie\Permission\Test\Team */
+    protected $testTeam2;
+
+    protected function setUpDatabase($app)
+    {
+        parent::setUpDatabase($app);
+
+        $app['db']->connection()->getSchemaBuilder()->create('teams', function (Blueprint $table) {
+            $table->increments('id');
+            $table->softDeletes();
+        });
+        $this->testTeam1 = Team::create([]);
+        $this->testTeam2 = Team::create([]);
+    }
+
+    /** @test */
+    public function it_deletes_pivot_table_entries_when_deleting_teams()
+    {
+        $user = User::create(['email' => 'user@test.com']);
+
+        setPermissionsTeamId($this->testTeam1->id);
+        $user->assignRole('testRole');
+        $user->givePermissionTo('edit-articles');
+        setPermissionsTeamId($this->testTeam2->id);
+        $user->assignRole('testRole2');
+        $user->givePermissionTo('edit-news');
+
+        setPermissionsTeamId($this->testTeam1->id);
+        $this->assertDatabaseHas('model_has_permissions', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+        $this->assertDatabaseHas('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+
+        setPermissionsTeamId($this->testTeam2->id);
+        $this->testTeam1->delete();
+
+        setPermissionsTeamId($this->testTeam1->id);
+        $this->assertDatabaseMissing('model_has_permissions', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+        $this->assertDatabaseMissing('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+
+        setPermissionsTeamId($this->testTeam2->id);
+        $this->assertDatabaseHas('model_has_permissions', [config('permission.column_names.team_foreign_key') => $this->testTeam2->id]);
+        $this->assertDatabaseHas('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam2->id]);
+    }
+
+    /** @test */
+    public function it_deletes_especific_role_entries_when_deleting_teams()
+    {
+        $roleTeam1 = app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => $this->testTeam1->id]);
+        $roleTeam2 = app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => $this->testTeam2->id]);
+        $user = User::create(['email' => 'user@test.com']);
+        $user->assignRole('testRole3');
+        setPermissionsTeamId($this->testTeam2->id);
+        $user->assignRole('testRole3');
+
+        $this->assertDatabaseHas('roles', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+        $this->assertDatabaseHas('roles', [config('permission.column_names.team_foreign_key') => $this->testTeam2->id]);
+        $this->assertDatabaseHas('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+        $this->assertDatabaseHas('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam2->id]);
+
+        $this->testTeam1->delete();
+
+        $this->assertDatabaseMissing('roles', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+        $this->assertDatabaseMissing('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam1->id]);
+        $this->assertDatabaseHas('roles', [config('permission.column_names.team_foreign_key') => $this->testTeam2->id]);
+        $this->assertDatabaseHas('model_has_roles', [config('permission.column_names.team_foreign_key') => $this->testTeam2->id]);
+    }
+
+    /** @test */
+    public function it_does_not_detach_roles_when_soft_deleting()
+    {
+        $user = User::create(['email' => 'test@example.com']);
+        setPermissionsTeamId($this->testTeam1->id);
+
+        $team1 = SoftDeletingTeam::find($this->testTeam1->id);
+        $roleTeam1 = app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => $team1->id]);
+        $user->assignRole('testRole');
+
+        $team1->delete();
+
+        $team1 = SoftDeletingTeam::onlyTrashed()->find($this->testTeam1->id);
+
+        $this->assertDatabaseHas('model_has_roles', [config('permission.column_names.team_foreign_key') => $team1->id]);
+        $this->assertDatabaseHas('roles', [config('permission.column_names.team_foreign_key') => $team1->id]);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/spatie/laravel-permission/discussions/1932
>if a role is removed then any related permissions and pivots will be removed but if a team is removed then the related records hang around in the package tables?

This PR detach roles/permissions when a team is deleted, also remove especific roles when they have `team_id`

**EDIT:** Doc added [teams-permissions.md#optional-trait-for-teams](https://github.com/erikn69/laravel-permission/blob/fix_delete_team/docs/basic-usage/teams-permissions.md#optional-trait-for-teams)