### PR TITLE
[V5] WherePivot instead of only Where on team relation pivot, better readability

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -44,18 +44,19 @@ trait HasPermissions
      */
     public function permissions(): BelongsToMany
     {
-        return $this->morphToMany(
+        $relation = $this->morphToMany(
             config('permission.models.permission'),
             'model',
             config('permission.table_names.model_has_permissions'),
             config('permission.column_names.model_morph_key'),
             PermissionRegistrar::$pivotPermission
-        )
-        ->where(function ($q) {
-            $q->when(PermissionRegistrar::$teams, function ($q) {
-                $q->where(PermissionRegistrar::$teamsKey, app(PermissionRegistrar::class)->getPermissionsTeamId());
-            });
-        });
+        );
+
+        if (! PermissionRegistrar::$teams) {
+            return $relation;
+        }
+
+        return $relation->wherePivot(PermissionRegistrar::$teamsKey, getPermissionsTeamId());
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -316,21 +316,6 @@ trait HasPermissions
     }
 
     /**
-     * Add teams pivot if teams are enabled
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
-     */
-    protected function getPermissionsRelation()
-    {
-        $relation = $this->permissions();
-        if (PermissionRegistrar::$teams && ! is_a($this, Role::class)) {
-            $relation->wherePivot(PermissionRegistrar::$teamsKey, app(PermissionRegistrar::class)->getPermissionsTeamId());
-        }
-
-        return $relation;
-    }
-
-    /**
      * Grant the given permission(s) to a role.
      *
      * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection $permissions
@@ -339,33 +324,30 @@ trait HasPermissions
      */
     public function givePermissionTo(...$permissions)
     {
-        $permissionClass = $this->getPermissionClass();
         $permissions = collect($permissions)
             ->flatten()
-            ->map(function ($permission) {
+            ->reduce(function ($array, $permission) {
                 if (empty($permission)) {
-                    return false;
+                    return $array;
                 }
 
-                return $this->getStoredPermission($permission);
-            })
-            ->filter(function ($permission) {
-                return $permission instanceof Permission;
-            })
-            ->each(function ($permission) {
+                $permission = $this->getStoredPermission($permission);
+                if (! $permission instanceof Permission) {
+                    return $array;
+                }
+
                 $this->ensureModelSharesGuard($permission);
-            })
-            ->map(function ($permission) {
-                return [$permission->getKeyName() => $permission->getKey(), 'values' => PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
-                    [PermissionRegistrar::$teamsKey => app(PermissionRegistrar::class)->getPermissionsTeamId()] : [],
-                ];
-            })
-            ->pluck('values', (new $permissionClass())->getKeyName())->toArray();
+
+                $array[$permission->getKey()] = PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
+                    [PermissionRegistrar::$teamsKey => getPermissionsTeamId()] : [];
+
+                return $array;
+            }, []);
 
         $model = $this->getModel();
 
         if ($model->exists) {
-            $this->getPermissionsRelation()->sync($permissions, false);
+            $this->permissions()->sync($permissions, false);
             $model->load('permissions');
         } else {
             $class = \get_class($model);
@@ -397,7 +379,7 @@ trait HasPermissions
      */
     public function syncPermissions(...$permissions)
     {
-        $this->getPermissionsRelation()->detach();
+        $this->permissions()->detach();
 
         return $this->givePermissionTo($permissions);
     }
@@ -411,7 +393,7 @@ trait HasPermissions
      */
     public function revokePermissionTo($permission)
     {
-        $this->getPermissionsRelation()->detach($this->getStoredPermission($permission));
+        $this->permissions()->detach($this->getStoredPermission($permission));
 
         if (is_a($this, get_class(app(PermissionRegistrar::class)->getRoleClass()))) {
             $this->forgetCachedPermissions();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -36,6 +36,6 @@ if (! function_exists('getPermissionsTeamId')) {
      */
     function getPermissionsTeamId()
     {
-        app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();
+        return app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();
     }
 }


### PR DESCRIPTION
- [IMPORTANT] Fixed missing return on `getPermissionsTeamId() `helper
- Better readability
- Early returns
- WherePivot instead of only Where(fix relations with teams, less code)
- Global helper `getPermissionsTeamId` used
- `assignRole`, `givePermissionTo` fixed(less code, less bucles with `reduce`, `ensureModelSharesGuard` throws earlier exception)

Works the same, no test nedded