### PR TITLE
Add Cache Repository getter on `PermissionRegistrar`

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -5,6 +5,8 @@ namespace Spatie\Permission;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Cache\Store;
 use Illuminate\Database\Eloquent\Collection;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
@@ -79,7 +81,7 @@ class PermissionRegistrar
         $this->cache = $this->getCacheStoreFromConfig();
     }
 
-    protected function getCacheStoreFromConfig(): \Illuminate\Contracts\Cache\Repository
+    protected function getCacheStoreFromConfig(): Repository
     {
         // the 'default' fallback here is from the permission.php config file,
         // where 'default' means to use config(cache.default)
@@ -265,12 +267,12 @@ class PermissionRegistrar
         return $this;
     }
 
-    /**
-     * Get the instance of the Cache Store.
-     *
-     * @return \Illuminate\Contracts\Cache\Store
-     */
-    public function getCacheStore(): \Illuminate\Contracts\Cache\Store
+    public function getCacheRepository(): Repository
+    {
+        return $this->cache;
+    }
+
+    public function getCacheStore(): Store
     {
         return $this->cache->getStore();
     }


### PR DESCRIPTION
Make public Cache Repository getter, usefull when creating custom traits and we want to manipulate permission cache repository 
Also acording https://spatie.be/guidelines/laravel-php#docblocks, phpdoc from `getCacheStore` removed