### PR TITLE
[V5] Scope Roles/Permissions by user(and team when available)

### DIFF
--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -52,4 +52,23 @@ class PermissionTest extends TestCase
 
         $this->assertEquals($this->testUserPermission->id, $permission_by_id->id);
     }
+
+    /** @test */
+    public function it_can_scope_direct_permissions_using_user_id()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user3 = User::create(['email' => 'user3@test.com']);
+
+        $user1->givePermissionTo(['edit-articles', 'edit-news']);
+        $user2->givePermissionTo('edit-articles');
+
+        $scopedPermissions1 = app(Permission::class)::user($user1)->get();
+        $scopedPermissions2 = app(Permission::class)::user($user2)->get();
+        $scopedPermissions3 = app(Permission::class)::user($user3->id)->get();
+
+        $this->assertEquals(['edit-articles', 'edit-news'], $scopedPermissions1->pluck('name')->toArray());
+        $this->assertEquals(['edit-articles'], $scopedPermissions2->pluck('name')->toArray());
+        $this->assertEquals([], $scopedPermissions3->pluck('name')->toArray());
+    }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -242,6 +242,25 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    public function it_can_scope_roles_using_user_id()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+        $user2 = User::create(['email' => 'user2@test.com']);
+        $user3 = User::create(['email' => 'user3@test.com']);
+
+        $user1->assignRole(['testRole', 'testRole2']);
+        $user2->assignRole('testRole');
+
+        $scopedRoles1 = app(Role::class)::user($user1)->get();
+        $scopedRoles2 = app(Role::class)::user($user2)->get();
+        $scopedRoles3 = app(Role::class)::user($user3->id)->get();
+
+        $this->assertEquals(['testRole', 'testRole2'], $scopedRoles1->pluck('name')->toArray());
+        $this->assertEquals(['testRole'], $scopedRoles2->pluck('name')->toArray());
+        $this->assertEquals([], $scopedRoles3->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_can_change_role_class_on_runtime()
     {
         $role = app(Role::class)->create(['name' => 'test-role-old']);

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -8,6 +8,25 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     protected $hasTeams = true;
 
     /** @test */
+    public function it_can_scope_direct_permissions_using_user_id_and_team_id()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        setPermissionsTeamId(1);
+        $user1->givePermissionTo(['edit-articles', 'edit-news']);
+        setPermissionsTeamId(2);
+        $user1->givePermissionTo('edit-articles');
+
+        $scopedPermissions1 = app(Permission::class)::user($user1, 1)->get();
+        $scopedPermissions2 = app(Permission::class)::user($user1, 2)->get();
+        $scopedPermissions3 = app(Permission::class)::user($user1->id, 3)->get();
+
+        $this->assertEquals(['edit-articles', 'edit-news'], $scopedPermissions1->pluck('name')->toArray());
+        $this->assertEquals(['edit-articles'], $scopedPermissions2->pluck('name')->toArray());
+        $this->assertEquals([], $scopedPermissions3->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_can_assign_same_and_different_permission_on_same_user_on_different_teams()
     {
         $this->setPermissionsTeamId(1);

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -10,6 +10,25 @@ class TeamHasRolesTest extends HasRolesTest
     protected $hasTeams = true;
 
     /** @test */
+    public function it_can_scope_roles_using_user_id_and_team_id()
+    {
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        setPermissionsTeamId(1);
+        $user1->syncRoles(['testRole', 'testRole2']);
+        setPermissionsTeamId(2);
+        $user1->syncRoles('testRole');
+
+        $scopedRoles1 = app(Role::class)::user($user1, 1)->get();
+        $scopedRoles2 = app(Role::class)::user($user1, 2)->get();
+        $scopedRoles3 = app(Role::class)::user($user1->id, 3)->get();
+
+        $this->assertEquals(['testRole', 'testRole2'], $scopedRoles1->pluck('name')->toArray());
+        $this->assertEquals(['testRole'], $scopedRoles2->pluck('name')->toArray());
+        $this->assertEquals([], $scopedRoles3->pluck('name')->toArray());
+    }
+
+    /** @test */
     public function it_can_assign_same_and_different_roles_on_same_user_different_teams()
     {
         app(Role::class)->create(['name' => 'testRole3']); //team_test_id = 1 by main class


### PR DESCRIPTION
https://github.com/spatie/laravel-permission/discussions/1947#discussioncomment-1738676
Useful when teams enabled and editing roles/permissions from an user and many teams(Admin Panel)

**Usage:**
```php
//when no teams enabled or wants default global team
Permission::user($USER_ID)->get(); 
Role::user($USER_ID)->get();
//with specific team
Permission::user($USER_ID, $TEAM_ID)->get();
Role::user($USER_ID, $TEAM_ID)->get();
```
Complements of `scopeRole`, `scopePermission`, but for `Role.php`, `Permission.php` models
https://github.com/spatie/laravel-permission/blob/08cc9bdbf89640cb1d64fb01eb9513c1cbb2549d/src/Traits/HasPermissions.php#L69-L91
https://github.com/spatie/laravel-permission/blob/08cc9bdbf89640cb1d64fb01eb9513c1cbb2549d/src/Traits/HasRoles.php#L74-L99