### PR TITLE
Adds documentation for `LazilyRefreshDatabase`

### DIFF
--- a/docs/advanced-usage/testing.md
+++ b/docs/advanced-usage/testing.md
@@ -20,6 +20,17 @@ In your tests simply add a `setUp()` instruction to re-register the permissions,
     }
 ```
 
+If you are using Laravels `LazilyRefreshDatabase` trait, you most likely want to avoid seeding permissions before every test, because that would negate the use of the `LazilyRefreshDatabase` trait. To overcome this, you should wrap your seeder in an event listener for the `MigrationsEnded` event:
+
+```php
+Event::listen(MigrationsEnded::class, function () {
+    $this->artisan('db:seed', ['--class' => RoleAndPermissionSeeder::class]);
+    $this->app->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+});
+```
+
+Note that we call `PermissionRegistrar::forgetCachedPermissions` after seeding. This is to prevent a caching issue that can occur when the database is set up after permissions have already been registered and cached. 
+
 ## Factories
 
 Many applications do not require using factories to create fake roles/permissions for testing, because they use a Seeder to create specific roles and permissions that the application uses; thus tests are performed using the declared roles and permissions.

--- a/docs/advanced-usage/testing.md
+++ b/docs/advanced-usage/testing.md
@@ -20,7 +20,7 @@ In your tests simply add a `setUp()` instruction to re-register the permissions,
     }
 ```
 
-If you are using Laravels `LazilyRefreshDatabase` trait, you most likely want to avoid seeding permissions before every test, because that would negate the use of the `LazilyRefreshDatabase` trait. To overcome this, you should wrap your seeder in an event listener for the `MigrationsEnded` event:
+If you are using Laravel's `LazilyRefreshDatabase` trait, you most likely want to avoid seeding permissions before every test, because that would negate the use of the `LazilyRefreshDatabase` trait. To overcome this, you should wrap your seeder in an event listener for the `MigrationsEnded` event:
 
 ```php
 Event::listen(MigrationsEnded::class, function () {


### PR DESCRIPTION
Howdy!

When using `LazilyRefreshDatabase`, you ideally want to avoid seeding before each and every test, because that makes the trait useless. The approach described in this doc PR shows how to get around this, and also shows the user how to avoid a caveat with cached permissions when lazily refreshing the database.

Thanks for all the hard work!

Kind Regards,
Luke