### PR TITLE
Disable foreign key checks in teams migration

### DIFF
--- a/database/migrations/add_teams_fields.php.stub
+++ b/database/migrations/add_teams_fields.php.stub
@@ -33,6 +33,8 @@ class AddTeamsFields extends Migration
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
             }
         });
+        
+        Schema::disableForeignKeyConstraints();
 
         Schema::table($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
             if (! Schema::hasColumn($tableNames['model_has_permissions'], $columnNames['team_foreign_key'])) {


### PR DESCRIPTION
Suggested fix to #1957 