### PR TITLE
Fix teams upgrade migration

### DIFF
--- a/database/migrations/add_teams_fields.php.stub
+++ b/database/migrations/add_teams_fields.php.stub
@@ -1,8 +1,10 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\PermissionRegistrar;
 
 class AddTeamsFields extends Migration
 {
@@ -27,34 +29,50 @@ class AddTeamsFields extends Migration
             throw new \Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.');
         }
 
-        Schema::table($tableNames['roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
-            if (! Schema::hasColumn($tableNames['roles'], $columnNames['team_foreign_key'])) {
+        if (! Schema::hasColumn($tableNames['roles'], $columnNames['team_foreign_key'])) {
+            Schema::table($tableNames['roles'], function (Blueprint $table) use ($columnNames) {
                 $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
-            }
-        });
+            });
+        }
 
-        Schema::table($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
-            if (! Schema::hasColumn($tableNames['model_has_permissions'], $columnNames['team_foreign_key'])) {
+        if (! Schema::hasColumn($tableNames['model_has_permissions'], $columnNames['team_foreign_key'])) {
+            Schema::table($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames) {
                 $table->unsignedBigInteger($columnNames['team_foreign_key'])->default('1');;
                 $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
 
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->dropForeign([PermissionRegistrar::$pivotPermission]);
+                }
                 $table->dropPrimary();
-                $table->primary([$columnNames['team_foreign_key'], 'permission_id', $columnNames['model_morph_key'], 'model_type'],
-                    'model_has_permissions_permission_model_type_primary');
-            }
-        });
 
-        Schema::table($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
-            if (! Schema::hasColumn($tableNames['model_has_roles'], $columnNames['team_foreign_key'])) {
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->foreign(PermissionRegistrar::$pivotPermission)
+                        ->references('id')->on($tableNames['permissions'])->onDelete('cascade');
+                }
+            });
+        }
+
+        if (! Schema::hasColumn($tableNames['model_has_roles'], $columnNames['team_foreign_key'])) {
+            Schema::table($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
                 $table->unsignedBigInteger($columnNames['team_foreign_key'])->default('1');;
                 $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
 
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->dropForeign([PermissionRegistrar::$pivotRole]);
+                }
                 $table->dropPrimary();
-                $table->primary([$columnNames['team_foreign_key'], 'role_id', $columnNames['model_morph_key'], 'model_type'],
+
+                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary');
-            }
-        });
+                if (DB::getDriverName() !== 'sqlite') {
+                    $table->foreign(PermissionRegistrar::$pivotRole)
+                        ->references('id')->on($tableNames['roles'])->onDelete('cascade');
+                }
+            });
+        }
 
         app('cache')
             ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)


### PR DESCRIPTION
Closes #1957

- Avoid `"Foreign key constraint is incorrectly formed"` described on #1957
- Support for custom pivots(`PermissionRegistrar::$pivotRole`, `PermissionRegistrar::$pivotPermission`)


**To Reproduce Bug**
Steps to reproduce the behavior:

- Delete `xxxx_xx_xx_xxxxxx_add_teams_fields.php` from `database/migrations`
- Update config to disable Teams `'teams' => false,`
- Run `php artisan migrate:fresh`
- Update config to enable Teams `'teams' => true,`
- Run `php artisan permission:setup-teams`
- Run `php artisan migrate`

https://github.com/spatie/laravel-permission/blob/08cc9bdbf89640cb1d64fb01eb9513c1cbb2549d/tests/CommandTest.php#L135-L159