### PR TITLE
[V5] Fix `Duplicate entry 'roles_name_guard_name_unique'` on migration for teams

### DIFF
--- a/database/migrations/add_teams_fields.php.stub
+++ b/database/migrations/add_teams_fields.php.stub
@@ -31,8 +31,11 @@ class AddTeamsFields extends Migration
 
         if (! Schema::hasColumn($tableNames['roles'], $columnNames['team_foreign_key'])) {
             Schema::table($tableNames['roles'], function (Blueprint $table) use ($columnNames) {
-                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable()->after('id');
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+
+                $table->dropUnique('roles_name_guard_name_unique');
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
             });
         }
 


### PR DESCRIPTION
Closes #1966