### PR TITLE
Fix links to docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,7 +17,7 @@ $user->assignRole('writer');
 $role->givePermissionTo('edit articles');
 ```
 
-If you're using multiple guards we've got you covered as well. Every guard will have its own set of permissions and roles that can be assigned to the guard's users. Read about it in the [using multiple guards](https://docs.spatie.be/laravel-permission/v5/basic-usage/multiple-guards/) section.
+If you're using multiple guards we've got you covered as well. Every guard will have its own set of permissions and roles that can be assigned to the guard's users. Read about it in the [using multiple guards](./basic-usage/multiple-guards/) section.
 
 Because all permissions will be registered on [Laravel's gate](https://laravel.com/docs/authorization), you can check if a user has a permission with Laravel's default `can` function:
 


### PR DESCRIPTION
~~Closes #1972~~(Fixed on https://github.com/spatie/laravel-permission/commit/94443e59d64c90186c65000ac0859c8120f76379)
Complement of #1965

~~@freekmurze  also link on `Edit repository details` must be changed
`https://docs.spatie.be/laravel-permission` to `https://spatie.be/docs/laravel-permission`~~

