### PR TITLE
Update documentation link (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Documentation, Installation, and Usage Instructions
 
-See the [DOCUMENTATION](https://docs.spatie.be/laravel-permission/v3/introduction/) for detailed installation and usage instructions.
+See the [DOCUMENTATION](https://spatie.be/docs/laravel-permission/v3/introduction/) for detailed installation and usage instructions.
 
 ## What It Does
 This package allows you to manage user permissions and roles in a database.


### PR DESCRIPTION
This PR updates the URL for documentation in v3 to use `spatie.be/docs/*` instead of `docs.spatie.be`. Resolves #1972 for v3 branch.