### PR TITLE
Fix Blade Directives incompatibility with renderers

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -84,65 +84,65 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerBladeExtensions()
     {
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
-            $bladeCompiler->directive('role', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+        $bladeCompiler = $this->app['blade.compiler'];
 
-                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
-            });
-            $bladeCompiler->directive('elserole', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+        $bladeCompiler->directive('role', function ($arguments) {
+            list($role, $guard) = explode(',', $arguments.',');
 
-                return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
-            });
-            $bladeCompiler->directive('endrole', function () {
-                return '<?php endif; ?>';
-            });
+            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+        });
+        $bladeCompiler->directive('elserole', function ($arguments) {
+            list($role, $guard) = explode(',', $arguments.',');
 
-            $bladeCompiler->directive('hasrole', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+            return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+        });
+        $bladeCompiler->directive('endrole', function () {
+            return '<?php endif; ?>';
+        });
 
-                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
-            });
-            $bladeCompiler->directive('endhasrole', function () {
-                return '<?php endif; ?>';
-            });
+        $bladeCompiler->directive('hasrole', function ($arguments) {
+            list($role, $guard) = explode(',', $arguments.',');
 
-            $bladeCompiler->directive('hasanyrole', function ($arguments) {
-                list($roles, $guard) = explode(',', $arguments.',');
+            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+        });
+        $bladeCompiler->directive('endhasrole', function () {
+            return '<?php endif; ?>';
+        });
 
-                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyRole({$roles})): ?>";
-            });
-            $bladeCompiler->directive('endhasanyrole', function () {
-                return '<?php endif; ?>';
-            });
+        $bladeCompiler->directive('hasanyrole', function ($arguments) {
+            list($roles, $guard) = explode(',', $arguments.',');
 
-            $bladeCompiler->directive('hasallroles', function ($arguments) {
-                list($roles, $guard) = explode(',', $arguments.',');
+            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyRole({$roles})): ?>";
+        });
+        $bladeCompiler->directive('endhasanyrole', function () {
+            return '<?php endif; ?>';
+        });
 
-                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
-            });
-            $bladeCompiler->directive('endhasallroles', function () {
-                return '<?php endif; ?>';
-            });
+        $bladeCompiler->directive('hasallroles', function ($arguments) {
+            list($roles, $guard) = explode(',', $arguments.',');
 
-            $bladeCompiler->directive('unlessrole', function ($arguments) {
-                list($role, $guard) = explode(',', $arguments.',');
+            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
+        });
+        $bladeCompiler->directive('endhasallroles', function () {
+            return '<?php endif; ?>';
+        });
 
-                return "<?php if(!auth({$guard})->check() || ! auth({$guard})->user()->hasRole({$role})): ?>";
-            });
-            $bladeCompiler->directive('endunlessrole', function () {
-                return '<?php endif; ?>';
-            });
+        $bladeCompiler->directive('unlessrole', function ($arguments) {
+            list($role, $guard) = explode(',', $arguments.',');
 
-            $bladeCompiler->directive('hasexactroles', function ($arguments) {
-                list($roles, $guard) = explode(',', $arguments.',');
+            return "<?php if(!auth({$guard})->check() || ! auth({$guard})->user()->hasRole({$role})): ?>";
+        });
+        $bladeCompiler->directive('endunlessrole', function () {
+            return '<?php endif; ?>';
+        });
 
-                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasExactRoles({$roles})): ?>";
-            });
-            $bladeCompiler->directive('endhasexactroles', function () {
-                return '<?php endif; ?>';
-            });
+        $bladeCompiler->directive('hasexactroles', function ($arguments) {
+            list($roles, $guard) = explode(',', $arguments.',');
+
+            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasExactRoles({$roles})): ?>";
+        });
+        $bladeCompiler->directive('endhasexactroles', function () {
+            return '<?php endif; ?>';
         });
     }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Contracts\Role as RoleContract;
 


### PR DESCRIPTION
Closes #2038
>When `spatie/laravel-markdown` and `spatie/laravel-permission` are installed the `@role` type directives are displayed as part of the HTML.

With `spatie/laravel-markdown` all `laravel-permission` blade directives stop working

Based on [spatie/laravel-blade-javascript](https://github.com/spatie/laravel-blade-javascript) which it is working with `spatie/laravel-markdown`
https://github.com/spatie/laravel-blade-javascript/blob/1a0d5daaf91e123799b0250b216f75d30264502a/src/BladeJavaScriptServiceProvider.php#L21

