### PR TITLE
Revert #2039 - register blade directives after resolving blade compiler

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -39,7 +39,6 @@ class PermissionServiceProvider extends ServiceProvider
             'permission'
         );
 
-        });
         $this->registerBladeExtensions();
     }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -39,6 +39,7 @@ class PermissionServiceProvider extends ServiceProvider
             'permission'
         );
 
+        });
         $this->registerBladeExtensions();
     }
 
@@ -83,65 +84,65 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerBladeExtensions()
     {
-        $bladeCompiler = $this->app['blade.compiler'];
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+            $bladeCompiler->directive('role', function ($arguments) {
+                list($role, $guard) = explode(',', $arguments.',');
 
-        $bladeCompiler->directive('role', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+            });
+            $bladeCompiler->directive('elserole', function ($arguments) {
+                list($role, $guard) = explode(',', $arguments.',');
 
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
-        });
-        $bladeCompiler->directive('elserole', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
+                return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+            });
+            $bladeCompiler->directive('endrole', function () {
+                return '<?php endif; ?>';
+            });
 
-            return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
-        });
-        $bladeCompiler->directive('endrole', function () {
-            return '<?php endif; ?>';
-        });
+            $bladeCompiler->directive('hasrole', function ($arguments) {
+                list($role, $guard) = explode(',', $arguments.',');
 
-        $bladeCompiler->directive('hasrole', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+            });
+            $bladeCompiler->directive('endhasrole', function () {
+                return '<?php endif; ?>';
+            });
 
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
-        });
-        $bladeCompiler->directive('endhasrole', function () {
-            return '<?php endif; ?>';
-        });
+            $bladeCompiler->directive('hasanyrole', function ($arguments) {
+                list($roles, $guard) = explode(',', $arguments.',');
 
-        $bladeCompiler->directive('hasanyrole', function ($arguments) {
-            list($roles, $guard) = explode(',', $arguments.',');
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyRole({$roles})): ?>";
+            });
+            $bladeCompiler->directive('endhasanyrole', function () {
+                return '<?php endif; ?>';
+            });
 
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyRole({$roles})): ?>";
-        });
-        $bladeCompiler->directive('endhasanyrole', function () {
-            return '<?php endif; ?>';
-        });
+            $bladeCompiler->directive('hasallroles', function ($arguments) {
+                list($roles, $guard) = explode(',', $arguments.',');
 
-        $bladeCompiler->directive('hasallroles', function ($arguments) {
-            list($roles, $guard) = explode(',', $arguments.',');
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
+            });
+            $bladeCompiler->directive('endhasallroles', function () {
+                return '<?php endif; ?>';
+            });
 
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
-        });
-        $bladeCompiler->directive('endhasallroles', function () {
-            return '<?php endif; ?>';
-        });
+            $bladeCompiler->directive('unlessrole', function ($arguments) {
+                list($role, $guard) = explode(',', $arguments.',');
 
-        $bladeCompiler->directive('unlessrole', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
+                return "<?php if(!auth({$guard})->check() || ! auth({$guard})->user()->hasRole({$role})): ?>";
+            });
+            $bladeCompiler->directive('endunlessrole', function () {
+                return '<?php endif; ?>';
+            });
 
-            return "<?php if(!auth({$guard})->check() || ! auth({$guard})->user()->hasRole({$role})): ?>";
-        });
-        $bladeCompiler->directive('endunlessrole', function () {
-            return '<?php endif; ?>';
-        });
+            $bladeCompiler->directive('hasexactroles', function ($arguments) {
+                list($roles, $guard) = explode(',', $arguments.',');
 
-        $bladeCompiler->directive('hasexactroles', function ($arguments) {
-            list($roles, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasExactRoles({$roles})): ?>";
-        });
-        $bladeCompiler->directive('endhasexactroles', function () {
-            return '<?php endif; ?>';
+                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasExactRoles({$roles})): ?>";
+            });
+            $bladeCompiler->directive('endhasexactroles', function () {
+                return '<?php endif; ?>';
+            });
         });
     }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Compilers\BladeCompiler;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Contracts\Role as RoleContract;
 


### PR DESCRIPTION
This PR reverts #2039 , because that PR:
- caused bug https://github.com/spatie/laravel-permission/issues/2044
- made `laravel-permission` compatible with `laravel-markdown`, but **incompatible** with A LOT of very popular Laravel packages, including but not limited to:
    - https://github.com/404labfr/laravel-impersonate
    - https://github.com/albertcht/invisible-recaptcha
    - https://github.com/tighten/ziggy
    - https://github.com/laravel-backpack/crud

@erikn69 **can you please take a look and confirm my logic and PR here?** I think your opinion is very important here to confirm this is a good solution and bring this to an end.

---

Here's the "_executive summary_" for @freekmurze , so that he doesn't spend hours to understand why this is needed:

# Premise

It matters _how_ blade directives are loaded, because:
- packages that use `Blade::directive()` will work with packages that use `Blade::directive()`
- packages that use `afterResolving` will work with packages that use `afterResolving`
- if you have just one package that uses the "other kind" of loading in your Laravel app, the other packages will no longer load their directives;

So we package maintainers have to pick one, and all stick to it. And it's been decided by the crowd: **the most popular packages already use `afterResolving`**. Even taken in isolation, I would argue that it's _better_ for packages to use `afterResolving`, because package should NOT force the resolving of that class. It's better to wait for its natural resolving and just add stuff to the end.


# What happened

Here's a summary:
- for years, `laravel-permission` has been using `afterResolving`;
- issue #2038 came up, saying this package is incompatible with `spatie/laravel-markdown`;
- @erikn69 was kind enough to take a look, and fixed it in #2039 (the PR this reverts) ; the problem is:
    - the fix changes `afterResolving` to `Blade:directive()`, which I think was a mistake;
    - the mindset was the problem: it's not that `spatie/laravel-permission` is incompatible with `spatie/laravel-markdown`, but the other way around: markdown (with 25k downloads) is incompatible with permission (with 7M downloads); **the fix should have been made in `spatie/laravel-markdown`, not in `spatie/laravel-permission`**;
- after that PR was merged, bug #2044 was reported, which then @erikn69 promptly fixed in #2045; 
- other bug reports will follow, as people try to install `spatie/laravel-permission` in combination with other popular packages, since most of them use `afterResolving`;

---

By merging this PR and reverting #2039 :
- [ ] https://github.com/spatie/laravel-permission/issues/2044 will be fixed;
- [ ] https://github.com/spatie/laravel-permission/pull/2045 will no longer be needed, and can be closed;
- [ ] this package becomes compatible with the other popular Laravel packages again;

Going forward, to fix the original issue ( #2038 ), I think a PR should be submitted in `laravel-markdown`, for it to use `afterResolving` too. Happy to help with that if you want.

@freekmurze , @erikn69 - let me know if you have any questions. I've went down the BladeCompiler rabbit hole 1 month ago, it's quite difficult to understand. Of course, let me know if I'm entirely wrong, it wouldn't be the first time 😅 Though I believe I'm right on this one, and we should stick to `afterResolving`, since it's been working well for years.

Cheers!