### PR TITLE
Fix markdown code issues in install guide

### DIFF
--- a/docs/installation-laravel.md
+++ b/docs/installation-laravel.md
@@ -15,35 +15,41 @@ This package can be used with Laravel 6.0 or higher.
 
 3. You can install the package via composer:
 
-        composer require spatie/laravel-permission
+```
+composer require spatie/laravel-permission
+```
 
 4. Optional: The service provider will automatically get registered. Or you may manually add the service provider in your `config/app.php` file:
 
-    ```
-    'providers' => [
-        // ...
-        Spatie\Permission\PermissionServiceProvider::class,
-    ];
-    ```
+```
+'providers' => [
+    // ...
+    Spatie\Permission\PermissionServiceProvider::class,
+];
+```
 
 5. You should publish [the migration](https://github.com/spatie/laravel-permission/blob/main/database/migrations/create_permission_tables.php.stub) and the [`config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/main/config/permission.php) with:
 
-    ```
-    php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider"
-    ```
+```
+php artisan vendor:publish --provider="Spatie\Permission\PermissionServiceProvider"
+```
 
 6. NOTE: If you are using UUIDs, see the Advanced section of the docs on UUID steps, before you continue. It explains some changes you may want to make to the migrations and config file before continuing. It also mentions important considerations after extending this package's models for UUID capability.
     If you are going to use teams feature, you have to update your [`config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/main/config/permission.php) and set `'teams' => true,`, if you want to use a custom foreign key for teams you must change `team_foreign_key`.
 
 7. Clear your config cache. This package requires access to the `permission` config. Generally it's bad practice to do config-caching in a development environment. If you've been caching configurations locally, clear your config cache with either of these commands:
 
-        php artisan optimize:clear
-        # or
-        php artisan config:clear
+```
+php artisan optimize:clear
+# or
+php artisan config:clear
+```
 
 8. Run the migrations: After the config and migration have been published and configured, you can create the tables for this package by running:
 
-        php artisan migrate
+```
+php artisan migrate
+```
 
 9. Add the necessary trait to your User model: Consult the Basic Usage section of the docs for how to get started using the features of this package.
 


### PR DESCRIPTION
Right now, in the docs, the commands & code snippets are being formatted oddly. I've tried to fix it but can't confirm as I don't know how the docs work but pretty confident it'll make some kind of improvement.

![image](https://user-images.githubusercontent.com/19637309/158583803-2946fc4b-7976-45eb-b491-587152457087.png)
