### PR TITLE
[V5] Custom primary keys support on `Role`, `Permission` models

### DIFF
--- a/.github/workflows/run-tests-L7.yml
+++ b/.github/workflows/run-tests-L7.yml
@@ -15,6 +15,10 @@ jobs:
         include:
           - laravel: 7.*
             testbench: 5.20
+        exclude:
+          - laravel: 7.*
+            php: 8.0
+            dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ tests/temp
 .idea
 .phpunit.result.cache
 .php-cs-fixer.cache
-
+tests/CreatePermissionCustomTables.php

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -26,7 +26,7 @@ class CreatePermissionTables extends Migration
         }
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->bigIncrements('id'); // permission id
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
@@ -35,7 +35,7 @@ class CreatePermissionTables extends Migration
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) use ($teams, $columnNames) {
-            $table->bigIncrements('id');
+            $table->bigIncrements('id'); // role id
             if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
                 $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
@@ -58,7 +58,7 @@ class CreatePermissionTables extends Migration
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
 
             $table->foreign(PermissionRegistrar::$pivotPermission)
-                ->references('id')
+                ->references('id') // permission id
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
             if ($teams) {
@@ -82,7 +82,7 @@ class CreatePermissionTables extends Migration
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
 
             $table->foreign(PermissionRegistrar::$pivotRole)
-                ->references('id')
+                ->references('id') // role id
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
             if ($teams) {
@@ -102,12 +102,12 @@ class CreatePermissionTables extends Migration
             $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
 
             $table->foreign(PermissionRegistrar::$pivotPermission)
-                ->references('id')
+                ->references('id') // permission id
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
             $table->foreign(PermissionRegistrar::$pivotRole)
-                ->references('id')
+                ->references('id') // role id
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -108,7 +108,7 @@ class Permission extends Model implements PermissionContract
     public static function findById(int $id, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermission(['id' => $id, 'guard_name' => $guardName]);
+        $permission = static::getPermission([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -115,7 +115,7 @@ class Role extends Model implements RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $role = static::findByParam(['id' => $id, 'guard_name' => $guardName]);
+        $role = static::findByParam([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $role) {
             throw RoleDoesNotExist::withId($id);

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -273,10 +273,10 @@ class PermissionRegistrar
     private function getSerializedPermissionsForCache()
     {
         $roleClass = $this->getRoleClass();
-        $roleKey = (new $roleClass())->getKeyName();
+        $roleKey = (new $roleClass())->getTable().'.'.(new $roleClass())->getKeyName();
 
         $permissionClass = $this->getPermissionClass();
-        $permissionKey = (new $permissionClass())->getKeyName();
+        $permissionKey = (new $permissionClass())->getTable().'.'.(new $permissionClass())->getKeyName();
 
         $permissions = $permissionClass
             ->select($permissionKey, "$permissionKey as i", 'name as n', 'guard_name as g')

--- a/tests/Permission.php
+++ b/tests/Permission.php
@@ -4,8 +4,10 @@ namespace Spatie\Permission\Test;
 
 class Permission extends \Spatie\Permission\Models\Permission
 {
+    protected $primaryKey = 'permission_test_id';
+
     protected $visible = [
-      'id',
+      'permission_test_id',
       'name',
     ];
 }

--- a/tests/Role.php
+++ b/tests/Role.php
@@ -4,8 +4,10 @@ namespace Spatie\Permission\Test;
 
 class Role extends \Spatie\Permission\Models\Role
 {
+    protected $primaryKey = 'role_test_id';
+
     protected $visible = [
-      'id',
+      'role_test_id',
       'name',
     ];
 }


### PR DESCRIPTION
Sometimes is needed use other primary key name than `id`, like when somebody uses UUID format, normally use `uuid` as name for primary keys

Added a temporal modificated migration for test this (`CreatePermissionCustomTables`), it is created once on the fly with replace function