### PR TITLE
Support custom primary key names on models

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -108,7 +108,7 @@ class Permission extends Model implements PermissionContract
     public static function findById(int $id, $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermission(['id' => $id, 'guard_name' => $guardName]);
+        $permission = static::getPermission([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -115,7 +115,7 @@ class Role extends Model implements RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $role = static::findByParam(['id' => $id, 'guard_name' => $guardName]);
+        $role = static::findByParam([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $role) {
             throw RoleDoesNotExist::withId($id);


### PR DESCRIPTION
Sometimes is needed use other primary key name than `id`, like when somebody uses UUID format, normally use `uuid` as name for primary keys, or when somebody implements "laravel-permission" in a existing project (#1805)