### PR TITLE
Fix UuidTrait on uuid doc page

### DIFF
--- a/docs/advanced-usage/uuid.md
+++ b/docs/advanced-usage/uuid.md
@@ -96,10 +96,8 @@ It is common to use a trait to handle the $keyType and $incrementing settings, a
 
     trait UuidTrait
     {
-        protected static function bootUuidTrait()
+        public static function bootUuidTrait()
         {
-            parent::boot();
-
             static::creating(function ($model) {
                 $model->keyType = 'string';
                 $model->incrementing = false;


### PR DESCRIPTION
Boot method having protected it should be public and no need to call parent boot method