### PR TITLE
Custom primary keys tests(Only tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ tests/temp
 .idea
 .phpunit.result.cache
 .php-cs-fixer.cache
-
+tests/CreatePermissionCustomTables.php

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -26,7 +26,7 @@ class CreatePermissionTables extends Migration
         }
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->bigIncrements('id'); // permission id
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
@@ -35,7 +35,7 @@ class CreatePermissionTables extends Migration
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) use ($teams, $columnNames) {
-            $table->bigIncrements('id');
+            $table->bigIncrements('id'); // role id
             if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
                 $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
@@ -58,7 +58,7 @@ class CreatePermissionTables extends Migration
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
 
             $table->foreign(PermissionRegistrar::$pivotPermission)
-                ->references('id')
+                ->references('id') // permission id
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
             if ($teams) {
@@ -82,7 +82,7 @@ class CreatePermissionTables extends Migration
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
 
             $table->foreign(PermissionRegistrar::$pivotRole)
-                ->references('id')
+                ->references('id') // role id
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
             if ($teams) {
@@ -102,12 +102,12 @@ class CreatePermissionTables extends Migration
             $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
 
             $table->foreign(PermissionRegistrar::$pivotPermission)
-                ->references('id')
+                ->references('id') // permission id
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
             $table->foreign(PermissionRegistrar::$pivotRole)
-                ->references('id')
+                ->references('id') // role id
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 

--- a/tests/Permission.php
+++ b/tests/Permission.php
@@ -4,8 +4,10 @@ namespace Spatie\Permission\Test;
 
 class Permission extends \Spatie\Permission\Models\Permission
 {
+    protected $primaryKey = 'permission_test_id';
+
     protected $visible = [
-      'id',
+      'permission_test_id',
       'name',
     ];
 }

--- a/tests/Role.php
+++ b/tests/Role.php
@@ -4,8 +4,10 @@ namespace Spatie\Permission\Test;
 
 class Role extends \Spatie\Permission\Models\Role
 {
+    protected $primaryKey = 'role_test_id';
+
     protected $visible = [
-      'id',
+      'role_test_id',
       'name',
     ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,9 +39,16 @@ abstract class TestCase extends Orchestra
     /** @var bool */
     protected $hasTeams = false;
 
+    protected static $migration;
+    protected static $customMigration;
+
     public function setUp(): void
     {
         parent::setUp();
+
+        if (! self::$migration) {
+            $this->prepareMigration();
+        }
 
         // Note: this also flushes the cache from within the migration
         $this->setUpDatabase($this->app);
@@ -125,9 +132,11 @@ abstract class TestCase extends Orchestra
             $this->createCacheTable();
         }
 
-        include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
-
-        (new \CreatePermissionTables())->up();
+        if (! $this->useCustomModels) {
+            self::$migration->up();
+        } else {
+            self::$customMigration->up();
+        }
 
         $this->testUser = User::create(['email' => 'test@user.com']);
         $this->testAdmin = Admin::create(['email' => 'admin@user.com']);
@@ -139,6 +148,35 @@ abstract class TestCase extends Orchestra
         $app[Permission::class]->create(['name' => 'edit-blog']);
         $this->testAdminPermission = $app[Permission::class]->create(['name' => 'admin-permission', 'guard_name' => 'admin']);
         $app[Permission::class]->create(['name' => 'Edit News']);
+    }
+
+    private function prepareMigration()
+    {
+        $migration = str_replace(
+            [
+                'CreatePermissionTables',
+                '(\'id\'); // permission id',
+                '(\'id\'); // role id',
+                'references(\'id\') // permission id',
+                'references(\'id\') // role id',
+            ],
+            [
+                'CreatePermissionCustomTables',
+                '(\'permission_test_id\');',
+                '(\'role_test_id\');',
+                'references(\'permission_test_id\')',
+                'references(\'role_test_id\')',
+            ],
+            file_get_contents(__DIR__.'/../database/migrations/create_permission_tables.php.stub')
+        );
+
+        file_put_contents(__DIR__.'/CreatePermissionCustomTables.php', $migration);
+
+        include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
+        self::$migration = new \CreatePermissionTables();
+
+        include_once __DIR__.'/CreatePermissionCustomTables.php';
+        self::$customMigration = new \CreatePermissionCustomTables();
     }
 
     protected function reloadPermissions()


### PR DESCRIPTION
**For avoid breaking this again on the future**

- Complement of  #2092

-----
Also using variables for migrations as starting point for future anonymous migrations support

```php
protected static $migration;
protected static $customMigration;
```

