### PR TITLE
Avoid calling the config helper in the role/perm model constructor

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -22,8 +22,6 @@ class Permission extends Model implements PermissionContract
 
     public function __construct(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
-
         parent::__construct($attributes);
 
         $this->guarded[] = $this->primaryKey;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -22,8 +22,6 @@ class Role extends Model implements RoleContract
 
     public function __construct(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
-
         parent::__construct($attributes);
 
         $this->guarded[] = $this->primaryKey;


### PR DESCRIPTION
I described the problem in #2097 with initializing the config.
I propose a solution.

Fixes #2097