### PR TITLE
Detach permissions, roles from user when not soft deleting

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -193,6 +193,6 @@ class Role extends Model implements RoleContract
             throw GuardDoesNotMatch::create($permission->guard_name, $this->getGuardNames());
         }
 
-        return $this->permissions->contains('id', $permission->id);
+        return $this->permissions->contains($permission->getKeyName(), $permission->getKey());
     }
 }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -27,6 +27,16 @@ trait HasPermissions
                 return;
             }
 
+            if (is_a($model, get_class($model->getPermissionClass()))) {
+                $model->users()->detach();
+
+                return;
+            }
+
+            if (is_a($model, get_class(app(PermissionRegistrar::class)->getRoleClass()))) {
+                $model->users()->detach();
+            }
+
             $model->permissions()->detach();
         });
     }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -572,6 +572,28 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function it_detach_roles_when_deleting()
+    {
+        $user = User::create(['email' => 'user1@test.com']);
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+        $this->testUserPermission->assignRole('testRole2');
+        $user->assignRole($this->testUserRole->name, 'testRole2');
+
+        $this->testUserRole->delete();
+
+        $this->assertDatabaseMissing('model_has_roles', [config('permission.column_names.role_pivot_key') => $this->testUserRole->getKey()]);
+        $this->assertDatabaseMissing('role_has_permissions', [config('permission.column_names.role_pivot_key') => $this->testUserRole->getKey()]);
+
+        $user->load('roles');
+        $this->testUserPermission->load('roles');
+
+        $this->assertTrue($this->testUserPermission->hasRole('testRole2'));
+        $this->assertTrue($user->hasRole('testRole2'));
+        $this->assertFalse($this->testUserPermission->hasRole($this->testUserRole));
+        $this->assertFalse($user->hasRole($this->testUserRole));
+    }
+
+    /** @test */
     public function it_does_not_detach_roles_when_soft_deleting()
     {
         $user = SoftDeletingUser::create(['email' => 'test@example.com']);


### PR DESCRIPTION
> if I remove a permission, the entry still exists in model_has_permissions

From #2114, there is a **bug** when Permission or Role models not are using soft deleting and they are deleted

I write a test for this bug
```php
public function it_detach_permissions_when_deleting()
{
    $user = User::create(['email' => 'user1@test.com']);
    $user->givePermissionTo($this->testUserPermission);

    $this->assertTrue($user->hasPermissionTo($this->testUserPermission));

    $this->testUserPermission->delete();

    $this->assertDatabaseMissing(
        'model_has_permissions', 
        [config('permission.column_names.permission_pivot_key') => $this->testUserPermission->getKey()]
    );
}
```
And i get
```batch
Failed asserting that a row in the table [model_has_permissions] does not match the attributes {
    "permission_test_id": 1
}.

Found similar results: [
    {
        "permission_test_id": 1,
        "model_type": "Spatie\\Permission\\Test\\User",
        "model_test_id": 2
    }
].
```