### PR TITLE
Use `getKey`, `getKeyName` instead of `id`

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -193,6 +193,6 @@ class Role extends Model implements RoleContract
             throw GuardDoesNotMatch::create($permission->guard_name, $this->getGuardNames());
         }
 
-        return $this->permissions->contains('id', $permission->id);
+        return $this->permissions->contains($permission->getKeyName(), $permission->getKey());
     }
 }


### PR DESCRIPTION
Same as others, more abstract on custom primary key names
https://github.com/spatie/laravel-permission/blob/96466b07c9a416fcc095a9097e87131e082e60af/src/Traits/HasPermissions.php#L288