### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/src/Commands/UpgradeForTeams.php
+++ b/src/Commands/UpgradeForTeams.php
@@ -122,6 +122,6 @@ class UpgradeForTeams extends Command
     {
         $date = $date ?: date('Y_m_d_His');
 
-        return database_path("migrations/${date}_{$this->migrationSuffix}");
+        return database_path("migrations/{$date}_{$this->migrationSuffix}");
     }
 }


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes the only such occurrence in `spatie/laravel-permission` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)