### PR TITLE
Support static arrays on blade directives

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -84,62 +84,53 @@ class PermissionServiceProvider extends ServiceProvider
         $this->app->bind(RoleContract::class, $config['role']);
     }
 
+    public static function bladeMethodWrapper($method, $role, $guard = null)
+    {
+        return auth($guard)->check() && auth($guard)->user()->{$method}($role);
+    }
+
     protected function registerBladeExtensions($bladeCompiler)
     {
         $bladeCompiler->directive('role', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasRole', {$arguments})): ?>";
         });
         $bladeCompiler->directive('elserole', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
-
-            return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+            return "<?php elseif(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasRole', {$arguments})): ?>";
         });
         $bladeCompiler->directive('endrole', function () {
             return '<?php endif; ?>';
         });
 
         $bladeCompiler->directive('hasrole', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
+            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasRole', {$arguments})): ?>";
         });
         $bladeCompiler->directive('endhasrole', function () {
             return '<?php endif; ?>';
         });
 
         $bladeCompiler->directive('hasanyrole', function ($arguments) {
-            list($roles, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAnyRole({$roles})): ?>";
+            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasAnyRole', {$arguments})): ?>";
         });
         $bladeCompiler->directive('endhasanyrole', function () {
             return '<?php endif; ?>';
         });
 
         $bladeCompiler->directive('hasallroles', function ($arguments) {
-            list($roles, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasAllRoles({$roles})): ?>";
+            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasAllRoles', {$arguments})): ?>";
         });
         $bladeCompiler->directive('endhasallroles', function () {
             return '<?php endif; ?>';
         });
 
         $bladeCompiler->directive('unlessrole', function ($arguments) {
-            list($role, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(!auth({$guard})->check() || ! auth({$guard})->user()->hasRole({$role})): ?>";
+            return "<?php if(! \\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasRole', {$arguments})): ?>";
         });
         $bladeCompiler->directive('endunlessrole', function () {
             return '<?php endif; ?>';
         });
 
         $bladeCompiler->directive('hasexactroles', function ($arguments) {
-            list($roles, $guard) = explode(',', $arguments.',');
-
-            return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasExactRoles({$roles})): ?>";
+            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasExactRoles', {$arguments})): ?>";
         });
         $bladeCompiler->directive('endhasexactroles', function () {
             return '<?php endif; ?>';

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -31,9 +31,9 @@ class BladeTest extends TestCase
         $this->assertEquals('does not have permission', $this->renderView('can', ['permission' => $permission]));
         $this->assertEquals('does not have role', $this->renderView('role', compact('role', 'elserole')));
         $this->assertEquals('does not have role', $this->renderView('hasRole', compact('role', 'elserole')));
-        $this->assertEquals('does not have all of the given roles', $this->renderView('hasAllRoles', $roles));
+        $this->assertEquals('does not have all of the given roles', $this->renderView('hasAllRoles', compact('roles')));
         $this->assertEquals('does not have all of the given roles', $this->renderView('hasAllRoles', ['roles' => implode('|', $roles)]));
-        $this->assertEquals('does not have any of the given roles', $this->renderView('hasAnyRole', $roles));
+        $this->assertEquals('does not have any of the given roles', $this->renderView('hasAnyRole', compact('roles')));
         $this->assertEquals('does not have any of the given roles', $this->renderView('hasAnyRole', ['roles' => implode('|', $roles)]));
     }
 
@@ -260,6 +260,33 @@ class BladeTest extends TestCase
         auth()->setUser($user);
 
         $this->assertEquals('does not have all of the given roles', $this->renderView('guardHasAllRolesPipe', compact('guard')));
+    }
+
+    /** @test */
+    public function the_hasallroles_directive_will_evaluate_true_when_the_logged_in_user_does_have_all_required_roles_in_array()
+    {
+        $guard = 'admin';
+
+        $admin = $this->getSuperAdmin();
+
+        $admin->assignRole('moderator');
+
+        auth('admin')->setUser($admin);
+
+        $this->assertEquals('does have all of the given roles', $this->renderView('guardHasAllRolesArray', compact('guard')));
+    }
+
+    /** @test */
+    public function the_hasallroles_directive_will_evaluate_false_when_the_logged_in_user_doesnt_have_all_required_roles_in_array()
+    {
+        $guard = '';
+        $user = $this->getMember();
+
+        $user->assignRole('writer');
+
+        auth()->setUser($user);
+
+        $this->assertEquals('does not have all of the given roles', $this->renderView('guardHasAllRolesArray', compact('guard')));
     }
 
     protected function getWriter()

--- a/tests/resources/views/guardHasAllRolesArray.blade.php
+++ b/tests/resources/views/guardHasAllRolesArray.blade.php
@@ -1,0 +1,5 @@
+@hasallroles(['super-admin', 'moderator'], $guard)
+does have all of the given roles
+@else
+does not have all of the given roles
+@endhasallroles


### PR DESCRIPTION
Closes #2165
Closes https://github.com/spatie/laravel-permission/issues/1997#issuecomment-1019023930
Closes https://github.com/spatie/laravel-permission/issues/626#issuecomment-358911209
Closes #309

This PR adds support for arrays(also expressions) on blade directives, example

```blade
@hasanyrole(['admin', 'manager'])
        
@endhasanyrole

@hasallroles(['admin', 'manager'])
        
@endhasallroles
```

Without this PR only `PIPE` an `VARIABLE's REF` are supported
https://github.com/spatie/laravel-permission/blob/dbc6c18ef4b2d097350a5faf82382564748e6c97/tests/resources/views/guardHasAllRolesPipe.blade.php#L1-L1
https://github.com/spatie/laravel-permission/blob/dbc6c18ef4b2d097350a5faf82382564748e6c97/tests/resources/views/guardHasAllRoles.blade.php#L1-L1
