### PR TITLE
Fix returning all roles instead of the assigned

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -189,6 +189,8 @@ trait HasRoles
      */
     public function hasRole($roles, string $guard = null): bool
     {
+        $this->loadMissing('roles');
+
         if (is_string($roles) && false !== strpos($roles, '|')) {
             $roles = $this->convertPipeToArray($roles);
         }
@@ -248,6 +250,8 @@ trait HasRoles
      */
     public function hasAllRoles($roles, string $guard = null): bool
     {
+        $this->loadMissing('roles');
+
         if (is_string($roles) && false !== strpos($roles, '|')) {
             $roles = $this->convertPipeToArray($roles);
         }
@@ -282,6 +286,8 @@ trait HasRoles
      */
     public function hasExactRoles($roles, string $guard = null): bool
     {
+        $this->loadMissing('roles');
+
         if (is_string($roles) && false !== strpos($roles, '|')) {
             $roles = $this->convertPipeToArray($roles);
         }
@@ -311,6 +317,8 @@ trait HasRoles
 
     public function getRoleNames(): Collection
     {
+        $this->loadMissing('roles');
+
         return $this->roles->pluck('name');
     }
 


### PR DESCRIPTION
Closes #2190
Closes #2161
Closes #1829
> This behavior occurs when a controller requires a model with a relationship before loading the roles and the relationship uses the hasRole function
> 
> web.php
> 
> ```php
> Route::get('/test', function(){
>     $var = MyParent::withCount('limitedView')->get(); //not used but creates the issue
>     return[ Auth::user()->roles, App\Models\User::find(Auth::id())->roles ];
> });
> ```
> 
> MyParent.php
> 
> ````php
> class MyParent extends Model
> {
>     public function children(): HasMany {
>         return $this->hasMany(Child::class);
>     }
> 
>     public function limitedView() {
>         $query = $this->children();
> 
>         if(!Auth::user()->hasRole('Super-Admin')){
>             $query->orWhere('age', '>=', 18);
>         }
> 
>         return $query;
>     }
> }
> ```
