### PR TITLE
Make Writing Policies link clickable

### DIFF
--- a/docs/basic-usage/role-permissions.md
+++ b/docs/basic-usage/role-permissions.md
@@ -170,4 +170,4 @@ the second will be a collection with the `edit article` permission and the third
 
 ### NOTE about using permission names in policies
 
-When calling `authorize()` for a policy method, if you have a permission named the same as one of those policy methods, your permission "name" will take precedence and not fire the policy. For this reason it may be wise to avoid naming your permissions the same as the methods in your policy. While you can define your own method names, you can read more about the defaults Laravel offers in Laravel's documentation at https://laravel.com/docs/authorization#writing-policies
+When calling `authorize()` for a policy method, if you have a permission named the same as one of those policy methods, your permission "name" will take precedence and not fire the policy. For this reason it may be wise to avoid naming your permissions the same as the methods in your policy. While you can define your own method names, you can read more about the defaults Laravel offers in Laravel's documentation at [Writing Policies](https://laravel.com/docs/authorization#writing-policies).


### PR DESCRIPTION
The link wasn't clickable at the documentation website.