### PR TITLE
Add configurable default guard

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -135,6 +135,15 @@ return [
 
     'enable_wildcard_permission' => false,
 
+    /*
+     * By default the guard name relevant for the model and the current user will be looked up.
+     * If you set this to `web`, all permissions will be checked against the `web` guard, for example.
+     * This is useful if your application relies on multiple guards sharing the exact same permissions.
+     *
+     * If this is set to `true` the guard name from `auth.defaults.guard` will be used.
+     */
+    'default_guard' => null,
+
     'cache' => [
 
         /*

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -125,6 +125,8 @@ trait HasPermissions
      */
     public function hasPermissionTo($permission, $guardName = null): bool
     {
+        $guardName = $guardName ?? $this->getDefaultGuardFromConfig();
+
         if (config('permission.enable_wildcard_permission', false)) {
             return $this->hasWildcardPermission($permission, $guardName);
         }
@@ -456,9 +458,18 @@ trait HasPermissions
         return Guard::getNames($this);
     }
 
+    protected function getDefaultGuardFromConfig(): ?string
+    {
+        if (config('permission.default_guard') === true) {
+            return config('auth.defaults.guard');
+        }
+
+        return config('permission.default_guard') ?: null;
+    }
+
     protected function getDefaultGuardName(): string
     {
-        return Guard::getDefaultName($this);
+        return $this->getDefaultGuardFromConfig() ?? Guard::getDefaultName($this);
     }
 
     /**

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -124,8 +124,6 @@ trait HasPermissions
      */
     public function filterPermission($permission, $guardName = null)
     {
-        $guardName = $guardName ?? $this->getDefaultGuardFromConfig();
-
         $permissionClass = $this->getPermissionClass();
 
         if (is_string($permission)) {

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -23,7 +23,7 @@ trait HasPermissions
     public static function bootHasPermissions()
     {
         static::deleting(function ($model) {
-            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+            if (method_exists($model, 'isForceDeleting') && !$model->isForceDeleting()) {
                 return;
             }
 
@@ -33,7 +33,7 @@ trait HasPermissions
 
     public function getPermissionClass()
     {
-        if (! isset($this->permissionClass)) {
+        if (!isset($this->permissionClass)) {
             $this->permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
         }
 
@@ -53,7 +53,7 @@ trait HasPermissions
             PermissionRegistrar::$pivotPermission
         );
 
-        if (! PermissionRegistrar::$teams) {
+        if (!PermissionRegistrar::$teams) {
             return $relation;
         }
 
@@ -80,13 +80,13 @@ trait HasPermissions
             $query->whereHas('permissions', function (Builder $subQuery) use ($permissions) {
                 $permissionClass = $this->getPermissionClass();
                 $key = (new $permissionClass())->getKeyName();
-                $subQuery->whereIn(config('permission.table_names.permissions').".$key", \array_column($permissions, $key));
+                $subQuery->whereIn(config('permission.table_names.permissions') . ".$key", \array_column($permissions, $key));
             });
             if (count($rolesWithPermissions) > 0) {
                 $query->orWhereHas('roles', function (Builder $subQuery) use ($rolesWithPermissions) {
                     $roleClass = $this->getRoleClass();
                     $key = (new $roleClass())->getKeyName();
-                    $subQuery->whereIn(config('permission.table_names.roles').".$key", \array_column($rolesWithPermissions, $key));
+                    $subQuery->whereIn(config('permission.table_names.roles') . ".$key", \array_column($rolesWithPermissions, $key));
                 });
             }
         });
@@ -124,8 +124,6 @@ trait HasPermissions
      */
     public function filterPermission($permission, $guardName = null)
     {
-        $guardName = $guardName ?? $this->getDefaultGuardFromConfig();
-
         $permissionClass = $this->getPermissionClass();
 
         if (is_string($permission)) {
@@ -142,7 +140,7 @@ trait HasPermissions
             );
         }
 
-        if (! $permission instanceof Permission) {
+        if (!$permission instanceof Permission) {
             throw new PermissionDoesNotExist();
         }
 
@@ -189,7 +187,7 @@ trait HasPermissions
             $permission = $permission->name;
         }
 
-        if (! is_string($permission)) {
+        if (!is_string($permission)) {
             throw WildcardPermissionInvalidArgument::create();
         }
 
@@ -258,7 +256,7 @@ trait HasPermissions
         $permissions = collect($permissions)->flatten();
 
         foreach ($permissions as $permission) {
-            if (! $this->hasPermissionTo($permission)) {
+            if (!$this->hasPermissionTo($permission)) {
                 return false;
             }
         }
@@ -336,13 +334,13 @@ trait HasPermissions
                 }
 
                 $permission = $this->getStoredPermission($permission);
-                if (! $permission instanceof Permission) {
+                if (!$permission instanceof Permission) {
                     return $array;
                 }
 
                 $this->ensureModelSharesGuard($permission);
 
-                $array[$permission->getKey()] = PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
+                $array[$permission->getKey()] = PermissionRegistrar::$teams && !is_a($this, Role::class) ?
                     [PermissionRegistrar::$teamsKey => getPermissionsTeamId()] : [];
 
                 return $array;
@@ -463,7 +461,7 @@ trait HasPermissions
      */
     protected function ensureModelSharesGuard($roleOrPermission)
     {
-        if (! $this->getGuardNames()->contains($roleOrPermission->guard_name)) {
+        if (!$this->getGuardNames()->contains($roleOrPermission->guard_name)) {
             throw GuardDoesNotMatch::create($roleOrPermission->guard_name, $this->getGuardNames());
         }
     }
@@ -505,7 +503,7 @@ trait HasPermissions
         $permissions = collect($permissions)->flatten();
 
         foreach ($permissions as $permission) {
-            if (! $this->hasDirectPermission($permission)) {
+            if (!$this->hasDirectPermission($permission)) {
                 return false;
             }
         }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -23,7 +23,7 @@ trait HasPermissions
     public static function bootHasPermissions()
     {
         static::deleting(function ($model) {
-            if (method_exists($model, 'isForceDeleting') && !$model->isForceDeleting()) {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
                 return;
             }
 
@@ -33,7 +33,7 @@ trait HasPermissions
 
     public function getPermissionClass()
     {
-        if (!isset($this->permissionClass)) {
+        if (! isset($this->permissionClass)) {
             $this->permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
         }
 
@@ -53,7 +53,7 @@ trait HasPermissions
             PermissionRegistrar::$pivotPermission
         );
 
-        if (!PermissionRegistrar::$teams) {
+        if (! PermissionRegistrar::$teams) {
             return $relation;
         }
 
@@ -80,13 +80,13 @@ trait HasPermissions
             $query->whereHas('permissions', function (Builder $subQuery) use ($permissions) {
                 $permissionClass = $this->getPermissionClass();
                 $key = (new $permissionClass())->getKeyName();
-                $subQuery->whereIn(config('permission.table_names.permissions') . ".$key", \array_column($permissions, $key));
+                $subQuery->whereIn(config('permission.table_names.permissions').".$key", \array_column($permissions, $key));
             });
             if (count($rolesWithPermissions) > 0) {
                 $query->orWhereHas('roles', function (Builder $subQuery) use ($rolesWithPermissions) {
                     $roleClass = $this->getRoleClass();
                     $key = (new $roleClass())->getKeyName();
-                    $subQuery->whereIn(config('permission.table_names.roles') . ".$key", \array_column($rolesWithPermissions, $key));
+                    $subQuery->whereIn(config('permission.table_names.roles').".$key", \array_column($rolesWithPermissions, $key));
                 });
             }
         });
@@ -124,6 +124,8 @@ trait HasPermissions
      */
     public function filterPermission($permission, $guardName = null)
     {
+        $guardName = $guardName ?? $this->getDefaultGuardFromConfig();
+
         $permissionClass = $this->getPermissionClass();
 
         if (is_string($permission)) {
@@ -140,7 +142,7 @@ trait HasPermissions
             );
         }
 
-        if (!$permission instanceof Permission) {
+        if (! $permission instanceof Permission) {
             throw new PermissionDoesNotExist();
         }
 
@@ -187,7 +189,7 @@ trait HasPermissions
             $permission = $permission->name;
         }
 
-        if (!is_string($permission)) {
+        if (! is_string($permission)) {
             throw WildcardPermissionInvalidArgument::create();
         }
 
@@ -256,7 +258,7 @@ trait HasPermissions
         $permissions = collect($permissions)->flatten();
 
         foreach ($permissions as $permission) {
-            if (!$this->hasPermissionTo($permission)) {
+            if (! $this->hasPermissionTo($permission)) {
                 return false;
             }
         }
@@ -334,13 +336,13 @@ trait HasPermissions
                 }
 
                 $permission = $this->getStoredPermission($permission);
-                if (!$permission instanceof Permission) {
+                if (! $permission instanceof Permission) {
                     return $array;
                 }
 
                 $this->ensureModelSharesGuard($permission);
 
-                $array[$permission->getKey()] = PermissionRegistrar::$teams && !is_a($this, Role::class) ?
+                $array[$permission->getKey()] = PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
                     [PermissionRegistrar::$teamsKey => getPermissionsTeamId()] : [];
 
                 return $array;
@@ -461,7 +463,7 @@ trait HasPermissions
      */
     protected function ensureModelSharesGuard($roleOrPermission)
     {
-        if (!$this->getGuardNames()->contains($roleOrPermission->guard_name)) {
+        if (! $this->getGuardNames()->contains($roleOrPermission->guard_name)) {
             throw GuardDoesNotMatch::create($roleOrPermission->guard_name, $this->getGuardNames());
         }
     }
@@ -503,7 +505,7 @@ trait HasPermissions
         $permissions = collect($permissions)->flatten();
 
         foreach ($permissions as $permission) {
-            if (!$this->hasDirectPermission($permission)) {
+            if (! $this->hasDirectPermission($permission)) {
                 return false;
             }
         }

--- a/tests/DefaultGuardTest.php
+++ b/tests/DefaultGuardTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Models\Role;
+
+class DefaultGuardTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('auth.guards', [
+            'web' => ['driver' => 'session', 'provider' => 'users'],
+            'api' => ['driver' => 'token', 'provider' => 'users'],
+            'jwt' => ['driver' => 'token', 'provider' => 'users'],
+        ]);
+    }
+
+    /** @test */
+    public function it_checks_against_first_matching_guard_name_by_default()
+    {
+        $this->testUser->givePermissionTo(app(Permission::class)::create([
+            'name' => 'do_this',
+            'guard_name' => 'web',
+        ]));
+
+        $this->testUser->givePermissionTo(app(Permission::class)::create([
+            'name' => 'do_that',
+            'guard_name' => 'api',
+        ]));
+
+        $permission = app(Permission::class)::create([
+            'name' => 'do_that',
+            'guard_name' => 'web',
+        ]);
+
+        $this->assertTrue($this->testUser->checkPermissionTo('do_this'));
+        $this->assertFalse($this->testUser->checkPermissionTo('do_that'));
+        $this->assertFalse($this->testUser->checkPermissionTo('do_that', 'web'));
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that', 'api'));
+
+        $this->testUser->givePermissionTo($permission);
+
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that'));
+    }
+
+    /** @test */
+    public function it_checks_against_default_guard_if_configured()
+    {
+        config(['permission.default_guard' => 'api']);
+
+        $this->testUser->givePermissionTo(app(Permission::class)::create([
+            'name' => 'do_this',
+            'guard_name' => 'web',
+        ]));
+
+        $apiPermission = app(Permission::class)::create([
+            'name' => 'do_that',
+            'guard_name' => 'api',
+        ]);
+
+        $this->testUser->givePermissionTo($apiPermission);
+
+        $permission = app(Permission::class)::create([
+            'name' => 'do_that',
+            'guard_name' => 'web',
+        ]);
+
+        $this->assertFalse($this->testUser->checkPermissionTo('do_this'));
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that'));
+        $this->assertFalse($this->testUser->checkPermissionTo('do_that', 'web'));
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that', 'api'));
+
+        $this->testUser->revokePermissionTo($apiPermission);
+        $this->testUser->givePermissionTo($permission);
+
+        $this->assertFalse($this->testUser->checkPermissionTo('do_that'));
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that', 'web'));
+    }
+
+    /** @test */
+    public function it_uses_auth_default_guard_if_configured()
+    {
+        config(['auth.defaults.guard' => 'api']);
+        config(['permission.default_guard' => true]);
+
+        $this->testUser->givePermissionTo(app(Permission::class)::create([
+            'name' => 'do_this',
+            'guard_name' => 'web',
+        ]));
+
+        $apiPermission = app(Permission::class)::create([
+            'name' => 'do_that',
+            'guard_name' => 'api',
+        ]);
+
+        $this->testUser->givePermissionTo($apiPermission);
+
+        $permission = app(Permission::class)::create([
+            'name' => 'do_that',
+            'guard_name' => 'web',
+        ]);
+
+        $this->assertFalse($this->testUser->checkPermissionTo('do_this'));
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that'));
+        $this->assertFalse($this->testUser->checkPermissionTo('do_that', 'web'));
+        $this->assertTrue($this->testUser->checkPermissionTo('do_that', 'api'));
+    }
+
+    /** @test */
+    public function it_creates_roles_for_auth_default_guard_if_configured()
+    {
+        $this->assertEquals('web', Role::create(['name' => 'admin'])->guard_name);
+
+        config(['auth.defaults.guard' => 'api']);
+        config(['permission.default_guard' => true]);
+
+        $this->assertEquals('api', Role::create(['name' => 'admin'])->guard_name);
+        $this->assertEquals('jwt', Role::create(['name' => 'admin', 'guard_name' => 'jwt'])->guard_name);
+
+        config(['permission.default_guard' => 'web']);
+
+        $this->assertEquals('api', Role::create(['name' => 'supa doopa admin'])->guard_name);
+    }
+}


### PR DESCRIPTION
This Pull Request is backwards compatible and adds a new `default_guard` config option. 

This option is `null` by default. Setting it to `true` will always check permissions against the default guard from `auth.defaults.guard` if no explicit guard is passed. Users may also set this to a guard name which will then be used as the default.

This should address the issues from #1156.