### PR TITLE
Prevent MissingAttributeException for guard_name

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -22,7 +22,7 @@ class Guard
             if (\method_exists($model, 'guardName')) {
                 $guardName = $model->guardName();
             } else {
-                $guardName = $model->guard_name ?? null;
+                $guardName = $model->getAttributeValue('guard_name');
             }
         }
 


### PR DESCRIPTION
When new Laravel feature `Model::preventAccessingMissingAttributes()` is enabled you may get a `MissingAttributeException` for `guard_name`. This change uses `getAttributeValue()` to prevent the exception. Fixes #2215