### PR TITLE
[Bug] Avoid checking permissions-via-roles on `Role` model (ref `Model::preventAccessingMissingAttributes()`)

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,7 +4,6 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleAlreadyExists;
@@ -195,13 +194,5 @@ class Role extends Model implements RoleContract
         }
 
         return $this->permissions->contains($permission->getKeyName(), $permission->getKey());
-    }
-
-    /**
-     * Return all the permissions the model has, both directly and via roles.
-     */
-    public function getAllPermissions(): Collection
-    {
-        return $this->permissions->sort()->values();
     }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleAlreadyExists;
@@ -194,5 +195,13 @@ class Role extends Model implements RoleContract
         }
 
         return $this->permissions->contains($permission->getKeyName(), $permission->getKey());
+    }
+
+    /**
+     * Return all the permissions the model has, both directly and via roles.
+     */
+    public function getAllPermissions(): Collection
+    {
+        return $this->permissions->sort()->values();
     }
 }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -310,7 +310,7 @@ trait HasPermissions
         /** @var Collection $permissions */
         $permissions = $this->permissions;
 
-        if ($this->roles) {
+        if (method_exists($this, 'roles')) {
             $permissions = $permissions->merge($this->getPermissionsViaRoles());
         }
 


### PR DESCRIPTION
This PR aims to fix an issue when trying to check for `Role`'s `hasPermissionTo()` when `Model::preventAccessingMissingAttributes()` is enabled.

The implemented fix overrides the `HasPermission::getAllPermissions()` to not check for `$this->roles` as the `Role` model will never have a relationship to itself.