### PR TITLE
[Docs] Fix broken Link that link to freek's blog post

### DIFF
--- a/docs/basic-usage/super-admin.md
+++ b/docs/basic-usage/super-admin.md
@@ -38,7 +38,7 @@ Jeffrey Way explains the concept of a super-admin (and a model owner, and model 
 
 Alternatively you might want to move the Super Admin check to the `Gate::after` phase instead, particularly if your Super Admin shouldn't be allowed to do things your app doesn't want "anyone" to do, such as writing more than 1 review, or bypassing unsubscribe rules, etc.
 
-The following code snippet is inspired from [Freek's blog article](https://murze.be/when-to-use-gateafter-in-laravel) where this topic is discussed further.
+The following code snippet is inspired from [Freek's blog article](https://freek.dev/1325-when-to-use-gateafter-in-laravel) where this topic is discussed further.
 
 ```php
 // somewhere in a service provider


### PR DESCRIPTION
Hi Spatie Team while i passing by the docs i found out the link (https://murze.be/when-to-use-gateafter-in-laravel) is broken possibly caused by different slug was used when redirect to new domain. 

I am sure if this is the way to solve the problem as freek can just add a redirection url in freek.dev, feel free to close this PR if this solution is not acceptable 😉 

Love the package btw ❤️ 