### PR TITLE
[Docs] Add syncPermissions() in role-permissions.md

### DIFF
--- a/docs/basic-usage/role-permissions.md
+++ b/docs/basic-usage/role-permissions.md
@@ -84,6 +84,12 @@ A permission can be revoked from a role:
 $role->revokePermissionTo('edit articles');
 ```
 
+Or revoke & add new permissions in one go:
+
+```php
+$role->syncPermissions(['edit articles', 'delete articles']);
+```
+
 The `givePermissionTo` and `revokePermissionTo` functions can accept a
 string or a `Spatie\Permission\Models\Permission` object.
 


### PR DESCRIPTION
the `syncPermissions` method on the `Role` object was missing from this page