### PR TITLE
Don't throw an exception when checking hasAllPermissions()

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -249,14 +249,13 @@ trait HasPermissions
      * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      *
      * @return bool
-     * @throws \Exception
      */
     public function hasAllPermissions(...$permissions): bool
     {
         $permissions = collect($permissions)->flatten();
 
         foreach ($permissions as $permission) {
-            if (! $this->hasPermissionTo($permission)) {
+            if (! $this->checkPermissionTo($permission)) {
                 return false;
             }
         }
@@ -486,6 +485,7 @@ trait HasPermissions
 
     /**
      * Check if the model has All of the requested Direct permissions.
+     *
      * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      * @return bool
      */
@@ -504,6 +504,7 @@ trait HasPermissions
 
     /**
      * Check if the model has Any of the requested Direct permissions.
+     *
      * @param string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection ...$permissions
      * @return bool
      */


### PR DESCRIPTION
I believe this change must be the same as the `hasAnyPermission` functionality as it coded [here](https://github.com/spatie/laravel-permission/blob/main/src/Traits/HasPermissions.php#L238).
Also, throwing an error while we expect a boolean value doesn't make sense.