### PR TITLE
Custom wildcard verification/separators support

### DIFF
--- a/src/Contracts/Wildcard.php
+++ b/src/Contracts/Wildcard.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Contracts;
+
+interface Wildcard
+{
+    /**
+     * @param string|Wildcard $permission
+     *
+     * @return bool
+     */
+    public function implies($permission): bool;
+}

--- a/src/Exceptions/WildcardPermissionNotImplementsContract.php
+++ b/src/Exceptions/WildcardPermissionNotImplementsContract.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Exceptions;
+
+use InvalidArgumentException;
+
+class WildcardPermissionNotImplementsContract extends InvalidArgumentException
+{
+    public static function create()
+    {
+        return new static('Wildcard permission class must implements Spatie\Permission\Contracts\Wildcard contract');
+    }
+}

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -8,9 +8,11 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Contracts\Wildcard;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
+use Spatie\Permission\Exceptions\WildcardPermissionNotImplementsContract;
 use Spatie\Permission\Guard;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\WildcardPermission;
@@ -19,6 +21,9 @@ trait HasPermissions
 {
     /** @var string */
     private $permissionClass;
+
+    /** @var string */
+    private $wildcardClass;
 
     public static function bootHasPermissions()
     {
@@ -38,6 +43,25 @@ trait HasPermissions
         }
 
         return $this->permissionClass;
+    }
+
+    protected function getWildcardClass()
+    {
+        if (! is_null($this->wildcardClass)) {
+            return $this->wildcardClass;
+        }
+
+        $this->wildcardClass = false;
+
+        if (config('permission.enable_wildcard_permission', false)) {
+            $this->wildcardClass = config('permission.wildcard_permission', WildcardPermission::class);
+
+            if (! is_subclass_of($this->wildcardClass, Wildcard::class)) {
+                throw WildcardPermissionNotImplementsContract::create();
+            }
+        }
+
+        return $this->wildcardClass;
     }
 
     /**
@@ -158,7 +182,7 @@ trait HasPermissions
      */
     public function hasPermissionTo($permission, $guardName = null): bool
     {
-        if (config('permission.enable_wildcard_permission', false)) {
+        if ($this->getWildcardClass()) {
             return $this->hasWildcardPermission($permission, $guardName);
         }
 
@@ -191,12 +215,14 @@ trait HasPermissions
             throw WildcardPermissionInvalidArgument::create();
         }
 
+        $WildcardPermissionClass = $this->getWildcardClass();
+
         foreach ($this->getAllPermissions() as $userPermission) {
             if ($guardName !== $userPermission->guard_name) {
                 continue;
             }
 
-            $userPermission = new WildcardPermission($userPermission->name);
+            $userPermission = new $WildcardPermissionClass($userPermission->name);
 
             if ($userPermission->implies($permission)) {
                 return true;

--- a/src/WildcardPermission.php
+++ b/src/WildcardPermission.php
@@ -3,9 +3,10 @@
 namespace Spatie\Permission;
 
 use Illuminate\Support\Collection;
+use Spatie\Permission\Contracts\Wildcard;
 use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
 
-class WildcardPermission
+class WildcardPermission implements Wildcard
 {
     /** @var string */
     public const WILDCARD_TOKEN = '*';

--- a/tests/WildcardPermission.php
+++ b/tests/WildcardPermission.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Permission\Test;
+
+use Spatie\Permission\WildcardPermission as BaseWildcardPermission;
+
+class WildcardPermission extends BaseWildcardPermission
+{
+    /** @var string */
+    public const WILDCARD_TOKEN = '@';
+
+    /** @var string */
+    public const PART_DELIMITER = ':';
+
+    /** @var string */
+    public const SUBPART_DELIMITER = ';';
+}


### PR DESCRIPTION
- Allow to custom wildcard verification (Like change separators, dot, comma, change `implies` logic)
- Avoid calling `config('permission.enable_wildcard_permission')` on every `hasPermissionTo`

**Closes:** 
- #2110
- #1756

With tests
