### PR TITLE
Allow guard_name parameter on gate's can methods

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -136,9 +136,9 @@ class PermissionRegistrar
      */
     public function registerPermissions(): bool
     {
-        app(Gate::class)->before(function (Authorizable $user, string $ability) {
+        app(Gate::class)->before(function (Authorizable $user, string $ability, $arguments = []) {
             if (method_exists($user, 'checkPermissionTo')) {
-                return $user->checkPermissionTo($ability) ?: null;
+                return $user->checkPermissionTo($ability, $arguments[0] ?? null) ?: null;
             }
         });
 

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -63,6 +63,7 @@ class BladeTest extends TestCase
         $elserole = 'na';
 
         auth('admin')->setUser($this->testAdmin);
+        auth()->shouldUse('admin');
 
         $this->assertEquals('does not have permission', $this->renderView('can', compact('permission')));
         $this->assertEquals('does not have role', $this->renderView('role', compact('role', 'elserole')));
@@ -82,6 +83,23 @@ class BladeTest extends TestCase
         auth()->setUser($user);
 
         $this->assertEquals('has permission', $this->renderView('can', ['permission' => 'edit-articles']));
+        $this->assertEquals('does not have permission', $this->renderView('can', ['permission' => 'edit-news']));
+    }
+
+    /** @test */
+    public function the_can_directive_will_evaluate_when_somebody_with_another_guard_is_logged_in_and_guard_is_setted()
+    {
+        $permission = 'admin-permission';
+        $user = $this->getAdmin();
+
+        $user->givePermissionTo($permission);
+
+        auth('admin')->setUser($user);
+        auth()->shouldUse('admin');
+
+        $this->assertEquals('has permission', $this->renderView('can', compact('permission')));
+        $this->assertEquals('has permission', $this->renderView('can', compact('permission') + ['guard' => 'admin']));
+        $this->assertEquals('does not have permission', $this->renderView('can', compact('permission') + ['guard' => 'web']));
     }
 
     /** @test */
@@ -301,6 +319,13 @@ class BladeTest extends TestCase
         $this->testUser->assignRole('member');
 
         return $this->testUser;
+    }
+
+    protected function getAdmin()
+    {
+        $this->testAdmin->assignRole('testAdminRole');
+
+        return $this->testAdmin;
     }
 
     protected function getSuperAdmin()

--- a/tests/GateTest.php
+++ b/tests/GateTest.php
@@ -31,6 +31,12 @@ class GateTest extends TestCase
 
         $this->assertTrue($this->testUser->can('edit-articles'));
 
+        $this->assertTrue($this->testUser->can('edit-articles', 'web'));
+
+        $this->assertFalse($this->testUser->can('edit-articles', 'admin'));
+
+        $this->assertFalse($this->testUser->can('edit-articles', 'non-existing-guard'));
+
         $this->assertFalse($this->testUser->can('non-existing-permission'));
 
         $this->assertFalse($this->testUser->can('admin-permission'));
@@ -47,6 +53,12 @@ class GateTest extends TestCase
 
         $this->assertTrue($this->testUser->can('edit-articles'));
 
+        $this->assertTrue($this->testUser->can('edit-articles', 'web'));
+
+        $this->assertFalse($this->testUser->can('edit-articles', 'admin'));
+
+        $this->assertFalse($this->testUser->can('edit-articles', 'non-existing-guard'));
+
         $this->assertFalse($this->testUser->can('non-existing-permission'));
 
         $this->assertFalse($this->testUser->can('admin-permission'));
@@ -62,6 +74,12 @@ class GateTest extends TestCase
         $this->assertTrue($this->testAdmin->hasPermissionTo($this->testAdminPermission));
 
         $this->assertTrue($this->testAdmin->can('admin-permission'));
+
+        $this->assertTrue($this->testAdmin->can('admin-permission', 'admin'));
+
+        $this->assertFalse($this->testAdmin->can('admin-permission', 'web'));
+
+        $this->assertFalse($this->testAdmin->can('admin-permission', 'non-existing-guard'));
 
         $this->assertFalse($this->testAdmin->can('non-existing-permission'));
 

--- a/tests/resources/views/can.blade.php
+++ b/tests/resources/views/can.blade.php
@@ -1,4 +1,4 @@
-@can($permission)
+@can($permission, $guard ?? null)
 has permission
 @else
 does not have permission


### PR DESCRIPTION
This PR allows
```php
$user->can('permission', 'api');
$user->canany(['permission1', 'permission2'], 'api');

///

Route::group([
   'middleware' => [
       'auth:api',
       'can:permission,api'
   ]
], function(){
});
```
```blade
@can('permission', 'api')
    ///
@endcan

@can('permission', 'web')
    ///
@endcan
```

**Source:** [Auth/Access/Authorizable.php](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Foundation/Auth/Access/Authorizable.php)

Closes https://github.com/spatie/laravel-permission/issues/2037#issuecomment-1325580792

----

**UPDATE:** Tests added