### PR TITLE
Extract query to `getPermissionsWithRoles` method.

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -273,6 +273,11 @@ class PermissionRegistrar
         return $this->cache->getStore();
     }
 
+    protected function getPermissionsWithRoles(): Collection
+    {
+        return $this->getPermissionClass()->select()->with('roles')->get();
+    }
+
     /**
      * Changes array keys with alias
      *
@@ -310,7 +315,7 @@ class PermissionRegistrar
     {
         $this->except = config('permission.cache.column_names_except', ['created_at', 'updated_at', 'deleted_at']);
 
-        $permissions = $this->getPermissionClass()->select()->with('roles')->get()
+        $permissions = $this->getPermissionsWithRoles()
             ->map(function ($permission) {
                 if (! $this->alias) {
                     $this->aliasModelFields($permission);


### PR DESCRIPTION
This PR extracts the query a different method.

This will allow to extend the `PermissionRegistrar` class and change the query.

### Example

```php

class PermissionRegistrar extends BasePermissionRegistrar
{
    protected function getPermissionsWithRoles(): Collection
    {
        return $this->getPermissionClass()
            ->withoutGlobalScopes()
            ->select()
            ->with('roles', fn ($query) => $query->withoutGlobalScopes())
            ->get();
    }
}

```

In this case, I can remove any global scope, applied to the `Permission` and `Role` model.

Thanks,
Francisco 