### PR TITLE
fix: Lazily bind dependencies

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -133,9 +133,9 @@ class PermissionRegistrar
      *
      * @return bool
      */
-    public function registerPermissions(): bool
+    public function registerPermissions(Gate $gate): bool
     {
-        app(Gate::class)->before(function (Authorizable $user, string $ability) {
+        $gate->before(function (Authorizable $user, string $ability) {
             if (method_exists($user, 'checkPermissionTo')) {
                 return $user->checkPermissionTo($ability) ?: null;
             }

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Permission;
 
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
@@ -13,7 +15,7 @@ use Spatie\Permission\Contracts\Role as RoleContract;
 
 class PermissionServiceProvider extends ServiceProvider
 {
-    public function boot(PermissionRegistrar $permissionLoader)
+    public function boot()
     {
         $this->offerPublishing();
 
@@ -23,14 +25,17 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerModelBindings();
 
-        if ($this->app->config['permission.register_permission_check_method']) {
-            $permissionLoader->clearClassPermissions();
-            $permissionLoader->registerPermissions();
-        }
-
-        $this->app->singleton(PermissionRegistrar::class, function ($app) use ($permissionLoader) {
-            return $permissionLoader;
+        $this->callAfterResolving(Gate::class, function (Gate $gate, Application $app) {
+            if ($this->app->config['permission.register_permission_check_method']) {
+                /** @var PermissionRegistrar $permissionLoader */
+                $permissionLoader = $app->get(PermissionRegistrar::class);
+                $permissionLoader->clearClassPermissions();
+                $permissionLoader->registerPermissions($gate);
+            }
         });
+
+
+        $this->app->singleton(PermissionRegistrar::class);
     }
 
     public function register()
@@ -74,14 +79,16 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerModelBindings()
     {
-        $config = $this->app->config['permission.models'];
+        $this->app->bind(PermissionContract::class, function ($app) {
+            $config = $app->config['permission.models'];
 
-        if (! $config) {
-            return;
-        }
+            return $app->make($config['permission']);
+        });
+        $this->app->bind(RoleContract::class, function ($app) {
+            $config = $app->config['permission.models'];
 
-        $this->app->bind(PermissionContract::class, $config['permission']);
-        $this->app->bind(RoleContract::class, $config['role']);
+            return $app->make($config['role']);
+        });
     }
 
     public static function bladeMethodWrapper($method, $role, $guard = null)


### PR DESCRIPTION
Here is a new version of the lazy binding solution. The reason why it was causing issues the first time around was because the `registerPermissions` method was called once `PermissionRegistrar` was resolved instead of when `Gate` was resolved.


I tested this out in a fresh installation of Laravel with the `can` directive in a file and my change here worked. but ofc. would love someone else to also validate

ping @drbyte 