### PR TITLE
refactor: Change static properties to non-static

### DIFF
--- a/database/migrations/add_teams_fields.php.stub
+++ b/database/migrations/add_teams_fields.php.stub
@@ -45,14 +45,14 @@ class AddTeamsFields extends Migration
                 $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
 
                 if (DB::getDriverName() !== 'sqlite') {
-                    $table->dropForeign([PermissionRegistrar::$pivotPermission]);
+                    $table->dropForeign([app(PermissionRegistrar::class)->pivotPermission]);
                 }
                 $table->dropPrimary();
 
-                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([$columnNames['team_foreign_key'], app(PermissionRegistrar::class)->pivotPermission, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_permissions_permission_model_type_primary');
                 if (DB::getDriverName() !== 'sqlite') {
-                    $table->foreign(PermissionRegistrar::$pivotPermission)
+                    $table->foreign(app(PermissionRegistrar::class)->pivotPermission)
                         ->references('id')->on($tableNames['permissions'])->onDelete('cascade');
                 }
             });
@@ -64,14 +64,14 @@ class AddTeamsFields extends Migration
                 $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
 
                 if (DB::getDriverName() !== 'sqlite') {
-                    $table->dropForeign([PermissionRegistrar::$pivotRole]);
+                    $table->dropForeign([app(PermissionRegistrar::class)->pivotRole]);
                 }
                 $table->dropPrimary();
 
-                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([$columnNames['team_foreign_key'], app(PermissionRegistrar::class)->pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary');
                 if (DB::getDriverName() !== 'sqlite') {
-                    $table->foreign(PermissionRegistrar::$pivotRole)
+                    $table->foreign(app(PermissionRegistrar::class)->pivotRole)
                         ->references('id')->on($tableNames['roles'])->onDelete('cascade');
                 }
             });

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -51,13 +51,13 @@ class CreatePermissionTables extends Migration
         });
 
         Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $columnNames, $teams) {
-            $table->unsignedBigInteger(PermissionRegistrar::$pivotPermission);
+            $table->unsignedBigInteger(app(PermissionRegistrar::class)->pivotPermission);
 
             $table->string('model_type');
             $table->unsignedBigInteger($columnNames['model_morph_key']);
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
 
-            $table->foreign(PermissionRegistrar::$pivotPermission)
+            $table->foreign(app(PermissionRegistrar::class)->pivotPermission)
                 ->references('id') // permission id
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
@@ -65,23 +65,23 @@ class CreatePermissionTables extends Migration
                 $table->unsignedBigInteger($columnNames['team_foreign_key']);
                 $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
 
-                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([$columnNames['team_foreign_key'], app(PermissionRegistrar::class)->pivotPermission, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_permissions_permission_model_type_primary');
             } else {
-                $table->primary([PermissionRegistrar::$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([app(PermissionRegistrar::class)->pivotPermission, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_permissions_permission_model_type_primary');
             }
 
         });
 
         Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames, $teams) {
-            $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
+            $table->unsignedBigInteger(app(PermissionRegistrar::class)->pivotRole);
 
             $table->string('model_type');
             $table->unsignedBigInteger($columnNames['model_morph_key']);
             $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
 
-            $table->foreign(PermissionRegistrar::$pivotRole)
+            $table->foreign(app(PermissionRegistrar::class)->pivotRole)
                 ->references('id') // role id
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
@@ -89,29 +89,29 @@ class CreatePermissionTables extends Migration
                 $table->unsignedBigInteger($columnNames['team_foreign_key']);
                 $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
 
-                $table->primary([$columnNames['team_foreign_key'], PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([$columnNames['team_foreign_key'], app(PermissionRegistrar::class)->pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary');
             } else {
-                $table->primary([PermissionRegistrar::$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                $table->primary([app(PermissionRegistrar::class)->pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary');
             }
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
-            $table->unsignedBigInteger(PermissionRegistrar::$pivotPermission);
-            $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
+            $table->unsignedBigInteger(app(PermissionRegistrar::class)->pivotPermission);
+            $table->unsignedBigInteger(app(PermissionRegistrar::class)->pivotRole);
 
-            $table->foreign(PermissionRegistrar::$pivotPermission)
+            $table->foreign(app(PermissionRegistrar::class)->pivotPermission)
                 ->references('id') // permission id
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->foreign(PermissionRegistrar::$pivotRole)
+            $table->foreign(app(PermissionRegistrar::class)->pivotRole)
                 ->references('id') // role id
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->primary([PermissionRegistrar::$pivotPermission, PermissionRegistrar::$pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+            $table->primary([app(PermissionRegistrar::class)->pivotPermission, app(PermissionRegistrar::class)->pivotRole], 'role_has_permissions_permission_id_role_id_primary');
         });
 
         app('cache')

--- a/src/Commands/CreateRole.php
+++ b/src/Commands/CreateRole.php
@@ -17,14 +17,14 @@ class CreateRole extends Command
 
     protected $description = 'Create a role';
 
-    public function handle()
+    public function handle(PermissionRegistrar $permissionRegistrar)
     {
         $roleClass = app(RoleContract::class);
 
         $teamIdAux = getPermissionsTeamId();
         setPermissionsTeamId($this->option('team-id') ?: null);
 
-        if (! PermissionRegistrar::$teams && $this->option('team-id')) {
+        if (! $permissionRegistrar->teams && $this->option('team-id')) {
             $this->warn('Teams feature disabled, argument --team-id has no effect. Either enable it in permissions config file or remove --team-id parameter');
 
             return;
@@ -33,8 +33,8 @@ class CreateRole extends Command
         $role = $roleClass::findOrCreate($this->argument('name'), $this->argument('guard'));
         setPermissionsTeamId($teamIdAux);
 
-        $teams_key = PermissionRegistrar::$teamsKey;
-        if (PermissionRegistrar::$teams && $this->option('team-id') && is_null($role->$teams_key)) {
+        $teams_key = $permissionRegistrar->teamsKey;
+        if ($permissionRegistrar->teams && $this->option('team-id') && is_null($role->$teams_key)) {
             $this->warn("Role `{$role->name}` already exists on the global team; argument --team-id has no effect");
         }
 

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -62,8 +62,8 @@ class Permission extends Model implements PermissionContract
         return $this->belongsToMany(
             config('permission.models.role'),
             config('permission.table_names.role_has_permissions'),
-            PermissionRegistrar::$pivotPermission,
-            PermissionRegistrar::$pivotRole
+            app(PermissionRegistrar::class)->pivotPermission,
+            app(PermissionRegistrar::class)->pivotRole
         );
     }
 
@@ -76,7 +76,7 @@ class Permission extends Model implements PermissionContract
             getModelForGuard($this->attributes['guard_name'] ?? config('auth.defaults.guard')),
             'model',
             config('permission.table_names.model_has_permissions'),
-            PermissionRegistrar::$pivotPermission,
+            app(PermissionRegistrar::class)->pivotPermission,
             config('permission.column_names.model_morph_key')
         );
     }

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -29,25 +29,25 @@ class PermissionRegistrar
     protected $permissions;
 
     /** @var string */
-    public static $pivotRole;
+    public $pivotRole;
 
     /** @var string */
-    public static $pivotPermission;
+    public $pivotPermission;
 
     /** @var \DateInterval|int */
-    public static $cacheExpirationTime;
+    public $cacheExpirationTime;
 
     /** @var bool */
-    public static $teams;
+    public $teams;
 
     /** @var string */
-    public static $teamsKey;
+    public $teamsKey;
 
     /** @var int|string */
     protected $teamId = null;
 
     /** @var string */
-    public static $cacheKey;
+    public $cacheKey;
 
     /** @var array */
     private $cachedRoles = [];
@@ -74,15 +74,15 @@ class PermissionRegistrar
 
     public function initializeCache()
     {
-        self::$cacheExpirationTime = config('permission.cache.expiration_time') ?: \DateInterval::createFromDateString('24 hours');
+        $this->cacheExpirationTime = config('permission.cache.expiration_time') ?: \DateInterval::createFromDateString('24 hours');
 
-        self::$teams = config('permission.teams', false);
-        self::$teamsKey = config('permission.column_names.team_foreign_key');
+        $this->teams = config('permission.teams', false);
+        $this->teamsKey = config('permission.column_names.team_foreign_key');
 
-        self::$cacheKey = config('permission.cache.key');
+        $this->cacheKey = config('permission.cache.key');
 
-        self::$pivotRole = config('permission.column_names.role_pivot_key') ?: 'role_id';
-        self::$pivotPermission = config('permission.column_names.permission_pivot_key') ?: 'permission_id';
+        $this->pivotRole = config('permission.column_names.role_pivot_key') ?: 'role_id';
+        $this->pivotPermission = config('permission.column_names.permission_pivot_key') ?: 'permission_id';
 
         $this->cache = $this->getCacheStoreFromConfig();
     }
@@ -151,7 +151,7 @@ class PermissionRegistrar
     {
         $this->permissions = null;
 
-        return $this->cache->forget(self::$cacheKey);
+        return $this->cache->forget($this->cacheKey);
     }
 
     /**
@@ -174,7 +174,7 @@ class PermissionRegistrar
             return;
         }
 
-        $this->permissions = $this->cache->remember(self::$cacheKey, self::$cacheExpirationTime, function () {
+        $this->permissions = $this->cache->remember($this->cacheKey, $this->cacheExpirationTime, function () {
             return $this->getSerializedPermissionsForCache();
         });
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -32,10 +32,10 @@ trait HasPermissions
                 return;
             }
 
-            $teams = PermissionRegistrar::$teams;
-            PermissionRegistrar::$teams = false;
+            $teams = app(PermissionRegistrar::class)->teams;
+            app(PermissionRegistrar::class)->teams = false;
             $model->permissions()->detach();
-            PermissionRegistrar::$teams = $teams;
+            app(PermissionRegistrar::class)->teams = $teams;
         });
     }
 
@@ -77,14 +77,14 @@ trait HasPermissions
             'model',
             config('permission.table_names.model_has_permissions'),
             config('permission.column_names.model_morph_key'),
-            PermissionRegistrar::$pivotPermission
+            app(PermissionRegistrar::class)->pivotPermission
         );
 
-        if (! PermissionRegistrar::$teams) {
+        if (! app(PermissionRegistrar::class)->teams) {
             return $relation;
         }
 
-        return $relation->wherePivot(PermissionRegistrar::$teamsKey, getPermissionsTeamId());
+        return $relation->wherePivot(app(PermissionRegistrar::class)->teamsKey, getPermissionsTeamId());
     }
 
     /**
@@ -361,8 +361,8 @@ trait HasPermissions
 
                 $this->ensureModelSharesGuard($permission);
 
-                $array[$permission->getKey()] = PermissionRegistrar::$teams && ! is_a($this, Role::class) ?
-                    [PermissionRegistrar::$teamsKey => getPermissionsTeamId()] : [];
+                $array[$permission->getKey()] = app(PermissionRegistrar::class)->teams && ! is_a($this, Role::class) ?
+                    [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
                 return $array;
             }, []);

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -24,10 +24,10 @@ trait HasRoles
                 return;
             }
 
-            $teams = PermissionRegistrar::$teams;
-            PermissionRegistrar::$teams = false;
+            $teams = app(PermissionRegistrar::class)->teams;
+            app(PermissionRegistrar::class)->teams = false;
             $model->roles()->detach();
-            PermissionRegistrar::$teams = $teams;
+            app(PermissionRegistrar::class)->teams = $teams;
         });
     }
 
@@ -50,16 +50,16 @@ trait HasRoles
             'model',
             config('permission.table_names.model_has_roles'),
             config('permission.column_names.model_morph_key'),
-            PermissionRegistrar::$pivotRole
+            app(PermissionRegistrar::class)->pivotRole
         );
 
-        if (! PermissionRegistrar::$teams) {
+        if (! app(PermissionRegistrar::class)->teams) {
             return $relation;
         }
 
-        return $relation->wherePivot(PermissionRegistrar::$teamsKey, getPermissionsTeamId())
+        return $relation->wherePivot(app(PermissionRegistrar::class)->teamsKey, getPermissionsTeamId())
             ->where(function ($q) {
-                $teamField = config('permission.table_names.roles').'.'.PermissionRegistrar::$teamsKey;
+                $teamField = config('permission.table_names.roles').'.'. app(PermissionRegistrar::class)->teamsKey;
                 $q->whereNull($teamField)->orWhere($teamField, getPermissionsTeamId());
             });
     }
@@ -117,8 +117,8 @@ trait HasRoles
 
                 $this->ensureModelSharesGuard($role);
 
-                $array[$role->getKey()] = PermissionRegistrar::$teams && ! is_a($this, Permission::class) ?
-                    [PermissionRegistrar::$teamsKey => getPermissionsTeamId()] : [];
+                $array[$role->getKey()] = app(PermissionRegistrar::class)->teams && ! is_a($this, Permission::class) ?
+                    [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
                 return $array;
             }, []);


### PR DESCRIPTION
Make the static properties on `PermissionRegistrar` non-static. 

This will make sure that if any of the properties are accessed, the cache initialization has happened first.


BREAKING CHANGE:
This is a breaking change as it will make all current migration files fail, as they are currently accessing the static properties which are not static anymore.