### PR TITLE
Add description column to Roles & Permissions table

### DIFF
--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -29,7 +29,7 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->bigIncrements('id'); // permission id
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
-            $table->string('description');       // For MySQL 8.0 use string('description', 125);
+            $table->string('description')->nullable();       // For MySQL 8.0 use string('description', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
 
@@ -43,7 +43,7 @@ class CreatePermissionTables extends Migration
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
             }
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
-            $table->string('description');       // For MySQL 8.0 use string('description', 125);
+            $table->string('description')->nullable();       // For MySQL 8.0 use string('description', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
             if ($teams || config('permission.testing')) {

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -29,6 +29,7 @@ class CreatePermissionTables extends Migration
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
             $table->bigIncrements('id'); // permission id
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
+            $table->string('description');       // For MySQL 8.0 use string('description', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
 
@@ -42,6 +43,7 @@ class CreatePermissionTables extends Migration
                 $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
             }
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
+            $table->string('description');       // For MySQL 8.0 use string('description', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
             $table->timestamps();
             if ($teams || config('permission.testing')) {

--- a/docs/basic-usage/basic-usage.md
+++ b/docs/basic-usage/basic-usage.md
@@ -28,6 +28,13 @@ $role = Role::create(['name' => 'writer']);
 $permission = Permission::create(['name' => 'edit articles']);
 ```
 
+Also, you can add descriptions to roles and permissions:
+
+```php
+$role = Role::create(['name' => 'writer', 'description' => 'A writer can write articles']);
+$permission = Permission::create(['name' => 'edit articles', 'description' => 'A user can edit articles']);
+```
+
 
 A permission can be assigned to a role using 1 of these methods:
 

--- a/src/Contracts/Permission.php
+++ b/src/Contracts/Permission.php
@@ -39,8 +39,9 @@ interface Permission
      * Find or Create a permission by its name and guard name.
      *
      * @param  string  $name
-     * @param  string|null  $guardName
+     * @param string|null $guardName
+     * @param string|null $description
      * @return Permission
      */
-    public static function findOrCreate(string $name, $guardName): self;
+    public static function findOrCreate(string $name, ?string $guardName, ?string $description): self;
 }

--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -39,10 +39,11 @@ interface Role
      * Find or create a role by its name and guard name.
      *
      * @param  string  $name
-     * @param  string|null  $guardName
+     * @param string|null $guardName
+     * @param string|null $description
      * @return \Spatie\Permission\Contracts\Role
      */
-    public static function findOrCreate(string $name, $guardName): self;
+    public static function findOrCreate(string $name, ?string $guardName, ?string $description): self;
 
     /**
      * Determine if the user may perform the given permission.

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -126,16 +126,17 @@ class Permission extends Model implements PermissionContract
      * Find or create permission by its name (and optionally guardName).
      *
      * @param  string  $name
-     * @param  string|null  $guardName
+     * @param string|null $guardName
+     * @param string|null $description
      * @return \Spatie\Permission\Contracts\Permission
      */
-    public static function findOrCreate(string $name, $guardName = null): PermissionContract
+    public static function findOrCreate(string $name, ?string $guardName, ?string $description): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $permission) {
-            return static::query()->create(['name' => $name, 'guard_name' => $guardName]);
+            return static::query()->create(['name' => $name, 'guard_name' => $guardName, 'description' => $description]);
         }
 
         return $permission;

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -41,7 +41,7 @@ class Role extends Model implements RoleContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
-        $params = ['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']];
+        $params = ['name' => $attributes['name'], 'guard_name' => $attributes['guard_name'], 'description' => $attributes['description']];
         if (app(PermissionRegistrar::class)->teams) {
             $teamsKey = app(PermissionRegistrar::class)->teamsKey;
 
@@ -131,17 +131,18 @@ class Role extends Model implements RoleContract
      * Find or create role by its name (and optionally guardName).
      *
      * @param  string  $name
-     * @param  string|null  $guardName
+     * @param string|null $guardName
+     * @param string|null $description
      * @return \Spatie\Permission\Contracts\Role|\Spatie\Permission\Models\Role
      */
-    public static function findOrCreate(string $name, $guardName = null): RoleContract
+    public static function findOrCreate(string $name, ?string $guardName = null, ?string $description = null): RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $role) {
-            return static::query()->create(['name' => $name, 'guard_name' => $guardName] + (app(PermissionRegistrar::class)->teams ? [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : []));
+            return static::query()->create(['name' => $name, 'guard_name' => $guardName, 'description' => $description] + (app(PermissionRegistrar::class)->teams ? [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : []));
         }
 
         return $role;


### PR DESCRIPTION
This PR adds the ability to define a **Description** for a role or permission. 

This is useful to provide more information about the role or permission and to display it in the UI or help you to understand what the role or permission is for in future .



```php
$role = Role::create(['name' => 'writer', 'description' => 'A writer can write articles']);
$permission = Permission::create(['name' => 'edit articles', 'description' => 'A user can edit articles']);
```


