### PR TITLE
Avoid loss of all permissions/roles pivots on sync error

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -343,9 +343,8 @@ trait HasPermissions
      * Returns permissions ids as array keys
      *
      * @param  string|int|array|\Spatie\Permission\Contracts\Permission|\Illuminate\Support\Collection  $permissions
-     * @return array
      */
-    public function collectPermissions(...$permissions)
+    private function collectPermissions(...$permissions): array
     {
         return collect($permissions)
             ->flatten()
@@ -376,7 +375,7 @@ trait HasPermissions
      */
     public function givePermissionTo(...$permissions)
     {
-        $permissions = $this->collectPermissions(...$permissions);
+        $permissions = $this->collectPermissions($permissions);
 
         $model = $this->getModel();
 
@@ -412,6 +411,8 @@ trait HasPermissions
      */
     public function syncPermissions(...$permissions)
     {
+        $this->collectPermissions($permissions);
+
         $this->permissions()->detach();
 
         return $this->givePermissionTo($permissions);

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -96,14 +96,13 @@ trait HasRoles
     }
 
     /**
-     * Assign the given role to the model.
+     * Returns roles ids as array keys
      *
-     * @param  array|string|int|\Spatie\Permission\Contracts\Role|\Illuminate\Support\Collection  ...$roles
-     * @return $this
+     * @param  array|string|int|\Spatie\Permission\Contracts\Role|\Illuminate\Support\Collection  $roles
      */
-    public function assignRole(...$roles)
+    private function collectRoles(...$roles): array
     {
-        $roles = collect($roles)
+        return collect($roles)
             ->flatten()
             ->reduce(function ($array, $role) {
                 if (empty($role)) {
@@ -122,6 +121,17 @@ trait HasRoles
 
                 return $array;
             }, []);
+    }
+
+    /**
+     * Assign the given role to the model.
+     *
+     * @param  array|string|int|\Spatie\Permission\Contracts\Role|\Illuminate\Support\Collection  ...$roles
+     * @return $this
+     */
+    public function assignRole(...$roles)
+    {
+        $roles = $this->collectRoles($roles);
 
         $model = $this->getModel();
 
@@ -175,6 +185,8 @@ trait HasRoles
      */
     public function syncRoles(...$roles)
     {
+        $this->collectRoles($roles);
+
         $this->roles()->detach();
 
         return $this->assignRole($roles);

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -477,6 +477,18 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    public function sync_permission_error_does_not_detach_permissions()
+    {
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUser->syncPermissions('edit-articles', 'permission-that-does-not-exist');
+
+        $this->assertTrue($this->testUser->fresh()->hasDirectPermission('edit-news'));
+    }
+
+    /** @test */
     public function it_does_not_remove_already_associated_permissions_when_assigning_new_permissions()
     {
         $this->testUser->givePermissionTo('edit-news');

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -228,6 +228,18 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function sync_roles_error_does_not_detach_roles()
+    {
+        $this->testUser->assignRole('testRole');
+
+        $this->expectException(RoleDoesNotExist::class);
+
+        $this->testUser->syncRoles('testRole2', 'role-that-does-not-exist');
+
+        $this->assertTrue($this->testUser->fresh()->hasRole('testRole'));
+    }
+
+    /** @test */
     public function it_will_sync_roles_to_a_model_that_is_not_persisted()
     {
         $user = new User(['email' => 'test@user.com']);

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -156,6 +156,18 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    public function sync_permission_error_does_not_detach_permissions()
+    {
+        $this->testUserRole->givePermissionTo('edit-news');
+
+        $this->expectException(PermissionDoesNotExist::class);
+
+        $this->testUserRole->syncPermissions('edit-articles', 'permission-that-does-not-exist');
+
+        $this->assertTrue($this->testUserRole->fresh()->hasDirectPermission('edit-news'));
+    }
+
+    /** @test */
     public function it_can_revoke_a_permission()
     {
         $this->testUserRole->givePermissionTo('edit-articles');


### PR DESCRIPTION
Closes #2339

>**Describe the bug**
When using the syncPermissions function from the HasPermissions trait, providing an accidental wrongly named permission will result in loss of all permissions. This is caused by the fact that syncPermissions eagerly removes all existing permissions.
>
>**Steps to reproduce the behavior:**
>Create a model that uses the HasPermissions trait
Assign some valid permissions to the model
Use the syncPermissions helper, with a combination of any number of valid permissions and at least one invalid permission
Result: all permissions will be lost on the user
>
>**Example Test**
Here is a link to my Github repo containing a minimal Laravel application which shows my problem:
https://github.com/spatie/laravel-permission/compare/main...jnoordsij:spatie-laravel-permission:permission-sync-fail