### PR TITLE
Fix HasRoles::hasRole to be type-safe

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -224,7 +224,11 @@ trait HasRoles
             return false;
         }
 
-        return $roles->intersect($guard ? $this->roles->where('guard_name', $guard) : $this->roles)->isNotEmpty();
+        if ($roles instanceof Collection) {
+            return $roles->intersect($guard ? $this->roles->where('guard_name', $guard) : $this->roles)->isNotEmpty();
+        }
+
+        throw new \InvalidArgumentException();
     }
 
     /**

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -134,6 +134,14 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    public function it_throws_an_exception_when_determining_with_invalid_argument()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->testUser->hasRole(new class {});
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_assigning_a_role_that_does_not_exist()
     {
         $this->expectException(RoleDoesNotExist::class);


### PR DESCRIPTION
I want below to be seen by members, everyone else, ignore this PR because;

I barely mentiond that I should request/report this PR's changes at #2332,
but my time was wasted with many spammers.

## Basically, #2332's related discussion comes down to:
* `HasRoles::hasRole` has doc-comment.
* We don't need to check input type, which has 1 micro second performance penality.
* Whatever happens, our doc-comment means it's your fault, check yourselves each time you call the function/method.

## My answer:
* PHP ignores your doc-comments, and is not type-safe in this case.
* Each such mixed input function/method is responsible to check it's input types.
* Don't make bad excuses, because both PHP and most IDEs silently ignore doc-comments, hence this is an issue worthy of reporting and/or PR.