### PR TITLE
Fix delete permissions on Permissions Model

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -32,6 +32,10 @@ trait HasPermissions
                 return;
             }
 
+            if (is_a($model, Permission::class)) {
+                return;
+            }
+
             $teams = app(PermissionRegistrar::class)->teams;
             app(PermissionRegistrar::class)->teams = false;
             $model->permissions()->detach();

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -217,7 +217,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
-    public function it_doesnt_detach_permissions_when_soft_deleting()
+    public function it_doesnt_detach_permissions_when_user_soft_deleting()
     {
         $user = SoftDeletingUser::create(['email' => 'test@example.com']);
         $user->givePermissionTo(['edit-news']);

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -584,7 +584,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_detach_roles_when_soft_deleting()
+    public function it_does_not_detach_roles_when_user_soft_deleting()
     {
         $user = SoftDeletingUser::create(['email' => 'test@example.com']);
         $user->assignRole('testRole');

--- a/tests/HasRolesWithCustomModelsTest.php
+++ b/tests/HasRolesWithCustomModelsTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Permission\Test;
 
+use DB;
+
 class HasRolesWithCustomModelsTest extends HasRolesTest
 {
     /** @var bool */
@@ -11,5 +13,54 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     public function it_can_use_custom_model_role()
     {
         $this->assertSame(get_class($this->testUserRole), Role::class);
+    }
+
+    /** @test */
+    public function it_doesnt_detach_permissions_when_soft_deleting()
+    {
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+
+        DB::enableQueryLog();
+        $this->testUserRole->delete();
+        DB::disableQueryLog();
+
+        $this->assertSame(1, count(DB::getQueryLog()));
+
+        $role = Role::onlyTrashed()->find($this->testUserRole->getKey());
+
+        $this->assertEquals(1, DB::table(config('permission.table_names.role_has_permissions'))->where('role_test_id', $this->testUserRole->getKey())->count());
+    }
+
+    /** @test */
+    public function it_doesnt_detach_users_when_soft_deleting()
+    {
+        $this->testUser->assignRole($this->testUserRole);
+
+        DB::enableQueryLog();
+        $this->testUserRole->delete();
+        DB::disableQueryLog();
+
+        $this->assertSame(1, count(DB::getQueryLog()));
+
+        $role = Role::onlyTrashed()->find($this->testUserRole->getKey());
+
+        $this->assertEquals(1, DB::table(config('permission.table_names.model_has_roles'))->where('role_test_id', $this->testUserRole->getKey())->count());
+    }
+
+    /** @test */
+    public function it_does_detach_permissions_when_force_deleting()
+    {
+        $this->testUserRole->givePermissionTo($this->testUserPermission);
+
+        DB::enableQueryLog();
+        $this->testUserRole->forceDelete();
+        DB::disableQueryLog();
+
+        $this->assertSame(2, count(DB::getQueryLog()));
+
+        $role = Role::withTrashed()->find($this->testUserRole->getKey());
+
+        $this->assertNull($role);
+        $this->assertEquals(0, DB::table(config('permission.table_names.role_has_permissions'))->where('role_test_id', $this->testUserRole->getKey())->count());
     }
 }

--- a/tests/Permission.php
+++ b/tests/Permission.php
@@ -2,8 +2,12 @@
 
 namespace Spatie\Permission\Test;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 class Permission extends \Spatie\Permission\Models\Permission
 {
+    use SoftDeletes;
+
     protected $primaryKey = 'permission_test_id';
 
     protected $visible = [

--- a/tests/Role.php
+++ b/tests/Role.php
@@ -2,8 +2,12 @@
 
 namespace Spatie\Permission\Test;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 class Role extends \Spatie\Permission\Models\Role
 {
+    use SoftDeletes;
+
     protected $primaryKey = 'role_test_id';
 
     protected $visible = [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -116,13 +116,15 @@ abstract class TestCase extends Orchestra
      */
     protected function setUpDatabase($app)
     {
-        $app['db']->connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+        $schema = $app['db']->connection()->getSchemaBuilder();
+
+        $schema->create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->softDeletes();
         });
 
-        $app['db']->connection()->getSchemaBuilder()->create('admins', function (Blueprint $table) {
+        $schema->create('admins', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
         });
@@ -136,6 +138,13 @@ abstract class TestCase extends Orchestra
             self::$migration->up();
         } else {
             self::$customMigration->up();
+
+            $schema->table(config('permission.table_names.roles'), function (Blueprint $table) {
+                $table->softDeletes();
+            });
+            $schema->table(config('permission.table_names.permissions'), function (Blueprint $table) {
+                $table->softDeletes();
+            });
         }
 
         $this->testUser = User::create(['email' => 'test@user.com']);


### PR DESCRIPTION
Closes #2365

**Describe the bug**
on delete permission when it uses `SoftDeletes`, and do `forceDelete()`, it tries to detach permissions relation in itself

`Permissions` Model uses `HasRoles` trait, 
`HasRoles` trait uses `HasPermission` trait, 
and `HasPermission` trait has `permissions` relation, so `Permissions` Model has `$model->permissions()->detach(); ` on deleting
https://github.com/spatie/laravel-permission/blob/a7692219b322657f8ed97c376dc7f91ad7dd464f/src/Models/Permission.php#L23-L25
https://github.com/spatie/laravel-permission/blob/a7692219b322657f8ed97c376dc7f91ad7dd464f/src/Traits/HasRoles.php#L13-L15
https://github.com/spatie/laravel-permission/blob/a7692219b322657f8ed97c376dc7f91ad7dd464f/src/Traits/HasPermissions.php#L37

This is the bug:
```sql
delete from "model_has_permissions" where
    "model_has_permissions"."model_test_id" = '8c0c850a-cd70-4689-8a18-cb96e3fd5ef9' 
    and "model_type" = 'Spatie\Permission\Test\Permission'
```
**`SoftDeletes` testing on `Roles`, `Permissions` models added**