### PR TITLE
[V6] [BC] Return string on getPermissionClass(), getRoleClass()

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -179,14 +179,12 @@ class Role extends Model implements RoleContract
             return $this->hasWildcardPermission($permission, $this->getDefaultGuardName());
         }
 
-        $permissionClass = $this->getPermissionClass();
-
         if (is_string($permission)) {
-            $permission = $permissionClass->findByName($permission, $this->getDefaultGuardName());
+            $permission = $this->getPermissionClass()::findByName($permission, $this->getDefaultGuardName());
         }
 
         if (is_int($permission)) {
-            $permission = $permissionClass->findById($permission, $this->getDefaultGuardName());
+            $permission = $this->getPermissionClass()::findById($permission, $this->getDefaultGuardName());
         }
 
         if (! $this->getGuardNames()->contains($permission->guard_name)) {

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -227,12 +227,9 @@ class PermissionRegistrar
         return $permissions;
     }
 
-    /**
-     * Get an instance of the permission class.
-     */
-    public function getPermissionClass(): Permission
+    public function getPermissionClass(): string
     {
-        return app($this->permissionClass);
+        return $this->permissionClass;
     }
 
     public function setPermissionClass($permissionClass)
@@ -244,12 +241,9 @@ class PermissionRegistrar
         return $this;
     }
 
-    /**
-     * Get an instance of the role class.
-     */
-    public function getRoleClass(): Role
+    public function getRoleClass(): string
     {
-        return app($this->roleClass);
+        return $this->roleClass;
     }
 
     public function setRoleClass($roleClass)
@@ -273,7 +267,7 @@ class PermissionRegistrar
 
     protected function getPermissionsWithRoles(): Collection
     {
-        return $this->getPermissionClass()->select()->with('roles')->get();
+        return $this->permissionClass::select()->with('roles')->get();
     }
 
     /**

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -34,7 +34,7 @@ trait HasRoles
         });
     }
 
-    public function getRoleClass()
+    public function getRoleClass(): string
     {
         if (! $this->roleClass) {
             $this->roleClass = app(PermissionRegistrar::class)->getRoleClass();
@@ -86,7 +86,7 @@ trait HasRoles
 
             $method = is_numeric($role) || PermissionRegistrar::isUid($role) ? 'findById' : 'findByName';
 
-            return $this->getRoleClass()->{$method}($role, $guard ?: $this->getDefaultGuardName());
+            return $this->getRoleClass()::{$method}($role, $guard ?: $this->getDefaultGuardName());
         }, Arr::wrap($roles));
 
         return $query->whereHas('roles', function (Builder $subQuery) use ($roles) {
@@ -153,7 +153,7 @@ trait HasRoles
             );
         }
 
-        if (is_a($this, get_class($this->getPermissionClass()))) {
+        if (is_a($this, Permission::class)) {
             $this->forgetCachedPermissions();
         }
 
@@ -171,7 +171,7 @@ trait HasRoles
 
         $this->load('roles');
 
-        if (is_a($this, get_class($this->getPermissionClass()))) {
+        if (is_a($this, Permission::class)) {
             $this->forgetCachedPermissions();
         }
 
@@ -329,14 +329,12 @@ trait HasRoles
 
     protected function getStoredRole($role): Role
     {
-        $roleClass = $this->getRoleClass();
-
         if (is_numeric($role) || PermissionRegistrar::isUid($role)) {
-            return $roleClass->findById($role, $this->getDefaultGuardName());
+            return $this->getRoleClass()::findById($role, $this->getDefaultGuardName());
         }
 
         if (is_string($role)) {
-            return $roleClass->findByName($role, $this->getDefaultGuardName());
+            return $this->getRoleClass()::findByName($role, $this->getDefaultGuardName());
         }
 
         return $role;

--- a/tests/PermissionRegistarTest.php
+++ b/tests/PermissionRegistarTest.php
@@ -2,7 +2,13 @@
 
 namespace Spatie\Permission\Tests;
 
+use Spatie\Permission\Contracts\Permission as PermissionContract;
+use Spatie\Permission\Contracts\Role as RoleContract;
+use Spatie\Permission\Models\Permission as SpatiePermission;
+use Spatie\Permission\Models\Role as SpatieRole;
 use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Tests\TestModels\Permission as TestPermission;
+use Spatie\Permission\Tests\TestModels\Role as TestRole;
 
 class PermissionRegistarTest extends TestCase
 {
@@ -63,5 +69,52 @@ class PermissionRegistarTest extends TestCase
         foreach ($not_uids as $not_uid) {
             $this->assertFalse(PermissionRegistrar::isUid($not_uid));
         }
+    }
+
+    /** @test */
+    public function it_can_get_permission_class() {
+        $this->assertSame(SpatiePermission::class, app(PermissionRegistrar::class)->getPermissionClass());
+        $this->assertSame(SpatiePermission::class, get_class(app(PermissionContract::class)));
+    }
+
+    /** @test */
+    public function it_can_change_permission_class() {
+        $this->assertSame(SpatiePermission::class, config('permission.models.permission'));
+        $this->assertSame(SpatiePermission::class, app(PermissionRegistrar::class)->getPermissionClass());
+        $this->assertSame(SpatiePermission::class, get_class(app(PermissionContract::class)));
+        
+        app(PermissionRegistrar::class)->setPermissionClass(TestPermission::class);
+
+        $this->assertSame(TestPermission::class, config('permission.models.permission'));
+        $this->assertSame(TestPermission::class, app(PermissionRegistrar::class)->getPermissionClass());
+        $this->assertSame(TestPermission::class, get_class(app(PermissionContract::class)));
+    }
+
+    /** @test */
+    public function it_can_get_role_class() {
+        $this->assertSame(SpatieRole::class, app(PermissionRegistrar::class)->getRoleClass());
+        $this->assertSame(SpatieRole::class, get_class(app(RoleContract::class)));
+    }
+
+    /** @test */
+    public function it_can_change_role_class() {
+        $this->assertSame(SpatieRole::class, config('permission.models.role'));
+        $this->assertSame(SpatieRole::class, app(PermissionRegistrar::class)->getRoleClass());
+        $this->assertSame(SpatieRole::class, get_class(app(RoleContract::class)));
+
+        app(PermissionRegistrar::class)->setRoleClass(TestRole::class);
+
+        $this->assertSame(TestRole::class, config('permission.models.role'));
+        $this->assertSame(TestRole::class, app(PermissionRegistrar::class)->getRoleClass());
+        $this->assertSame(TestRole::class, get_class(app(RoleContract::class)));
+    }
+
+    /** @test */
+    public function it_can_change_team_id() {
+        $team_id = '00000000-0000-0000-0000-000000000000';
+
+        app(PermissionRegistrar::class)->setPermissionsTeamId($team_id);
+
+        $this->assertSame($team_id, app(PermissionRegistrar::class)->getPermissionsTeamId());
     }
 }


### PR DESCRIPTION
This PR is for testing discussion #2367, this could be a breaking change if someone uses `getPermissionClass(), getRoleClass()`

**Tests with this change**
-> Time: 00:09.050, Memory: 46.00 MB
**Test without this change**
-> Time: 00:09.427, Memory: 48.00 MB
**Seems like this change uses less memory, also I think that this uses less cycles because it is not calling `app()` helper on every instance, and avoid making contract instances on every time**(Tested on PHP 8.1)