### PR TITLE
[V6] Rename clearClassPermissions method to clearPermissionsCollection

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -151,13 +151,22 @@ class PermissionRegistrar
     }
 
     /**
-     * Clear class permissions.
+     * Clear already loaded permissions collection.
      * This is only intended to be called by the PermissionServiceProvider on boot,
      * so that long-running instances like Swoole don't keep old data in memory.
      */
-    public function clearClassPermissions()
+    public function clearPermissionsCollection(): void
     {
         $this->permissions = null;
+    }
+
+    /**
+     * @deprecated
+     * @alias of clearPermissionsCollection()
+     */
+    public function clearClassPermissions()
+    {
+        $this->clearPermissionsCollection();
     }
 
     /**

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -29,7 +29,7 @@ class PermissionServiceProvider extends ServiceProvider
             if ($this->app->config['permission.register_permission_check_method']) {
                 /** @var PermissionRegistrar $permissionLoader */
                 $permissionLoader = $app->get(PermissionRegistrar::class);
-                $permissionLoader->clearClassPermissions();
+                $permissionLoader->clearPermissionsCollection();
                 $permissionLoader->registerPermissions($gate);
             }
         });

--- a/tests/PermissionRegistarTest.php
+++ b/tests/PermissionRegistarTest.php
@@ -7,6 +7,21 @@ use Spatie\Permission\PermissionRegistrar;
 class PermissionRegistarTest extends TestCase
 {
     /** @test */
+    public function it_can_clear_loaded_permissions_collection() {
+        $reflectedClass = new \ReflectionClass(app(PermissionRegistrar::class));
+        $reflectedProperty = $reflectedClass->getProperty('permissions');
+        $reflectedProperty->setAccessible(true);
+
+        app(PermissionRegistrar::class)->getPermissions();
+
+        $this->assertNotNull($reflectedProperty->getValue(app(PermissionRegistrar::class)));
+
+        app(PermissionRegistrar::class)->clearPermissionsCollection();
+
+        $this->assertNull($reflectedProperty->getValue(app(PermissionRegistrar::class)));
+    }
+
+    /** @test */
     public function it_can_check_uids()
     {
         $uids = [


### PR DESCRIPTION
Discussed on #2367
use a more descriptive name