### PR TITLE
Detach users on role/permission physical deletion

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -32,20 +32,21 @@ trait HasPermissions
                 return;
             }
 
-            if (is_a($model, Permission::class)) {
-                return;
-            }
-
             $teams = app(PermissionRegistrar::class)->teams;
             app(PermissionRegistrar::class)->teams = false;
-            $model->permissions()->detach();
+            if (! is_a($model, Permission::class)) {
+                $model->permissions()->detach();
+            }
+            if (is_a($model, Role::class)) {
+                $model->users()->detach();
+            }
             app(PermissionRegistrar::class)->teams = $teams;
         });
     }
 
     public function getPermissionClass()
     {
-        if (! isset($this->permissionClass)) {
+        if (! $this->permissionClass) {
             $this->permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
         }
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -27,13 +27,16 @@ trait HasRoles
             $teams = app(PermissionRegistrar::class)->teams;
             app(PermissionRegistrar::class)->teams = false;
             $model->roles()->detach();
+            if (is_a($model, Permission::class)) {
+                $model->users()->detach();
+            }
             app(PermissionRegistrar::class)->teams = $teams;
         });
     }
 
     public function getRoleClass()
     {
-        if (! isset($this->roleClass)) {
+        if (! $this->roleClass) {
             $this->roleClass = app(PermissionRegistrar::class)->getRoleClass();
         }
 

--- a/tests/HasRolesWithCustomModelsTest.php
+++ b/tests/HasRolesWithCustomModelsTest.php
@@ -28,7 +28,7 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
 
         $role = Role::onlyTrashed()->find($this->testUserRole->getKey());
 
-        $this->assertEquals(1, DB::table(config('permission.table_names.role_has_permissions'))->where('role_test_id', $this->testUserRole->getKey())->count());
+        $this->assertEquals(1, DB::table(config('permission.table_names.role_has_permissions'))->where('role_test_id', $role->getKey())->count());
     }
 
     /** @test */
@@ -44,23 +44,26 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
 
         $role = Role::onlyTrashed()->find($this->testUserRole->getKey());
 
-        $this->assertEquals(1, DB::table(config('permission.table_names.model_has_roles'))->where('role_test_id', $this->testUserRole->getKey())->count());
+        $this->assertEquals(1, DB::table(config('permission.table_names.model_has_roles'))->where('role_test_id', $role->getKey())->count());
     }
 
     /** @test */
-    public function it_does_detach_permissions_when_force_deleting()
+    public function it_does_detach_permissions_and_users_when_force_deleting()
     {
-        $this->testUserRole->givePermissionTo($this->testUserPermission);
+        $role_id = $this->testUserRole->getKey();
+        $this->testUserPermission->assignRole($role_id);
+        $this->testUser->assignRole($role_id);
 
         DB::enableQueryLog();
         $this->testUserRole->forceDelete();
         DB::disableQueryLog();
 
-        $this->assertSame(2, count(DB::getQueryLog()));
+        $this->assertSame(3, count(DB::getQueryLog()));
 
-        $role = Role::withTrashed()->find($this->testUserRole->getKey());
+        $role = Role::withTrashed()->find($role_id);
 
         $this->assertNull($role);
-        $this->assertEquals(0, DB::table(config('permission.table_names.role_has_permissions'))->where('role_test_id', $this->testUserRole->getKey())->count());
+        $this->assertEquals(0, DB::table(config('permission.table_names.role_has_permissions'))->where('role_test_id', $role_id)->count());
+        $this->assertEquals(0, DB::table(config('permission.table_names.model_has_roles'))->where('role_test_id', $role_id)->count());
     }
 }


### PR DESCRIPTION
On #2366 I found that if you have users attached to roles/permissions, when `forceDelete` one role/permission, users are not detached before delete, if we don't have cascade delete it breaks functionality

I don't know if there is a reason for this behavior or is it a bug that has gone unnoticed for years(I've never had to delete one)
This PR fix it and add tests for that