### PR TITLE
[V6] Use anonymous migrations (for L8+)

### DIFF
--- a/database/migrations/add_teams_fields.php.stub
+++ b/database/migrations/add_teams_fields.php.stub
@@ -5,14 +5,14 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class AddTeamsFields extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         $teams = config('permission.teams');
         $tableNames = config('permission.table_names');
@@ -88,8 +88,8 @@ class AddTeamsFields extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
 
     }
-}
+};

--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -4,14 +4,14 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreatePermissionTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         $teams = config('permission.teams');
         $tableNames = config('permission.table_names');
@@ -125,7 +125,7 @@ class CreatePermissionTables extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         $tableNames = config('permission.table_names');
 
@@ -139,4 +139,4 @@ class CreatePermissionTables extends Migration
         Schema::drop($tableNames['roles']);
         Schema::drop($tableNames['permissions']);
     }
-}
+};

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -143,9 +143,9 @@ class CommandTest extends TestCase
         $matchingFiles = glob(database_path('migrations/*_add_teams_fields.php'));
         $this->assertTrue(count($matchingFiles) > 0);
 
-        include_once $matchingFiles[count($matchingFiles) - 1];
-        (new \AddTeamsFields())->up();
-        (new \AddTeamsFields())->up(); //test upgrade teams migration fresh
+        $AddTeamsFields = require($matchingFiles[count($matchingFiles) - 1]);
+        $AddTeamsFields->up();
+        $AddTeamsFields->up(); //test upgrade teams migration fresh
 
         Role::create(['name' => 'new-role', 'team_test_id' => 1]);
         $role = Role::where('name', 'new-role')->first();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -163,7 +163,6 @@ abstract class TestCase extends Orchestra
     {
         $migration = str_replace(
             [
-                'CreatePermissionTables',
                 '(\'id\'); // permission id',
                 '(\'id\'); // role id',
                 'references(\'id\') // permission id',
@@ -173,7 +172,6 @@ abstract class TestCase extends Orchestra
                 'unsignedBigInteger($pivotPermission)',
             ],
             [
-                'CreatePermissionCustomTables',
                 '(\'permission_test_id\');',
                 '(\'role_test_id\');',
                 'references(\'permission_test_id\')',
@@ -186,12 +184,10 @@ abstract class TestCase extends Orchestra
         );
 
         file_put_contents(__DIR__.'/CreatePermissionCustomTables.php', $migration);
-
-        include_once __DIR__.'/../database/migrations/create_permission_tables.php.stub';
-        self::$migration = new \CreatePermissionTables();
-
-        include_once __DIR__.'/CreatePermissionCustomTables.php';
-        self::$customMigration = new \CreatePermissionCustomTables();
+        
+        self::$migration = require(__DIR__.'/../database/migrations/create_permission_tables.php.stub');
+        
+        self::$customMigration = require(__DIR__.'/CreatePermissionCustomTables.php');
     }
 
     protected function reloadPermissions()


### PR DESCRIPTION
Since Laravel 8.x it is possible to use anonymous migrations, I don't think anyone starts a new project using Laravel <=7.x
It's time to change migrations