### PR TITLE
Refactor Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Spatie\\Permission\\Test\\": "tests"
+            "Spatie\\Permission\\Tests\\": "tests"
         }
     },
     "config": {

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
-use Artisan;
+use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\Contracts\Role;
 
 class BladeTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -8,6 +8,7 @@ use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Tests\TestModels\User;
 
 class CacheTest extends TestCase
 {
@@ -21,7 +22,7 @@ class CacheTest extends TestCase
 
     protected $registrar;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\Models\Permission;

--- a/tests/CustomGateTest.php
+++ b/tests/CustomGateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Contracts\Auth\Access\Gate;
 

--- a/tests/GateTest.php
+++ b/tests/GateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Contracts\Auth\Access\Gate;
 

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -1,12 +1,14 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use DB;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
+use Spatie\Permission\Tests\TestModels\SoftDeletingUser;
+use Spatie\Permission\Tests\TestModels\User;
 
 class HasPermissionsTest extends TestCase
 {

--- a/tests/HasPermissionsWithCustomModelsTest.php
+++ b/tests/HasPermissionsWithCustomModelsTest.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Tests\TestModels\Permission;
+use Spatie\Permission\Tests\TestModels\User;
 
 class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
 {

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -1,11 +1,14 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
+use Spatie\Permission\Tests\TestModels\Admin;
+use Spatie\Permission\Tests\TestModels\SoftDeletingUser;
+use Spatie\Permission\Tests\TestModels\User;
 
 class HasRolesTest extends TestCase
 {

--- a/tests/HasRolesWithCustomModelsTest.php
+++ b/tests/HasRolesWithCustomModelsTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
-use DB;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Tests\TestModels\Role;
 
 class HasRolesWithCustomModelsTest extends HasRolesTest
 {

--- a/tests/MultipleGuardsTest.php
+++ b/tests/MultipleGuardsTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Spatie\Permission\Contracts\Permission;
+use Spatie\Permission\Tests\TestModels\Manager;
 
 class MultipleGuardsTest extends TestCase
 {

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -15,7 +15,7 @@ class PermissionMiddlewareTest extends TestCase
 {
     protected $permissionMiddleware;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -223,16 +223,5 @@ class PermissionMiddlewareTest extends TestCase
             200,
             $this->runMiddleware($this->permissionMiddleware, 'admin-permission', 'admin')
         );
-    }
-
-    protected function runMiddleware($middleware, $permission, $guard = null)
-    {
-        try {
-            return $middleware->handle(new Request(), function () {
-                return (new Response())->setContent('<html></html>');
-            }, $permission, $guard)->status();
-        } catch (UnauthorizedException $e) {
-            return $e->getStatusCode();
-        }
     }
 }

--- a/tests/PermissionRegistarTest.php
+++ b/tests/PermissionRegistarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Spatie\Permission\PermissionRegistrar;
 

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
+use Spatie\Permission\Tests\TestModels\User;
 
 class PermissionTest extends TestCase
 {

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -14,7 +14,7 @@ class RoleMiddlewareTest extends TestCase
 {
     protected $roleMiddleware;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -189,16 +189,5 @@ class RoleMiddlewareTest extends TestCase
             200,
             $this->runMiddleware($this->roleMiddleware, 'testAdminRole', 'admin')
         );
-    }
-
-    protected function runMiddleware($middleware, $roleName, $guard = null)
-    {
-        try {
-            return $middleware->handle(new Request(), function () {
-                return (new Response())->setContent('<html></html>');
-            }, $roleName, $guard)->status();
-        } catch (UnauthorizedException $e) {
-            return $e->getStatusCode();
-        }
     }
 }

--- a/tests/RoleOrPermissionMiddlewareTest.php
+++ b/tests/RoleOrPermissionMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -14,7 +14,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
 {
     protected $roleOrPermissionMiddleware;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -163,16 +163,5 @@ class RoleOrPermissionMiddlewareTest extends TestCase
         }
 
         $this->assertStringEndsWith('Necessary roles or permissions are some-permission, some-role', $message);
-    }
-
-    protected function runMiddleware($middleware, $name, $guard = null)
-    {
-        try {
-            return $middleware->handle(new Request(), function () {
-                return (new Response())->setContent('<html></html>');
-            }, $name, $guard)->status();
-        } catch (UnauthorizedException $e) {
-            return $e->getStatusCode();
-        }
     }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -9,10 +9,13 @@ use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Tests\TestModels\Admin;
+use Spatie\Permission\Tests\TestModels\User;
+use Spatie\Permission\Tests\TestModels\RuntimeRole;
 
 class RoleTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -10,8 +10,8 @@ use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Tests\TestModels\Admin;
-use Spatie\Permission\Tests\TestModels\User;
 use Spatie\Permission\Tests\TestModels\RuntimeRole;
+use Spatie\Permission\Tests\TestModels\User;
 
 class RoleTest extends TestCase
 {

--- a/tests/RoleWithNestingTest.php
+++ b/tests/RoleWithNestingTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
+
+use Spatie\Permission\Tests\TestModels\Role;
 
 class RoleWithNestingTest extends TestCase
 {
@@ -13,7 +15,7 @@ class RoleWithNestingTest extends TestCase
     /** @var Role[] */
     protected $child_roles = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
-
-use Illuminate\Http\Response;
+namespace Spatie\Permission\Tests;
 
 class RouteTest extends TestCase
 {
@@ -47,22 +45,5 @@ class RouteTest extends TestCase
             ],
             $this->getLastRouteMiddlewareFromRouter($router)
         );
-    }
-
-    protected function getLastRouteMiddlewareFromRouter($router)
-    {
-        return last($router->getRoutes()->get())->middleware();
-    }
-
-    protected function getRouter()
-    {
-        return app('router');
-    }
-
-    protected function getRouteResponse()
-    {
-        return function () {
-            return (new Response())->setContent('<html></html>');
-        };
     }
 }

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
+
+use Spatie\Permission\Tests\TestModels\User;
 
 class TeamHasPermissionsTest extends HasPermissionsTest
 {

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Tests\TestModels\User;
 
 class TeamHasRolesTest extends HasRolesTest
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\PermissionServiceProvider;
-use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Tests\TestModels\Admin;
 use Spatie\Permission\Tests\TestModels\User;
 
@@ -224,7 +224,6 @@ abstract class TestCase extends Orchestra
         });
     }
 
-
     ////// TEST HELPERS
     public function runMiddleware($middleware, $permission, $guard = null)
     {
@@ -238,9 +237,9 @@ abstract class TestCase extends Orchestra
     }
 
     public function getLastRouteMiddlewareFromRouter($router)
-     {
-         return last($router->getRoutes()->get())->middleware();
-     }
+    {
+        return last($router->getRoutes()->get())->middleware();
+    }
 
      public function getRouter()
      {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schema;
@@ -12,13 +13,16 @@ use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\PermissionServiceProvider;
+use Spatie\Permission\Exceptions\UnauthorizedException;
+use Spatie\Permission\Tests\TestModels\Admin;
+use Spatie\Permission\Tests\TestModels\User;
 
 abstract class TestCase extends Orchestra
 {
-    /** @var \Spatie\Permission\Test\User */
+    /** @var \Spatie\Permission\Tests\User */
     protected $testUser;
 
-    /** @var \Spatie\Permission\Test\Admin */
+    /** @var \Spatie\Permission\Tests\Admin */
     protected $testAdmin;
 
     /** @var \Spatie\Permission\Models\Role */
@@ -43,7 +47,7 @@ abstract class TestCase extends Orchestra
 
     protected static $customMigration;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -100,8 +104,8 @@ abstract class TestCase extends Orchestra
         $app['config']->set('auth.guards.admin', ['driver' => 'session', 'provider' => 'admins']);
         $app['config']->set('auth.providers.admins', ['driver' => 'eloquent', 'model' => Admin::class]);
         if ($this->useCustomModels) {
-            $app['config']->set('permission.models.permission', \Spatie\Permission\Test\Permission::class);
-            $app['config']->set('permission.models.role', \Spatie\Permission\Test\Role::class);
+            $app['config']->set('permission.models.permission', \Spatie\Permission\Tests\TestModels\Permission::class);
+            $app['config']->set('permission.models.role', \Spatie\Permission\Tests\TestModels\Role::class);
         }
         // Use test User model for users provider
         $app['config']->set('auth.providers.users.model', User::class);
@@ -219,4 +223,34 @@ abstract class TestCase extends Orchestra
             ];
         });
     }
+
+
+    ////// TEST HELPERS
+    public function runMiddleware($middleware, $permission, $guard = null)
+    {
+        try {
+            return $middleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
+            }, $permission, $guard)->status();
+        } catch (UnauthorizedException $e) {
+            return $e->getStatusCode();
+        }
+    }
+
+    public function getLastRouteMiddlewareFromRouter($router)
+     {
+         return last($router->getRoutes()->get())->middleware();
+     }
+
+     public function getRouter()
+     {
+         return app('router');
+     }
+
+     public function getRouteResponse()
+     {
+         return function () {
+             return (new Response())->setContent('<html></html>');
+         };
+     }
 }

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/tests/TestModels/Admin.php
+++ b/tests/TestModels/Admin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;

--- a/tests/TestModels/Manager.php
+++ b/tests/TestModels/Manager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Model implements AuthorizableContract, AuthenticatableContract
+class Manager extends Model implements AuthorizableContract, AuthenticatableContract
 {
     use HasRoles;
     use Authorizable;
@@ -20,4 +20,14 @@ class User extends Model implements AuthorizableContract, AuthenticatableContrac
     public $timestamps = false;
 
     protected $table = 'users';
+
+    // this function is added here to support the unit tests verifying it works
+    // When present, it takes precedence over the $guard_name property.
+    public function guardName()
+    {
+        return 'jwt';
+    }
+
+    // intentionally different property value for the sake of unit tests
+    protected $guard_name = 'web';
 }

--- a/tests/TestModels/Permission.php
+++ b/tests/TestModels/Permission.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 

--- a/tests/TestModels/Role.php
+++ b/tests/TestModels/Role.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 

--- a/tests/TestModels/RuntimeRole.php
+++ b/tests/TestModels/RuntimeRole.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 class RuntimeRole extends \Spatie\Permission\Models\Role
 {

--- a/tests/TestModels/SoftDeletingUser.php
+++ b/tests/TestModels/SoftDeletingUser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
 

--- a/tests/TestModels/User.php
+++ b/tests/TestModels/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Spatie\Permission\Traits\HasRoles;
 
-class Manager extends Model implements AuthorizableContract, AuthenticatableContract
+class User extends Model implements AuthorizableContract, AuthenticatableContract
 {
     use HasRoles;
     use Authorizable;
@@ -20,14 +20,4 @@ class Manager extends Model implements AuthorizableContract, AuthenticatableCont
     public $timestamps = false;
 
     protected $table = 'users';
-
-    // this function is added here to support the unit tests verifying it works
-    // When present, it takes precedence over the $guard_name property.
-    public function guardName()
-    {
-        return 'jwt';
-    }
-
-    // intentionally different property value for the sake of unit tests
-    protected $guard_name = 'web';
 }

--- a/tests/TestModels/WildcardPermission.php
+++ b/tests/TestModels/WildcardPermission.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests\TestModels;
 
 use Spatie\Permission\WildcardPermission as BaseWildcardPermission;
 

--- a/tests/WildcardHasPermissionsTest.php
+++ b/tests/WildcardHasPermissionsTest.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
 use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
 use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Tests\TestModels\User;
+use Spatie\Permission\Tests\TestModels\WildcardPermission;
 
 class WildcardHasPermissionsTest extends TestCase
 {

--- a/tests/WildcardMiddlewareTest.php
+++ b/tests/WildcardMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -19,7 +19,7 @@ class WildcardMiddlewareTest extends TestCase
 
     protected $roleOrPermissionMiddleware;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -154,16 +154,5 @@ class WildcardMiddlewareTest extends TestCase
         }
 
         $this->assertEquals(['permission.some'], $requiredPermissions);
-    }
-
-    protected function runMiddleware($middleware, $parameter)
-    {
-        try {
-            return $middleware->handle(new Request(), function () {
-                return (new Response())->setContent('<html></html>');
-            }, $parameter)->status();
-        } catch (UnauthorizedException $e) {
-            return $e->getStatusCode();
-        }
     }
 }

--- a/tests/WildcardRoleTest.php
+++ b/tests/WildcardRoleTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Spatie\Permission\Test;
+namespace Spatie\Permission\Tests;
 
 use Spatie\Permission\Models\Permission;
 
 class WildcardRoleTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/WildcardRouteTest.php
+++ b/tests/WildcardRouteTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Spatie\Permission\Test;
-
-use Illuminate\Http\Response;
+namespace Spatie\Permission\Tests;
 
 class WildcardRouteTest extends TestCase
 {
@@ -39,22 +37,5 @@ class WildcardRouteTest extends TestCase
             ],
             $this->getLastRouteMiddlewareFromRouter($router)
         );
-    }
-
-    protected function getLastRouteMiddlewareFromRouter($router)
-    {
-        return last($router->getRoutes()->get())->middleware();
-    }
-
-    protected function getRouter()
-    {
-        return app('router');
-    }
-
-    protected function getRouteResponse()
-    {
-        return function () {
-            return (new Response())->setContent('<html></html>');
-        };
     }
 }


### PR DESCRIPTION
- update namespace from `Test` to `Tests`
- namespace models into `Tests\TestModels`
- update PHPUnit setUp() fixture (protected, not public)
- consolidated middleware testing helpers

Thanks to @AyoobMH  - ref PR #2240