### PR TITLE
[v6] fix BadMethodCallException: undefined methods hasAnyRole, hasAnyPermissions

### DIFF
--- a/src/Exceptions/UnauthorizedException.php
+++ b/src/Exceptions/UnauthorizedException.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Exceptions;
 
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class UnauthorizedException extends HttpException
@@ -50,6 +51,13 @@ class UnauthorizedException extends HttpException
         $exception->requiredPermissions = $rolesOrPermissions;
 
         return $exception;
+    }
+
+    public static function missingTraitHasRoles(Authorizable $user): self
+    {
+        $class = get_class($user);
+
+        return new static(403, "Authorizable class `{$class}` must use Spatie\Permission\Traits\HasRoles trait.", null, []);
     }
 
     public static function notLoggedIn(): self

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -16,11 +16,17 @@ class RoleMiddleware
             throw UnauthorizedException::notLoggedIn();
         }
 
+        $user = $authGuard->user();
+
+        if (! method_exists($user, 'hasAnyRole')) {
+            throw UnauthorizedException::missingTraitHasRoles($user);
+        }
+
         $roles = is_array($role)
             ? $role
             : explode('|', $role);
 
-        if (! $authGuard->user()->hasAnyRole($roles)) {
+        if (! $user->hasAnyRole($roles) && ! $user->can('')) {
             throw UnauthorizedException::forRoles($roles);
         }
 

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -15,11 +15,17 @@ class RoleOrPermissionMiddleware
             throw UnauthorizedException::notLoggedIn();
         }
 
+        $user = $authGuard->user();
+
+        if (! method_exists($user, 'hasAnyRole') || ! method_exists($user, 'hasAnyPermission')) {
+            throw UnauthorizedException::missingTraitHasRoles($user);
+        }
+
         $rolesOrPermissions = is_array($roleOrPermission)
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        if (! $authGuard->user()->hasAnyRole($rolesOrPermissions) && ! $authGuard->user()->hasAnyPermission($rolesOrPermissions)) {
+        if (! $user->canAny($rolesOrPermissions) && ! $user->hasAnyRole($rolesOrPermissions)) {
             throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -6,10 +6,12 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middlewares\PermissionMiddleware;
+use Spatie\Permission\Tests\TestModels\UserWithoutHasRoles;
 
 class PermissionMiddlewareTest extends TestCase
 {
@@ -70,6 +72,21 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    public function a_super_admin_user_can_access_a_route_protected_by_permission_middleware()
+    {
+        Auth::login($this->testUser);
+
+        Gate::before(function ($user, $ability) {
+            return $user->getKey() ===  $this->testUser->getKey() ? true : null;
+        });
+
+        $this->assertEquals(
+            200,
+            $this->runMiddleware($this->permissionMiddleware, 'edit-articles')
+        );
+    }
+
+    /** @test */
     public function a_user_can_access_a_route_protected_by_permission_middleware_if_have_this_permission()
     {
         Auth::login($this->testUser);
@@ -97,6 +114,19 @@ class PermissionMiddlewareTest extends TestCase
         $this->assertEquals(
             200,
             $this->runMiddleware($this->permissionMiddleware, ['edit-news', 'edit-articles'])
+        );
+    }
+
+    /** @test */
+    public function a_user_cannot_access_a_route_protected_by_the_permission_middleware_if_have_not_has_roles_trait()
+    {
+        $userWithoutHasRoles = UserWithoutHasRoles::create(['email' => 'test_not_has_roles@user.com']);
+
+        Auth::login($userWithoutHasRoles);
+
+        $this->assertEquals(
+            403,
+            $this->runMiddleware($this->permissionMiddleware, 'edit-news')
         );
     }
 

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -6,9 +6,11 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middlewares\RoleMiddleware;
+use Spatie\Permission\Tests\TestModels\UserWithoutHasRoles;
 
 class RoleMiddlewareTest extends TestCase
 {
@@ -71,6 +73,19 @@ class RoleMiddlewareTest extends TestCase
         $this->assertEquals(
             200,
             $this->runMiddleware($this->roleMiddleware, ['testRole2', 'testRole'])
+        );
+    }
+
+    /** @test */
+    public function a_user_cannot_access_a_route_protected_by_the_role_middleware_if_have_not_has_roles_trait()
+    {
+        $userWithoutHasRoles = UserWithoutHasRoles::create(['email' => 'test_not_has_roles@user.com']);
+
+        Auth::login($userWithoutHasRoles);
+
+        $this->assertEquals(
+            403,
+            $this->runMiddleware($this->roleMiddleware, 'testRole')
         );
     }
 

--- a/tests/TestModels/UserWithoutHasRoles.php
+++ b/tests/TestModels/UserWithoutHasRoles.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels;
+
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\Access\Authorizable;
+
+class UserWithoutHasRoles extends Model implements AuthorizableContract, AuthenticatableContract
+{
+    use Authorizable;
+    use Authenticatable;
+
+    protected $fillable = ['email'];
+
+    public $timestamps = false;
+
+    protected $table = 'users';
+}


### PR DESCRIPTION
when we use middlewares and user model not has `HasRoles` trait we get a BadMethodCallException instead of 403
I don't know if this is expected behavior, but larastan points this out.