### PR TITLE
[V6] Register OctaneReloadPermissions listener for Laravel Octane

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -104,6 +104,13 @@ return [
     'register_permission_check_method' => true,
 
     /*
+     * When set to true, the Spatie\Permission\Listeners\OctaneReloadPermissions listener will be registered
+     * on the Laravel\Octane\Events\OperationTerminated event, this will refresh permissions on every
+     * TickTerminated, TaskTerminated and RequestTerminated
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
      * When set to true the package implements teams using the 'team_foreign_key'. If you want
      * the migrations to register the 'team_foreign_key', you must set this to true
      * before doing the migration. If you already did the migration then you must make a new

--- a/config/permission.php
+++ b/config/permission.php
@@ -107,6 +107,7 @@ return [
      * When set to true, the Spatie\Permission\Listeners\OctaneReloadPermissions listener will be registered
      * on the Laravel\Octane\Events\OperationTerminated event, this will refresh permissions on every
      * TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
      */
     'register_octane_reset_listener' => false,
 

--- a/src/Listeners/OctaneReloadPermissions.php
+++ b/src/Listeners/OctaneReloadPermissions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Listeners;
+
+use Spatie\Permission\PermissionRegistrar;
+
+class OctaneReloadPermissions
+{
+    public function handle($event): void
+    {
+        $event->sandbox->make(PermissionRegistrar::class)->clearPermissionsCollection();
+    }
+}


### PR DESCRIPTION
i'm not 100% sure on this 
i can't test octane 

this was a test for octane users to try but no one gave me feedback that it works

On https://github.com/spatie/laravel-permission/issues/2322#issuecomment-1493242776 was said that the problem was the **spatie/once** package, and that **spatie/laravel-permission** works correctly on octane

**I recommend not merging it until you do more testing that it's the correct approach.**