### PR TITLE
code reformatting

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -81,10 +81,8 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerModelBindings()
     {
-        $this->app->bind(PermissionContract::class, fn ($app) => $app->make($app->config['permission.models.permission'])
-        );
-        $this->app->bind(RoleContract::class, fn ($app) => $app->make($app->config['permission.models.role'])
-        );
+        $this->app->bind(PermissionContract::class, fn ($app) => $app->make($app->config['permission.models.permission']));
+        $this->app->bind(RoleContract::class, fn ($app) => $app->make($app->config['permission.models.role']));
     }
 
     public static function bladeMethodWrapper($method, $role, $guard = null)

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -82,7 +82,7 @@ trait HasRoles
                 return $role;
             }
 
-            $method = is_numeric($role) || PermissionRegistrar::isUid($role) ? 'findById' : 'findByName';
+            $method = is_int($role) || PermissionRegistrar::isUid($role) ? 'findById' : 'findByName';
 
             return $this->getRoleClass()::{$method}($role, $guard ?: $this->getDefaultGuardName());
         }, Arr::wrap($roles));
@@ -209,19 +209,19 @@ trait HasRoles
             $roles = $roles->value;
         }
 
-        if (is_string($roles) && ! PermissionRegistrar::isUid($roles)) {
-            return $guard
-                ? $this->roles->where('guard_name', $guard)->contains('name', $roles)
-                : $this->roles->contains('name', $roles);
-        }
-
-        if (is_int($roles) || is_string($roles)) {
+        if (is_int($roles) || PermissionRegistrar::isUid($roles)) {
             $roleClass = $this->getRoleClass();
             $key = (new $roleClass())->getKeyName();
 
             return $guard
                 ? $this->roles->where('guard_name', $guard)->contains($key, $roles)
                 : $this->roles->contains($key, $roles);
+        }
+
+        if (is_string($roles)) {
+            return $guard
+                ? $this->roles->where('guard_name', $guard)->contains('name', $roles)
+                : $this->roles->contains('name', $roles);
         }
 
         if ($roles instanceof Role) {
@@ -347,7 +347,7 @@ trait HasRoles
             $role = $role->value;
         }
 
-        if (is_numeric($role) || PermissionRegistrar::isUid($role)) {
+        if (is_int($role) || PermissionRegistrar::isUid($role)) {
             return $this->getRoleClass()::findById($role, $this->getDefaultGuardName());
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,8 +7,8 @@ if (! function_exists('getModelForGuard')) {
     function getModelForGuard(string $guard)
     {
         return collect(config('auth.guards'))
-            ->map(fn ($guard) => isset($guard['provider']) ? config("auth.providers.{$guard['provider']}.model") : null
-            )->get($guard);
+            ->map(fn ($guard) => isset($guard['provider']) ? config("auth.providers.{$guard['provider']}.model") : null)
+            ->get($guard);
     }
 }
 


### PR DESCRIPTION
Php 7.4 sintax 
Support id/uuid on enums, for consistency with the rest
use is_int instead of is_numeric, ids must be int
https://github.com/spatie/laravel-permission/blob/38f20496e0cf15f1129fc88a2598d6c10024f38c/src/Traits/HasPermissions.php#L169
https://github.com/spatie/laravel-permission/blob/38f20496e0cf15f1129fc88a2598d6c10024f38c/src/Traits/HasPermissions.php#L212
https://github.com/spatie/laravel-permission/blob/38f20496e0cf15f1129fc88a2598d6c10024f38c/src/Traits/HasRoles.php#L218