### PR TITLE
Improve Performance of Loading Relationships

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -391,7 +391,7 @@ trait HasPermissions
 
         if ($model->exists) {
             $this->permissions()->sync($permissions, false);
-            $model->load('permissions');
+            $model->loadMissing('permissions');
         } else {
             $class = \get_class($model);
 
@@ -401,7 +401,7 @@ trait HasPermissions
                         return;
                     }
                     $model->permissions()->sync($permissions, false);
-                    $model->load('permissions');
+                    $model->loadMissing('permissions');
                 }
             );
         }
@@ -442,7 +442,7 @@ trait HasPermissions
             $this->forgetCachedPermissions();
         }
 
-        $this->load('permissions');
+        $this->loadMissing('permissions');
 
         return $this;
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -137,7 +137,7 @@ trait HasRoles
 
         if ($model->exists) {
             $this->roles()->sync($roles, false);
-            $model->load('roles');
+            $model->loadMissing('roles');
         } else {
             $class = \get_class($model);
 
@@ -147,7 +147,7 @@ trait HasRoles
                         return;
                     }
                     $model->roles()->sync($roles, false);
-                    $model->load('roles');
+                    $model->loadMissing('roles');
                 }
             );
         }
@@ -168,7 +168,7 @@ trait HasRoles
     {
         $this->roles()->detach($this->getStoredRole($role));
 
-        $this->load('roles');
+        $this->loadMissing('roles');
 
         if (is_a($this, Permission::class)) {
             $this->forgetCachedPermissions();

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -13,15 +13,15 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     public function it_can_assign_same_and_different_permission_on_same_user_on_different_teams()
     {
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->testUser->givePermissionTo('edit-articles', 'edit-news');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->testUser->givePermissionTo('edit-articles', 'edit-blog');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->assertEquals(
             collect(['edit-articles', 'edit-news']),
             $this->testUser->getPermissionNames()->sort()->values()
@@ -30,7 +30,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         $this->assertFalse($this->testUser->hasAllDirectPermissions(['edit-articles', 'edit-blog']));
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->assertEquals(
             collect(['edit-articles', 'edit-blog']),
             $this->testUser->getPermissionNames()->sort()->values()
@@ -45,18 +45,18 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         $this->testUserRole->givePermissionTo('edit-articles');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->testUser->assignRole('testRole');
         $this->testUser->givePermissionTo('edit-news');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->testUser->assignRole('testRole');
         $this->testUser->givePermissionTo('edit-blog');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('roles');
+        $this->testUser->loadMissing('permissions');
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-news']),
@@ -64,8 +64,8 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         );
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('roles');
+        $this->testUser->loadMissing('permissions');
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-blog']),
@@ -77,15 +77,15 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     public function it_can_sync_or_remove_permission_without_detach_on_different_teams()
     {
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->testUser->syncPermissions('edit-articles', 'edit-news');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->testUser->syncPermissions('edit-articles', 'edit-blog');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-news']),
@@ -99,7 +99,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         );
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
+        $this->testUser->loadMissing('permissions');
         $this->assertEquals(
             collect(['edit-articles', 'edit-blog']),
             $this->testUser->getPermissionNames()->sort()->values()

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -50,15 +50,15 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertNotNull($testRole4NoTeam);
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
         $this->testUser->assignRole('testRole', 'testRole2');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
         $this->testUser->assignRole('testRole', 'testRole3');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
 
         $this->assertEquals(
             collect(['testRole', 'testRole2']),
@@ -72,7 +72,7 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertTrue($this->testUser->hasRole($testRole4NoTeam)); // global role team=null
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
 
         $this->assertEquals(
             collect(['testRole', 'testRole3']),
@@ -91,15 +91,15 @@ class TeamHasRolesTest extends HasRolesTest
         app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
         $this->testUser->syncRoles('testRole', 'testRole2');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
         $this->testUser->syncRoles('testRole', 'testRole3');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
+        $this->testUser->loadMissing('roles');
 
         $this->assertEquals(
             collect(['testRole', 'testRole2']),


### PR DESCRIPTION
If a model is already loaded, there shouldn't be any forcing of reloading a relationship through the `load()` method. Using Laravel's `loadMissing()` method, it will only load if it hasn't already been eager-loaded.

Won't interrupt anyone who doesn't eager load this already, and will improve performance of people who eager load permissions & roles on their model.