### PR TITLE
Fix call to an undefined method Role::getRoleClass

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			# PHPStan can't understand what's going on in context of Role class using Builder `when`
-			message: "#^Call to an undefined method Spatie\\\\Permission\\\\Models\\\\Role::getRoleClass\\(\\).$#"
-			count: 1
-			path: src\Traits\HasPermissions.php

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -101,7 +101,7 @@ trait HasPermissions
 
         $permissionClass = $this->getPermissionClass();
         $permissionKey = (new $permissionClass())->getKeyName();
-        $roleClass = $this->getRoleClass();
+        $roleClass = is_a($this, Role::class) ? static::class : $this->getRoleClass();
         $roleKey = (new $roleClass())->getKeyName();
 
         $rolesWithPermissions = is_a($this, Role::class) ? [] : array_unique(


### PR DESCRIPTION
```batch
./vendor/bin/phpstan analyse
Note: Using configuration file laravel-permission/phpstan.neon.dist.
 33/33 [============================] 100%

 ------ -----------------------------------------------------------------------------------
  Line   src\Traits\HasPermissions.php (in context of class Spatie\Permission\Models\Role)
 ------ -----------------------------------------------------------------------------------
  104    Call to an undefined method Spatie\Permission\Models\Role::getRoleClass().
 ------ -----------------------------------------------------------------------------------

 [ERROR] Found 1 error
```
