### PR TITLE
Remove force loading model relationships

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -391,7 +391,7 @@ trait HasPermissions
 
         if ($model->exists) {
             $this->permissions()->sync($permissions, false);
-            $model->load('permissions');
+            $model->unsetRelation('permissions');
         } else {
             $class = \get_class($model);
 
@@ -401,7 +401,7 @@ trait HasPermissions
                         return;
                     }
                     $model->permissions()->sync($permissions, false);
-                    $model->load('permissions');
+                    $model->unsetRelation('permissions');
                 }
             );
         }
@@ -442,7 +442,7 @@ trait HasPermissions
             $this->forgetCachedPermissions();
         }
 
-        $this->load('permissions');
+        $this->unsetRelation('permissions');
 
         return $this;
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -137,7 +137,7 @@ trait HasRoles
 
         if ($model->exists) {
             $this->roles()->sync($roles, false);
-            $model->load('roles');
+            $model->unsetRelation('roles');
         } else {
             $class = \get_class($model);
 
@@ -147,7 +147,7 @@ trait HasRoles
                         return;
                     }
                     $model->roles()->sync($roles, false);
-                    $model->load('roles');
+                    $model->unsetRelation('roles');
                 }
             );
         }
@@ -168,7 +168,7 @@ trait HasRoles
     {
         $this->roles()->detach($this->getStoredRole($role));
 
-        $this->load('roles');
+        $this->unsetRelation('roles');
 
         if (is_a($this, Permission::class)) {
             $this->forgetCachedPermissions();

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -18,8 +18,6 @@ class CacheTest extends TestCase
 
     protected $cache_run_count = 2; // roles lookup, permissions lookup
 
-    protected $cache_relations_count = 1;
-
     protected $registrar;
 
     protected function setUp(): void
@@ -199,10 +197,11 @@ class CacheTest extends TestCase
     {
         $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news', 'Edit News']);
         $this->testUser->assignRole('testRole');
+        $this->testUser->loadMissing('roles', 'permissions'); // load relations
 
         $this->resetQueryCount();
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles'));
-        $this->assertQueryCount($this->cache_init_count + $this->cache_load_count + $this->cache_run_count + $this->cache_relations_count);
+        $this->assertQueryCount($this->cache_init_count + $this->cache_load_count + $this->cache_run_count);
 
         $this->resetQueryCount();
         $this->assertTrue($this->testUser->hasPermissionTo('edit-news'));
@@ -224,10 +223,11 @@ class CacheTest extends TestCase
 
         $this->testUserRole->givePermissionTo(['edit-articles', 'web']);
         $this->testUser->assignRole('testRole');
+        $this->testUser->loadMissing('roles', 'permissions'); // load relations
 
         $this->resetQueryCount();
         $this->assertTrue($this->testUser->hasPermissionTo('edit-articles', 'web'));
-        $this->assertQueryCount($this->cache_init_count + $this->cache_load_count + $this->cache_run_count + $this->cache_relations_count);
+        $this->assertQueryCount($this->cache_init_count + $this->cache_load_count + $this->cache_run_count);
 
         $this->resetQueryCount();
         $this->assertFalse($this->testUser->hasPermissionTo('edit-articles', 'admin'));
@@ -239,6 +239,7 @@ class CacheTest extends TestCase
     {
         $this->testUserRole->givePermissionTo($expected = ['edit-articles', 'edit-news']);
         $this->testUser->assignRole('testRole');
+        $this->testUser->loadMissing('roles.permissions', 'permissions'); // load relations
 
         $this->resetQueryCount();
         $this->registrar->getPermissions();
@@ -248,7 +249,7 @@ class CacheTest extends TestCase
         $actual = $this->testUser->getAllPermissions()->pluck('name')->sort()->values();
         $this->assertEquals($actual, collect($expected));
 
-        $this->assertQueryCount(2);
+        $this->assertQueryCount(0);
     }
 
     /** @test */

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -591,7 +591,7 @@ class HasPermissionsTest extends TestCase
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
-        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
+        $this->assertSame(3, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */
@@ -613,7 +613,7 @@ class HasPermissionsTest extends TestCase
 
         $this->assertTrue($user2->fresh()->hasPermissionTo('edit-articles'));
         $this->assertFalse($user2->fresh()->hasPermissionTo('edit-news'));
-        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
+        $this->assertSame(3, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -303,7 +303,7 @@ class HasRolesTest extends TestCase
 
         $this->assertTrue($user2->fresh()->hasRole('testRole2'));
         $this->assertFalse($user2->fresh()->hasRole('testRole'));
-        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
+        $this->assertSame(3, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */
@@ -325,7 +325,7 @@ class HasRolesTest extends TestCase
 
         $this->assertTrue($admin_user->fresh()->hasRole('testRole2'));
         $this->assertFalse($admin_user->fresh()->hasRole('testRole'));
-        $this->assertSame(4, count(DB::getQueryLog())); //avoid unnecessary sync
+        $this->assertSame(3, count(DB::getQueryLog())); //avoid unnecessary sync
     }
 
     /** @test */

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -13,11 +13,9 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     public function it_can_assign_same_and_different_permission_on_same_user_on_different_teams()
     {
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
         $this->testUser->givePermissionTo('edit-articles', 'edit-news');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
         $this->testUser->givePermissionTo('edit-articles', 'edit-blog');
 
         setPermissionsTeamId(1);
@@ -45,18 +43,15 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         $this->testUserRole->givePermissionTo('edit-articles');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
         $this->testUser->assignRole('testRole');
         $this->testUser->givePermissionTo('edit-news');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
         $this->testUser->assignRole('testRole');
         $this->testUser->givePermissionTo('edit-blog');
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
-        $this->testUser->load('permissions');
+        $this->testUser->load('roles', 'permissions');
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-news']),
@@ -64,8 +59,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
         );
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
-        $this->testUser->load('permissions');
+        $this->testUser->load('roles', 'permissions');
 
         $this->assertEquals(
             collect(['edit-articles', 'edit-blog']),
@@ -77,11 +71,9 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     public function it_can_sync_or_remove_permission_without_detach_on_different_teams()
     {
         setPermissionsTeamId(1);
-        $this->testUser->load('permissions');
         $this->testUser->syncPermissions('edit-articles', 'edit-news');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('permissions');
         $this->testUser->syncPermissions('edit-articles', 'edit-blog');
 
         setPermissionsTeamId(1);

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -50,11 +50,9 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertNotNull($testRole4NoTeam);
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
         $this->testUser->assignRole('testRole', 'testRole2');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
         $this->testUser->assignRole('testRole', 'testRole3');
 
         setPermissionsTeamId(1);
@@ -91,11 +89,9 @@ class TeamHasRolesTest extends HasRolesTest
         app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
 
         setPermissionsTeamId(1);
-        $this->testUser->load('roles');
         $this->testUser->syncRoles('testRole', 'testRole2');
 
         setPermissionsTeamId(2);
-        $this->testUser->load('roles');
         $this->testUser->syncRoles('testRole', 'testRole3');
 
         setPermissionsTeamId(1);


### PR DESCRIPTION
Alternative to #2410

In some scenarios it is not necessary to load the relationships, and they are loaded later when they are required, this would allow less sqls to be executed in the mentioned scenarios
**Example:** batch user creation and assignment