### PR TITLE
[V6] fewer sqls in syncRoles, syncPermissions

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -391,7 +391,7 @@ trait HasPermissions
             [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
         if ($model->exists) {
-            $currentPermissions = $this->permissions()->get()->map(fn ($permission) => $permission->getKey())->toArray();
+            $currentPermissions = $this->permissions->map(fn ($permission) => $permission->getKey())->toArray();
 
             $this->permissions()->attach(array_diff($permissions, $currentPermissions), $teamPivot);
             $model->unsetRelation('permissions');
@@ -424,9 +424,11 @@ trait HasPermissions
      */
     public function syncPermissions(...$permissions)
     {
-        $this->collectPermissions($permissions);
-
-        $this->permissions()->detach();
+        if ($this->getModel()->exists) {
+            $this->collectPermissions($permissions);
+            $this->permissions()->detach();
+            $this->setRelation('permissions', collect());
+        }
 
         return $this->givePermissionTo($permissions);
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -137,7 +137,7 @@ trait HasRoles
             [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
         if ($model->exists) {
-            $currentRoles = $this->roles()->get()->map(fn ($role) => $role->getKey())->toArray();
+            $currentRoles = $this->roles->map(fn ($role) => $role->getKey())->toArray();
 
             $this->roles()->attach(array_diff($roles, $currentRoles), $teamPivot);
             $model->unsetRelation('roles');
@@ -188,9 +188,11 @@ trait HasRoles
      */
     public function syncRoles(...$roles)
     {
-        $this->collectRoles($roles);
-
-        $this->roles()->detach();
+        if ($this->getModel()->exists) {
+            $this->collectRoles($roles);
+            $this->roles()->detach();
+            $this->setRelation('roles', collect());
+        }
 
         return $this->assignRole($roles);
     }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -581,7 +581,7 @@ class HasPermissionsTest extends TestCase
         $this->testUser->syncPermissions($this->testUserPermission, $permission2);
         DB::disableQueryLog();
 
-        $this->assertSame(3, count(DB::getQueryLog())); //avoid unnecessary sqls
+        $this->assertSame(2, count(DB::getQueryLog())); //avoid unnecessary sqls
     }
 
     /** @test */

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -282,6 +282,10 @@ class HasRolesTest extends TestCase
         $user->save();
 
         $this->assertTrue($user->hasRole($this->testUserRole));
+
+        $user->syncRoles([$this->testUserRole]);
+        $this->assertTrue($user->hasRole($this->testUserRole));
+        $this->assertTrue($user->fresh()->hasRole($this->testUserRole));
     }
 
     /** @test */
@@ -293,7 +297,7 @@ class HasRolesTest extends TestCase
         $this->testUser->syncRoles($this->testUserRole, $role2);
         DB::disableQueryLog();
 
-        $this->assertSame(3, count(DB::getQueryLog())); //avoid unnecessary sqls
+        $this->assertSame(2, count(DB::getQueryLog())); //avoid unnecessary sqls
     }
 
     /** @test */


### PR DESCRIPTION
This avoid `detach` when model does'nt exists, and it set an empty collection on relation for prevent reload relation from sql
this results in fewer sql calls on sync