### PR TITLE
Add middleware using static method

### DIFF
--- a/docs/basic-usage/middleware.md
+++ b/docs/basic-usage/middleware.md
@@ -13,9 +13,18 @@ Route::group(['middleware' => ['can:publish articles']], function () {
 });
 ```
 
+In Laravel v10.9 and up, you can also call this middleware with a static method.
+
+```php
+Route::group(['middleware' => [\Illuminate\Auth\Middleware\Authorize::using('publish articles')]], function () {
+    //
+});
+```
+
 ## Package Middleware
 
-This package comes with `RoleMiddleware`, `PermissionMiddleware` and `RoleOrPermissionMiddleware` middleware. You can add them inside your `app/Http/Kernel.php` file.
+This package comes with `RoleMiddleware`, `PermissionMiddleware` and `RoleOrPermissionMiddleware` middleware.
+You can add them inside your `app/Http/Kernel.php` file to be able to use them through aliases.
 
 Note the property name difference between Laravel 10 and older versions of Laravel:
 
@@ -88,3 +97,22 @@ public function __construct()
 ```
 
 (You can use Laravel's Model Policy feature with your controller methods. See the Model Policies section of these docs.)
+
+## Use middleware static methods
+
+All of the middlewares can also be applied by calling the static `using` method,
+which accepts either a `|`-separated string or an array as input.
+
+```php
+Route::group(['middleware' => [\Spatie\Permission\Middlewares\RoleMiddleware::using('super-admin')]], function () {
+    //
+});
+
+Route::group(['middleware' => [\Spatie\Permission\Middlewares\PermissionMiddleware::using('publish articles|edit articles')]], function () {
+    //
+});
+
+Route::group(['middleware' => [\Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::using(['super-admin', 'edit articles'])]], function () {
+    //
+});
+```

--- a/src/Middlewares/PermissionMiddleware.php
+++ b/src/Middlewares/PermissionMiddleware.php
@@ -32,4 +32,19 @@ class PermissionMiddleware
 
         return $next($request);
     }
+
+    /**
+     * Specify the permission and guard for the middleware.
+     *
+     * @param  array|string  $permission
+     * @param  string|null  $guard
+     * @return string
+     */
+    public static function using($permission, $guard = null)
+    {
+        $permissionString = is_string($permission) ? $permission : implode('|', $permission);
+        $args = is_null($guard) ? $permissionString : "$permissionString,$guard";
+
+        return static::class.':'.$args;
+    }
 }

--- a/src/Middlewares/RoleMiddleware.php
+++ b/src/Middlewares/RoleMiddleware.php
@@ -32,4 +32,19 @@ class RoleMiddleware
 
         return $next($request);
     }
+
+    /**
+     * Specify the role and guard for the middleware.
+     *
+     * @param  array|string  $role
+     * @param  string|null  $guard
+     * @return string
+     */
+    public static function using($role, $guard = null)
+    {
+        $roleString = is_string($role) ? $role : implode('|', $role);
+        $args = is_null($guard) ? $roleString : "$roleString,$guard";
+
+        return static::class.':'.$args;
+    }
 }

--- a/src/Middlewares/RoleOrPermissionMiddleware.php
+++ b/src/Middlewares/RoleOrPermissionMiddleware.php
@@ -31,4 +31,19 @@ class RoleOrPermissionMiddleware
 
         return $next($request);
     }
+
+    /**
+     * Specify the role or permission and guard for the middleware.
+     *
+     * @param  array|string  $roleOrPermission
+     * @param  string|null  $guard
+     * @return string
+     */
+    public static function using($roleOrPermission, $guard = null)
+    {
+        $roleOrPermissionString = is_string($roleOrPermission) ? $roleOrPermission : implode('|', $roleOrPermission);
+        $args = is_null($guard) ? $roleOrPermissionString : "$roleOrPermissionString,$guard";
+
+        return static::class.':'.$args;
+    }
 }

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -254,4 +254,21 @@ class PermissionMiddlewareTest extends TestCase
             $this->runMiddleware($this->permissionMiddleware, 'admin-permission', 'admin')
         );
     }
+
+    /** @test */
+    public function the_middleware_can_be_created_with_static_using_method()
+    {
+        $this->assertSame(
+            'Spatie\Permission\Middlewares\PermissionMiddleware:edit-articles',
+            PermissionMiddleware::using('edit-articles')
+        );
+        $this->assertEquals(
+            'Spatie\Permission\Middlewares\PermissionMiddleware:edit-articles,my-guard',
+            PermissionMiddleware::using('edit-articles', 'my-guard')
+        );
+        $this->assertEquals(
+            'Spatie\Permission\Middlewares\PermissionMiddleware:edit-articles|edit-news',
+            PermissionMiddleware::using(['edit-articles', 'edit-news'])
+        );
+    }
 }

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -204,4 +204,21 @@ class RoleMiddlewareTest extends TestCase
             $this->runMiddleware($this->roleMiddleware, 'testAdminRole', 'admin')
         );
     }
+
+    /** @test */
+    public function the_middleware_can_be_created_with_static_using_method()
+    {
+        $this->assertSame(
+            'Spatie\Permission\Middlewares\RoleMiddleware:testAdminRole',
+            RoleMiddleware::using('testAdminRole')
+        );
+        $this->assertEquals(
+            'Spatie\Permission\Middlewares\RoleMiddleware:testAdminRole,my-guard',
+            RoleMiddleware::using('testAdminRole', 'my-guard')
+        );
+        $this->assertEquals(
+            'Spatie\Permission\Middlewares\RoleMiddleware:testAdminRole|anotherRole',
+            RoleMiddleware::using(['testAdminRole', 'anotherRole'])
+        );
+    }
 }

--- a/tests/RoleOrPermissionMiddlewareTest.php
+++ b/tests/RoleOrPermissionMiddlewareTest.php
@@ -194,4 +194,21 @@ class RoleOrPermissionMiddlewareTest extends TestCase
 
         $this->assertStringEndsWith('Necessary roles or permissions are some-permission, some-role', $message);
     }
+
+    /** @test */
+    public function the_middleware_can_be_created_with_static_using_method()
+    {
+        $this->assertSame(
+            'Spatie\Permission\Middlewares\RoleOrPermissionMiddleware:edit-articles',
+            RoleOrPermissionMiddleware::using('edit-articles')
+        );
+        $this->assertEquals(
+            'Spatie\Permission\Middlewares\RoleOrPermissionMiddleware:edit-articles,my-guard',
+            RoleOrPermissionMiddleware::using('edit-articles', 'my-guard')
+        );
+        $this->assertEquals(
+            'Spatie\Permission\Middlewares\RoleOrPermissionMiddleware:edit-articles|testAdminRole',
+            RoleOrPermissionMiddleware::using(['edit-articles', 'testAdminRole'])
+        );
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -243,15 +243,15 @@ abstract class TestCase extends Orchestra
         return last($router->getRoutes()->get())->middleware();
     }
 
-     public function getRouter()
-     {
-         return app('router');
-     }
+    public function getRouter()
+    {
+        return app('router');
+    }
 
-     public function getRouteResponse()
-     {
-         return function () {
-             return (new Response())->setContent('<html></html>');
-         };
-     }
+    public function getRouteResponse()
+    {
+        return function () {
+            return (new Response())->setContent('<html></html>');
+        };
+    }
 }


### PR DESCRIPTION
Inspired by the addition of static `using` methods in the Laravel framework itself that allow creating middlewares with arguments in a static way (see https://github.com/laravel/framework/pull/46362), this PR aims to add similar behavior to the middlewares in this package.

This allows a new syntax for adding the middlewares to routes and/or controllers, e.g. instead of `'permission:edit-articles|edit-news'`, one can now write `PermissionMiddleware::using('edit-articles|edit-news')` or even `PermissionMiddleware::using(['edit-articles', 'edit-news'])`.