### PR TITLE
Add description to table roles and permissions

### DIFF
--- a/database/migrations/create_permission_tables.php.stub
+++ b/database/migrations/create_permission_tables.php.stub
@@ -28,6 +28,7 @@ return new class extends Migration
             $table->bigIncrements('id'); // permission id
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
+            $table->string('description')->nullable(); // For MySQL 8.0 use string('description', 125);
             $table->timestamps();
 
             $table->unique(['name', 'guard_name']);
@@ -41,6 +42,7 @@ return new class extends Migration
             }
             $table->string('name');       // For MySQL 8.0 use string('name', 125);
             $table->string('guard_name'); // For MySQL 8.0 use string('guard_name', 125);
+            $table->string('description')->nullable(); // For MySQL 8.0 use string('description', 125);
             $table->timestamps();
             if ($teams || config('permission.testing')) {
                 $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);


### PR DESCRIPTION
Add description to the roles and permissions table, so that we know what the roles and permission is about in detail.