### PR TITLE
fix: Wildcard permissions algorithm performance

### DIFF
--- a/src/Contracts/Wildcard.php
+++ b/src/Contracts/Wildcard.php
@@ -2,10 +2,13 @@
 
 namespace Spatie\Permission\Contracts;
 
+use Illuminate\Database\Eloquent\Model;
+
 interface Wildcard
 {
-    /**
-     * @param  string|Wildcard  $permission
-     */
-    public function implies($permission): bool;
+    public function __construct(Model $record);
+
+    public function getIndex(): array;
+
+    public function implies(string $permission, string $guardName, array $index): bool;
 }

--- a/src/WildcardPermission.php
+++ b/src/WildcardPermission.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\Permission;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Spatie\Permission\Contracts\Wildcard;
 use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
 
@@ -17,94 +19,101 @@ class WildcardPermission implements Wildcard
     /** @var non-empty-string */
     public const SUBPART_DELIMITER = ',';
 
-    /** @var string */
-    protected $permission;
+    protected Model $record;
 
-    /** @var Collection */
-    protected $parts;
-
-    public function __construct(string $permission)
+    public function __construct(Model $record)
     {
-        $this->permission = $permission;
-        $this->parts = collect();
-
-        $this->setParts();
+        $this->record = $record;
     }
 
-    /**
-     * @param  string|WildcardPermission  $permission
-     */
-    public function implies($permission): bool
+    public function getIndex(): array
     {
-        if (is_string($permission)) {
-            $permission = new static($permission);
+        $index = [];
+
+        foreach ($this->record->getAllPermissions() as $permission) {
+            $index[$permission->guard_name] = $this->buildIndex(
+                $index[$permission->guard_name] ?? [],
+                explode(static::PART_DELIMITER, $permission->name),
+                $permission->name,
+            );
         }
 
-        $otherParts = $permission->getParts();
-
-        $i = 0;
-        $partsCount = $this->getParts()->count();
-        foreach ($otherParts as $otherPart) {
-            if ($partsCount - 1 < $i) {
-                return true;
-            }
-
-            if (! $this->parts->get($i)->contains(static::WILDCARD_TOKEN)
-                && ! $this->containsAll($this->parts->get($i), $otherPart)) {
-                return false;
-            }
-
-            $i++;
-        }
-
-        for ($i; $i < $partsCount; $i++) {
-            if (! $this->parts->get($i)->contains(static::WILDCARD_TOKEN)) {
-                return false;
-            }
-        }
-
-        return true;
+        return $index;
     }
 
-    protected function containsAll(Collection $part, Collection $otherPart): bool
+    protected function buildIndex(array $index, array $parts, string $permission): array
     {
-        foreach ($otherPart->toArray() as $item) {
-            if (! $part->contains($item)) {
-                return false;
-            }
+        if (empty($parts)) {
+            $index[null] = true;
+
+            return $index;
         }
 
-        return true;
-    }
+        $part = array_shift($parts);
 
-    public function getParts(): Collection
-    {
-        return $this->parts;
-    }
-
-    /**
-     * Sets the different parts and subparts from permission string.
-     */
-    protected function setParts(): void
-    {
-        if (empty($this->permission) || $this->permission == null) {
-            throw WildcardPermissionNotProperlyFormatted::create($this->permission);
+        if (blank($part)) {
+            throw WildcardPermissionNotProperlyFormatted::create($permission);
         }
 
-        $parts = collect(explode(static::PART_DELIMITER, $this->permission));
+        if (! Str::contains($part, static::SUBPART_DELIMITER)) {
+            $index[$part] = $this->buildIndex(
+                $index[$part] ?? [],
+                $parts,
+                $permission,
+            );
+        }
 
-        $parts->each(function ($item, $key) {
-            $subParts = collect(explode(static::SUBPART_DELIMITER, $item));
+        $subParts = explode(static::SUBPART_DELIMITER, $part);
 
-            if ($subParts->isEmpty() || $subParts->contains('')) {
-                throw WildcardPermissionNotProperlyFormatted::create($this->permission);
+        foreach ($subParts as $subPart) {
+            if (blank($subPart)) {
+                throw WildcardPermissionNotProperlyFormatted::create($permission);
             }
 
-            $this->parts->add($subParts);
-        });
-
-        if ($this->parts->isEmpty()) {
-            throw WildcardPermissionNotProperlyFormatted::create($this->permission);
+            $index[$subPart] = $this->buildIndex(
+                $index[$subPart] ?? [],
+                $parts,
+                $permission,
+            );
         }
+
+        return $index;
+    }
+
+    public function implies(string $permission, string $guardName, array $index): bool
+    {
+        if (! array_key_exists($guardName, $index)) {
+            return false;
+        }
+
+        $permission = explode(static::PART_DELIMITER, $permission);
+
+        return $this->checkIndex($permission, $index[$guardName]);
+    }
+
+    protected function checkIndex(array $permission, array $index): bool
+    {
+        if (array_key_exists(null, $index)) {
+            return true;
+        }
+
+        if (empty($permission)) {
+            return false;
+        }
+
+        $firstPermission = array_shift($permission);
+
+        if (
+            array_key_exists($firstPermission, $index) &&
+            $this->checkIndex($permission, $index[$firstPermission])
+        ) {
+            return true;
+        }
+
+        if (array_key_exists(static::WILDCARD_TOKEN, $index)) {
+            return $this->checkIndex($permission, $index[static::WILDCARD_TOKEN]);
+        }
+
+        return false;
     }
 }

--- a/src/WildcardPermission.php
+++ b/src/WildcardPermission.php
@@ -93,7 +93,7 @@ class WildcardPermission implements Wildcard
 
     protected function checkIndex(array $permission, array $index): bool
     {
-        if (array_key_exists(null, $index)) {
+        if (array_key_exists(strval(null), $index)) {
             return true;
         }
 


### PR DESCRIPTION
This week we were investigating performance improvements for an app. It uses wildcard permissions. A specific page checks 3000 wildcard permissions, and was taking ~3.5s to load.

We searched the issues, and found #1424, which explained that the cache was not being used for wildcard permissions. It ended up being closed without a solution. We checked our cache, and sure enough there were no permissions there.

We tested this discovery by disabling wildcard permission checks in the config file, and found that our page only took ~600ms to load after that.

I started off this PR investigating why permissions were not being cached, but then stumbled upon the real reason why these checks were so slow:
- Each time a permission is checked, a collection of "all permissions" is constructed from the user's direct permissions and their role permissions.
- This collection was being looped over, and an algorithm was being used to check if any of the patterns satisfied the permission that was currently being checked.

I probably don't need to explain why doing this for 3000 permission checks is not a good idea, but just to give you an idea, if you store the "all permissions" collection in memory instead of generating it every time, it does shave ~1s off of our loading time for this page. Which is a great improvement for us, but not enough.

This was a tricky problem to solve, so I had to make a lot of changes to how wildcard permissions work. I believe this PR introduces breaking changes, since I modified a public interface (`Wildcard`) and how the implementation (`WildcardPermission`) is used.

Now, with the solution, our page speed is down to ~600ms with 3000 checks instead of ~3.5s.

All existing tests are passing, but I have targeted this PR at the `main` branch instead, ready for the (upcoming?) major 6.x release.

## The solution

To start with, I have introduced a new "wildcard permission index" on the existing `PermissionRegistrar` class. This index is a deeply nested array that is optimised for wildcard permission checks.

The top level of the index array is keyed by the class name of the model which has permissions (`Role` or `User`). The second level of the index array is keyed by the key of the model which has permissions (`Role` or `User`). This allows us to optimally store the index of a particular model in memory, so it is not built more than once per request. When the index is requested for a particular model, we will check if it has been built already, and retrieve it. If not, we will build it, and store it in the `PermissionRegistrar` object of the container for next time. If a permission or role is added or removed from a user, the index for that user is flushed and rebuilt. If a permission is added or removed from a role, the index for all users is flushed.

The third level of the index array is keyed by the guard name of the permission that has been cached. That allows us to quickly eliminate any permissions from being checked that have the wrong guard.

The rest of the index array past the third level is responsible for the actual permission "parts". When a permission is indexed, it is split into parts. Each part name is used as the index of the array. If a part has "subparts" (separated by a comma usually), then multiple array entires are created, one for each subpart. Once all part names are in the index array, we add a final entry with a `null` key and `true` value. This signifies that the permission is granted to the user.

By structuring the index array in this way, we can more easily check if there is a wildcard permission that matches or not.

### Example 1

Permissions assigned to user - `articles`

Permission checked - `articles`

Index array:

```jsonb
{
    articles: {
        null: true,
    },
}
```

Checks required for wildcard permission - `index.articles`

### Example 2

Permissions assigned to user - `articles.*`

Permission checked - `articles.1`

Index array:

```jsonb
{
    articles: {
        *: {
            null: true,
        },
    },
}
```

Checks required for wildcard permission - `index.articles.1`, `index.articles.*`

### Example 3

Permissions assigned to user - `articles.*.edit`

Permission checked - `articles.1.edit`

Index array:

```jsonb
{
    articles: {
        *: {
            edit: {
                null: true,
            },
        },
    },
}
```

Checks required for wildcard permission - `index.articles.1.edit`, `index.articles.*.edit`

### Example 4

Permissions assigned to user - `articles.*.create,edit`

Permission checked - `articles.1.edit`

Index array:

```jsonb
{
    articles: {
        *: {
            create: {
                null: true,
            },
            edit: {
                null: true,
            },
        },
    },
}
```

Checks required for wildcard permission - `index.articles.1.edit`, `index.articles.*.edit`

### Example 5

Permissions assigned to user - `articles.1,2,3.edit`

Permission checked - `articles.2.edit`

Index array:

```jsonb
{
    articles: {
        1: {
            edit: {
                null: true,
            },
        },
        2: {
            edit: {
                null: true,
            },
        },
        3: {
            edit: {
                null: true,
            },
        },
    },
}
```

Checks required for wildcard permission - `index.articles.2.edit`

### Example 6

Permissions assigned to user - `articles.1,2,3`

Permission checked - `articles.2.edit`

Index array:

```jsonb
{
    articles: {
        1: {
            null: true,
        },
        2: {
            null: true,
        },
        3: {
            null: true,
        },
    },
}
```

Checks required for wildcard permission - `index.articles.2`