### PR TITLE
Add guard name to exceptions

### DIFF
--- a/src/Exceptions/PermissionDoesNotExist.php
+++ b/src/Exceptions/PermissionDoesNotExist.php
@@ -6,13 +6,18 @@ use InvalidArgumentException;
 
 class PermissionDoesNotExist extends InvalidArgumentException
 {
-    public static function create(string $permissionName, string $guardName = '')
+    public static function create(string $permissionName, ?string $guardName)
     {
         return new static("There is no permission named `{$permissionName}` for guard `{$guardName}`.");
     }
 
-    public static function withId(int $permissionId, string $guardName = '')
+    /**
+     * @param int|string $permissionId
+     * @param string $guardName
+     * @return static
+     */
+    public static function withId($permissionId, ?string $guardName)
     {
-        return new static("There is no [permission] with id `{$permissionId}` for guard `{$guardName}`.");
+        return new static("There is no [permission] with ID `{$permissionId}` for guard `{$guardName}`.");
     }
 }

--- a/src/Exceptions/PermissionDoesNotExist.php
+++ b/src/Exceptions/PermissionDoesNotExist.php
@@ -12,8 +12,8 @@ class PermissionDoesNotExist extends InvalidArgumentException
     }
 
     /**
-     * @param int|string $permissionId
-     * @param string $guardName
+     * @param  int|string  $permissionId
+     * @param  string  $guardName
      * @return static
      */
     public static function withId($permissionId, ?string $guardName)

--- a/src/Exceptions/RoleDoesNotExist.php
+++ b/src/Exceptions/RoleDoesNotExist.php
@@ -12,8 +12,7 @@ class RoleDoesNotExist extends InvalidArgumentException
     }
 
     /**
-     * @param int|string $roleId
-     * @param string|null $guardName
+     * @param  int|string  $roleId
      * @return static
      */
     public static function withId($roleId, ?string $guardName)

--- a/src/Exceptions/RoleDoesNotExist.php
+++ b/src/Exceptions/RoleDoesNotExist.php
@@ -6,13 +6,18 @@ use InvalidArgumentException;
 
 class RoleDoesNotExist extends InvalidArgumentException
 {
-    public static function named(string $roleName)
+    public static function named(string $roleName, ?string $guardName)
     {
-        return new static("There is no role named `{$roleName}`.");
+        return new static("There is no role named `{$roleName}` for guard `{$guardName}`.");
     }
 
-    public static function withId(int $roleId)
+    /**
+     * @param int|string $roleId
+     * @param string|null $guardName
+     * @return static
+     */
+    public static function withId($roleId, ?string $guardName)
     {
-        return new static("There is no role with id `{$roleId}`.");
+        return new static("There is no role with ID `{$roleId}` for guard `{$guardName}`.");
     }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -103,7 +103,7 @@ class Role extends Model implements RoleContract
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $role) {
-            throw RoleDoesNotExist::named($name);
+            throw RoleDoesNotExist::named($name, $guardName);
         }
 
         return $role;
@@ -123,7 +123,7 @@ class Role extends Model implements RoleContract
         $role = static::findByParam([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $role) {
-            throw RoleDoesNotExist::withId($id);
+            throw RoleDoesNotExist::withId($id, $guardName);
         }
 
         return $role;


### PR DESCRIPTION
It's much easier to troubleshoot guard-related issues when the guard is included in the exception.
