### PR TITLE
Drop PHP 7.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,23 +9,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.1, 8.0, 7.4]
-        laravel: [10.*, 9.*, 8.*]
+        php: [8.2, 8.1, 8.0]
+        laravel: ["^10.0", "^9.0", "^8.12"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
+          - laravel: "^10.0"
             testbench: 8.*
-          - laravel: 9.*
+          - laravel: "^9.0"
             testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.23
+          - laravel: "^8.12"
+            testbench: "^6.23"
         exclude:
-            - laravel: 10.*
+            - laravel: "^10.0"
               php: 8.0
-            - laravel: 10.*
-              php: 7.4
-            - laravel: 9.*
-              php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -42,7 +38,7 @@ jobs:
 
       - name: Install dependencies (remove passport)
         run: composer remove --dev laravel/passport --no-interaction --no-update
-        if: matrix.laravel == '8.*'
+        if: matrix.laravel == '^8.12'
 
       - name: Install dependencies
         run: |

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     ],
     "homepage": "https://github.com/spatie/laravel-permission",
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/auth": "^8.0|^9.0|^10.0",
-        "illuminate/container": "^8.0|^9.0|^10.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/database": "^8.0|^9.0|^10.0"
+        "php": "^8.0",
+        "illuminate/auth": "^8.12|^9.0|^10.0",
+        "illuminate/container": "^8.12|^9.0|^10.0",
+        "illuminate/contracts": "^8.12|^9.0|^10.0",
+        "illuminate/database": "^8.12|^9.0|^10.0"
     },
     "require-dev": {
         "laravel/passport": "^11.0",
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^6.23|^7.0|^8.0",
         "phpunit/phpunit": "^9.4"
     },
     "minimum-stability": "dev",

--- a/docs/installation-laravel.md
+++ b/docs/installation-laravel.md
@@ -9,7 +9,7 @@ This package can be used with Laravel 6.0 or higher.
 
 Package Version | Laravel Version
 ----------------|-----------
-   ^6.0         |  8,9,10
+   ^6.0         |  8,9,10 (PHP 8.0+)
    ^5.8         |  7,8,9,10
    ^5.7         |  7,8,9
    ^5.4-^5.6    |  7,8


### PR DESCRIPTION
(Note: Laravel 8.12 minimum is required for using PHP 8.0)