### PR TITLE
[V5] Avoid triggering `eloquent.retrieved` event

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -344,8 +344,8 @@ class PermissionRegistrar
 
         return Collection::make(
             array_map(function ($item) use ($permissionInstance) {
-                return $permissionInstance
-                    ->newFromBuilder($this->aliasedArray(array_diff_key($item, ['r' => 0])))
+                return $permissionInstance->newInstance([], true)
+                    ->setRawAttributes($this->aliasedArray(array_diff_key($item, ['r' => 0])), true)
                     ->setRelation('roles', $this->getHydratedRoleCollection($item['r'] ?? []));
             }, $this->permissions['permissions'])
         );
@@ -364,7 +364,8 @@ class PermissionRegistrar
         $roleInstance = new $roleClass();
 
         array_map(function ($item) use ($roleInstance) {
-            $role = $roleInstance->newFromBuilder($this->aliasedArray($item));
+            $role = $roleInstance->newInstance([], true)
+                ->setRawAttributes($this->aliasedArray($item), true);
             $this->cachedRoles[$role->getKey()] = $role;
         }, $this->permissions['roles']);
 


### PR DESCRIPTION
when hydrating the models that come from the cache, the `retrieved` event is being triggered, it should not be triggered because they are supposed to be preloaded from cache, this decreases performance
![image](https://github.com/spatie/laravel-permission/assets/4933954/a22f4aea-bb45-492c-8bc8-de7bd80396a4)

[Illuminate/Database/Eloquent/Model.php#L625-L636](https://github.com/laravel/framework/blob/4989e6de076688ade265e2f1970ab6f0c1b60fcb/src/Illuminate/Database/Eloquent/Model.php#L625-L636), here is the source

Same for **V6**