### PR TITLE
[Docs] Listen to DatabaseRefreshed rather than MigrationsEnded in TestCase

### DIFF
--- a/docs/advanced-usage/testing.md
+++ b/docs/advanced-usage/testing.md
@@ -22,10 +22,10 @@ In your tests simply add a `setUp()` instruction to re-register the permissions,
 
 ## Clear Cache When Using Seeders
 
-If you are using Laravel's `LazilyRefreshDatabase` trait, you most likely want to avoid seeding permissions before every test, because that would negate the use of the `LazilyRefreshDatabase` trait. To overcome this, you should wrap your seeder in an event listener for the `MigrationsEnded` event:
+If you are using Laravel's `LazilyRefreshDatabase` trait, you most likely want to avoid seeding permissions before every test, because that would negate the use of the `LazilyRefreshDatabase` trait. To overcome this, you should wrap your seeder in an event listener for the `DatabaseRefreshed` event:
 
 ```php
-Event::listen(MigrationsEnded::class, function () {
+Event::listen(DatabaseRefreshed::class, function () {
     $this->artisan('db:seed', ['--class' => RoleAndPermissionSeeder::class]);
     $this->app->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
 });


### PR DESCRIPTION
Listening to `DatabaseRefreshed` event rather than `MigrationsEnded` can avoid issues during testing after `artisan schema:dump` command has been executed.

In fact, `MigrationsEnded` is not called when the migration is based on a `mysql-schema.sql` file and has no migration executed anymore.

`DatabaseRefreshed` is always executed in both cases.