### PR TITLE
[v6] Sync v5 fix: Avoid triggering eloquent.retrieved event

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -354,12 +354,11 @@ class PermissionRegistrar
 
     private function getHydratedPermissionCollection(): Collection
     {
-        $permissionClass = $this->getPermissionClass();
-        $permissionInstance = new $permissionClass();
+        $permissionInstance = new ($this->getPermissionClass())();
 
         return Collection::make(array_map(
-            fn ($item) => $permissionInstance
-                ->newFromBuilder($this->aliasedArray(array_diff_key($item, ['r' => 0])))
+            fn ($item) => $permissionInstance->newInstance([], true)
+                ->setRawAttributes($this->aliasedArray(array_diff_key($item, ['r' => 0])), true)
                 ->setRelation('roles', $this->getHydratedRoleCollection($item['r'] ?? [])),
             $this->permissions['permissions']
         ));
@@ -374,11 +373,11 @@ class PermissionRegistrar
 
     private function hydrateRolesCache(): void
     {
-        $roleClass = $this->getRoleClass();
-        $roleInstance = new $roleClass();
+        $roleInstance = new ($this->getRoleClass())();
 
         array_map(function ($item) use ($roleInstance) {
-            $role = $roleInstance->newFromBuilder($this->aliasedArray($item));
+            $role = $roleInstance->newInstance([], true)
+                ->setRawAttributes($this->aliasedArray($item), true);
             $this->cachedRoles[$role->getKey()] = $role;
         }, $this->permissions['roles']);
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -101,10 +101,8 @@ trait HasPermissions
     {
         $permissions = $this->convertToPermissionModels($permissions);
 
-        $permissionClass = $this->getPermissionClass();
-        $permissionKey = (new $permissionClass())->getKeyName();
-        $roleClass = is_a($this, Role::class) ? static::class : $this->getRoleClass();
-        $roleKey = (new $roleClass())->getKeyName();
+        $permissionKey = (new ($this->getPermissionClass())())->getKeyName();
+        $roleKey = (new (is_a($this, Role::class) ? static::class : $this->getRoleClass())())->getKeyName();
 
         $rolesWithPermissions = is_a($this, Role::class) ? [] : array_unique(
             array_reduce($permissions, fn ($result, $permission) => array_merge($result, $permission->roles->all()), [])
@@ -132,10 +130,8 @@ trait HasPermissions
     {
         $permissions = $this->convertToPermissionModels($permissions);
 
-        $permissionClass = $this->getPermissionClass();
-        $permissionKey = (new $permissionClass())->getKeyName();
-        $roleClass = is_a($this, Role::class) ? static::class : $this->getRoleClass();
-        $roleKey = (new $roleClass())->getKeyName();
+        $permissionKey = (new ($this->getPermissionClass())())->getKeyName();
+        $roleKey = (new (is_a($this, Role::class) ? static::class : $this->getRoleClass())())->getKeyName();
 
         $rolesWithPermissions = is_a($this, Role::class) ? [] : array_unique(
             array_reduce($permissions, fn ($result, $permission) => array_merge($result, $permission->roles->all()), [])

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -253,8 +253,7 @@ trait HasRoles
         }
 
         if (is_int($roles) || PermissionRegistrar::isUid($roles)) {
-            $roleClass = $this->getRoleClass();
-            $key = (new $roleClass())->getKeyName();
+            $key = (new ($this->getRoleClass())())->getKeyName();
 
             return $guard
                 ? $this->roles->where('guard_name', $guard)->contains($key, $roles)


### PR DESCRIPTION
- #2490
- Use PHP 8 Syntax for avoid assign class string to variables