### PR TITLE
fix Lumen Documentation Address

### DIFF
--- a/docs/installation-lumen.md
+++ b/docs/installation-lumen.md
@@ -5,7 +5,7 @@ weight: 5
 
 NOTE: Lumen is **not** officially supported by this package. However, the following are some steps which may help get you started.
 
-Lumen installation instructions can be found in the [Lumen documentation](https://lumen.laravel.com/docs/main).
+Lumen installation instructions can be found in the [Lumen documentation](https://lumen.laravel.com/docs/master).
 
 ## Installing
 


### PR DESCRIPTION
The Lumen Documentation Address referred to `https://lumen.laravel.com/docs/10.x/main`, which returns a `404` error.

Now Address refers to `https://lumen.laravel.com/docs/master`, The last version of the Lumen.
