### PR TITLE
Has permission directive - Non Default guard

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -123,6 +123,16 @@ class PermissionServiceProvider extends ServiceProvider
         $bladeCompiler->directive('elserole', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endrole', fn () => '<?php endif; ?>');
 
+        $bladeCompiler->directive('haspermissionto', function ($arguments) {
+            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>";
+        });
+        $bladeCompiler->directive('elsehaspermissionto', function ($arguments) {
+            return "<?php elseif(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>";
+        });
+        $bladeCompiler->directive('endhaspermissionto', function () {
+            return '<?php endif; ?>';
+        });
+
         $bladeCompiler->directive('hasrole', fn ($args) => "<?php if({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endhasrole', fn () => '<?php endif; ?>');
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -123,15 +123,9 @@ class PermissionServiceProvider extends ServiceProvider
         $bladeCompiler->directive('elserole', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endrole', fn () => '<?php endif; ?>');
 
-        $bladeCompiler->directive('haspermissionto', function ($arguments) {
-            return "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>";
-        });
-        $bladeCompiler->directive('elsehaspermissionto', function ($arguments) {
-            return "<?php elseif(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>";
-        });
-        $bladeCompiler->directive('endhaspermissionto', function () {
-            return '<?php endif; ?>';
-        });
+        $bladeCompiler->directive('haspermissionto', fn ($arguments) => "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>");
+        $bladeCompiler->directive('elsehaspermissionto', fn ($arguments) => "<?php elseif(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>");
+        $bladeCompiler->directive('endhaspermissionto', fn () => '<?php endif; ?>');
 
         $bladeCompiler->directive('hasrole', fn ($args) => "<?php if({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endhasrole', fn () => '<?php endif; ?>');

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -123,8 +123,8 @@ class PermissionServiceProvider extends ServiceProvider
         $bladeCompiler->directive('elserole', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endrole', fn () => '<?php endif; ?>');
 
-        $bladeCompiler->directive('haspermission', fn ($args) => "<?php if({$bladeMethodWrapper}('hasPermissionTo', {$args})): ?>");
-        $bladeCompiler->directive('elsehaspermission', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasPermissionTo', {$args})): ?>");
+        $bladeCompiler->directive('haspermission', fn ($args) => "<?php if({$bladeMethodWrapper}('checkPermissionTo', {$args})): ?>");
+        $bladeCompiler->directive('elsehaspermission', fn ($args) => "<?php elseif({$bladeMethodWrapper}('checkPermissionTo', {$args})): ?>");
         $bladeCompiler->directive('endhaspermission', fn () => '<?php endif; ?>');
 
         $bladeCompiler->directive('hasrole', fn ($args) => "<?php if({$bladeMethodWrapper}('hasRole', {$args})): ?>");

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -123,9 +123,9 @@ class PermissionServiceProvider extends ServiceProvider
         $bladeCompiler->directive('elserole', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endrole', fn () => '<?php endif; ?>');
 
-        $bladeCompiler->directive('haspermissionto', fn ($arguments) => "<?php if(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>");
-        $bladeCompiler->directive('elsehaspermissionto', fn ($arguments) => "<?php elseif(\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper('hasPermissionTo', {$arguments})): ?>");
-        $bladeCompiler->directive('endhaspermissionto', fn () => '<?php endif; ?>');
+        $bladeCompiler->directive('haspermission', fn ($args) => "<?php if({$bladeMethodWrapper}('hasPermissionTo', {$args})): ?>");
+        $bladeCompiler->directive('elsehaspermission', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasPermissionTo', {$args})): ?>");
+        $bladeCompiler->directive('endhaspermission', fn () => '<?php endif; ?>');
 
         $bladeCompiler->directive('hasrole', fn ($args) => "<?php if({$bladeMethodWrapper}('hasRole', {$args})): ?>");
         $bladeCompiler->directive('endhasrole', fn () => '<?php endif; ?>');


### PR DESCRIPTION
Has permission directive to use instead can directive when using non-default guard

Creating this PR to be able to use another blade directive when you use another guard distinct from the default one.

This issue is mentioned [here](https://github.com/spatie/laravel-permission/issues/1290).

With this change, you can use the following directive
```
@haspermission('admin.users.view', 'admin')
   ...
@endhaspermission
```
instead of 
```
@can('admin.users.view')
   ...
@can
```