### PR TITLE
[Docs] Add missing closing bracket

### DIFF
--- a/docs/basic-usage/super-admin.md
+++ b/docs/basic-usage/super-admin.md
@@ -47,7 +47,7 @@ use App\Models\User; // could be any model
  */
 public function before(User $user, string $ability): bool|null
 {
-    if ($user->hasRole('Super Admin') {
+    if ($user->hasRole('Super Admin')) {
         return true;
     }
  


### PR DESCRIPTION
There is missing closing braket in the example of using Policy before() method.