### PR TITLE
[Docs] Update UUID

### DIFF
--- a/docs/advanced-usage/uuid.md
+++ b/docs/advanced-usage/uuid.md
@@ -64,6 +64,18 @@ If you also want the roles and permissions to use a UUID for their `id` value, t
 -        $table->unsignedBigInteger(PermissionRegistrar::$pivotRole);
 +        $table->uuid(PermissionRegistrar::$pivotPermission);
 +        $table->uuid(PermissionRegistrar::$pivotRole);
+
+         $table->foreign(PermissionRegistrar::$pivotPermission)
+-            ->references('id') // permission id
++            ->references('uuid') // permission id
+            ->on($tableNames['permissions'])
+            ->onDelete('cascade');
+
+         $table->foreign(PermissionRegistrar::$pivotRole)
+-            ->references('id') // role id
++            ->references('uuid') // role id
+            ->on($tableNames['roles'])
+            ->onDelete('cascade'); 
 ```
 
 


### PR DESCRIPTION
These changes ensure that foreign keys are correctly defined for database relationships in the `role_has_permissions` table, using UUIDs as the reference key, and improve the package's documentation.
These changes were missed in the `uuid` documentation.