### PR TITLE
[Docs] Update unsetRelation() example in teams-permissions.md

### DIFF
--- a/docs/basic-usage/teams-permissions.md
+++ b/docs/basic-usage/teams-permissions.md
@@ -96,7 +96,7 @@ setPermissionsTeamId($new_team_id);
 // $user = Auth::user();
 
 // unset cached model relations so new team relations will get reloaded
-$user->unsetRelation('roles','permissions');
+$user->unsetRelation('roles')->unsetRelation('permissions');
 
 // Now you can check:
 $roles = $user->roles;


### PR DESCRIPTION
In the teams-permissions doc, `unsetRelation()` method invoked with 2 parameters, but the method signature uses 1 parameter.
See the [Method Reference](https://github.com/illuminate/database/blob/571aa694dc6f588d4334e4e23d6721ff68893e10/Eloquent/Concerns/HasRelationships.php#L863)


I made the changes and we need to call `unsetRelation()` method twice for `models` and `permissions` relations