### PR TITLE
fix empty permissions in PermissionRegistrar.php

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -191,7 +191,7 @@ class PermissionRegistrar
      */
     private function loadPermissions(): void
     {
-        if ($this->permissions) {
+        if (count($this->permissions ?? [])) {
             return;
         }
 


### PR DESCRIPTION
hey,

bool check on an empty collection returns true so the cache is never populated. I came across this when doing syncPermissions on my user model threw an exception that the permission doesnt exist event when it does.

This fixes #2543 

greetings