### PR TITLE
Issue assigning team roles when relationship is preloaded

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -152,6 +152,8 @@ trait HasRoles
             [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
         if ($model->exists) {
+            $this->load('roles');
+
             $currentRoles = $this->roles->map(fn ($role) => $role->getKey())->toArray();
 
             $this->roles()->attach(array_diff($roles, $currentRoles), $teamPivot);

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -16,6 +16,8 @@ trait HasRoles
 
     private ?string $roleClass = null;
 
+    private mixed $rolesLoadedWithTeamId = null;
+
     public static function bootHasRoles()
     {
         static::deleting(function ($model) {
@@ -60,6 +62,8 @@ trait HasRoles
         }
 
         $teamField = config('permission.table_names.roles').'.'.app(PermissionRegistrar::class)->teamsKey;
+
+        $this->rolesLoadedWithTeamId = getPermissionsTeamId();
 
         return $relation->wherePivot(app(PermissionRegistrar::class)->teamsKey, getPermissionsTeamId())
             ->where(fn ($q) => $q->whereNull($teamField)->orWhere($teamField, getPermissionsTeamId()));
@@ -152,7 +156,9 @@ trait HasRoles
             [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
         if ($model->exists) {
-            $this->load('roles');
+            if (getPermissionsTeamId() !== $this->rolesLoadedWithTeamId) {
+                $this->load('roles');
+            }
 
             $currentRoles = $this->roles->map(fn ($role) => $role->getKey())->toArray();
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -16,8 +16,6 @@ trait HasRoles
 
     private ?string $roleClass = null;
 
-    private mixed $rolesLoadedWithTeamId = null;
-
     public static function bootHasRoles()
     {
         static::deleting(function ($model) {
@@ -62,8 +60,6 @@ trait HasRoles
         }
 
         $teamField = config('permission.table_names.roles').'.'.app(PermissionRegistrar::class)->teamsKey;
-
-        $this->rolesLoadedWithTeamId = getPermissionsTeamId();
 
         return $relation->wherePivot(app(PermissionRegistrar::class)->teamsKey, getPermissionsTeamId())
             ->where(fn ($q) => $q->whereNull($teamField)->orWhere($teamField, getPermissionsTeamId()));
@@ -156,9 +152,7 @@ trait HasRoles
             [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : [];
 
         if ($model->exists) {
-            if (getPermissionsTeamId() !== $this->rolesLoadedWithTeamId) {
-                $this->load('roles');
-            }
+            $this->loadMissing('roles');
 
             $currentRoles = $this->roles->map(fn ($role) => $role->getKey())->toArray();
 

--- a/tests/LazyLoadingTest.php
+++ b/tests/LazyLoadingTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Permission\Tests;
+
+class LazyLoadingTest extends TestCase
+{
+    /** @test */
+    public function test_it_does_not_violate_global_lazy_loading_rule()
+    {
+        $this->testUser->preventsLazyLoading = true;
+        $this->testUser->wasRecentlyCreated = false;
+
+        $this->expectNotToPerformAssertions();
+
+        $this->testUser->assignRole('testRole');
+    }
+}

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -149,4 +149,34 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertEquals(0, $scopedUsers2Team2->count());
         $this->assertEquals(1, $scopedUsers3Team2->count());
     }
+
+    /** @test */
+    public function it_can_assign_the_same_across_teams_when_roles_already_loaded()
+    {
+        setPermissionsTeamId(1);
+        $this->testUser->assignRole('testRole');
+
+        $this->testUser->load('roles');
+
+        setPermissionsTeamId(2);
+        $this->testUser->assignRole('testRole');
+
+        setPermissionsTeamId(1);
+        $this->testUser->load('roles');
+
+        $this->assertEquals(
+            collect(['testRole']),
+            $this->testUser->getRoleNames()->sort()->values()
+        );
+        $this->assertTrue($this->testUser->hasExactRoles(['testRole']));
+
+        setPermissionsTeamId(2);
+        $this->testUser->load('roles');
+
+        $this->assertEquals(
+            collect(['testRole']),
+            $this->testUser->getRoleNames()->sort()->values()
+        );
+        $this->assertTrue($this->testUser->hasExactRoles(['testRole']));
+    }
 }

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -149,34 +149,4 @@ class TeamHasRolesTest extends HasRolesTest
         $this->assertEquals(0, $scopedUsers2Team2->count());
         $this->assertEquals(1, $scopedUsers3Team2->count());
     }
-
-    /** @test */
-    public function it_can_assign_the_same_across_teams_when_roles_already_loaded()
-    {
-        setPermissionsTeamId(1);
-        $this->testUser->assignRole('testRole');
-
-        $this->testUser->load('roles');
-
-        setPermissionsTeamId(2);
-        $this->testUser->assignRole('testRole');
-
-        setPermissionsTeamId(1);
-        $this->testUser->load('roles');
-
-        $this->assertEquals(
-            collect(['testRole']),
-            $this->testUser->getRoleNames()->sort()->values()
-        );
-        $this->assertTrue($this->testUser->hasExactRoles(['testRole']));
-
-        setPermissionsTeamId(2);
-        $this->testUser->load('roles');
-
-        $this->assertEquals(
-            collect(['testRole']),
-            $this->testUser->getRoleNames()->sort()->values()
-        );
-        $this->assertTrue($this->testUser->hasExactRoles(['testRole']));
-    }
 }


### PR DESCRIPTION
### Overview

I ran into an issue assigning the same role to a user across multiple teams. The issue I ran into is as follows:

Say I have two teams in the database: "Team1" and "Team2". I want to load users from the database and assign them some role. Let's call it "testRole". They already have "testRole" on Team1, but I want to assign it for Team2.

If the "roles" relationship has been pre-loaded then the line:

    $currentRoles = $this->roles->map(fn ($role) => $role->getKey())->toArray();

In the `HasRoles` trait will see the role on Team1, and not add it for Team2.

### How I ran into the issue

Initially I was loading users from the database and assigning roles in a seeder like so:

```php
setPermissionsTeamId(2);

$users = User::where(...)->get();

foreach ($users as $user) {
    $user->assignRole('testRole');
}
```

As we have [lazy loading disabled](https://laravel.com/docs/10.x/eloquent-relationships#preventing-lazy-loading) in our app this causes an issue in the `spatie/laravel-permission` package [here](https://github.com/spatie/laravel-permission/blob/main/src/Traits/HasRoles.php#L155) as it lazy loads the roles relationship:

```php
$currentRoles = $this->roles->map(fn ($role) => $role->getKey())->toArray();
```

So I updated my snippet above to preload the roles:

```php
setPermissionsTeamId(2);

$users = User::with('roles')->where(...)->get();

...assign roles
```

But now I run into the issue that the role collection has a role with the key `testRole`, so when assigning it in `assignRole` the attachment which uses an `array_diff` won't actually attach a new role to the second team.

### Attempted Solution

As this didn't seem quite right, I have added a unit test to the package to try and reproduce the issue. I naively thought that I can just reload the roles relationship eagerly before we diff the roles, but then other tests fail which are confirming that we don't make unnecessary SQL queryies. Of course we are making a new query so I don't know how to proceed.

Should we allow the roles to be re-loaded, and update the number of allowed SQL queries in the test to be +1? Or is there a better solution here? Maybe if the `roles` relationship is pre-loaded then the line that gets the current role keys can use the current team ID to filter to just the current team?

Something like this (pseudo code):

```php
// Trait\HasRoles.php

public function assignRole(...$roles) {
    ...

    if ($model->exists) {
        $currentRoles = $this->roles
            ->filter(fn $role => $role->pivot->{$teamsKey) == getPermissionsTeamId()) // New filter
            ->map(fn ($role) => $role->getKey())
            ->toArray();

        $this->roles()->attach(array_diff($roles, $currentRoles), $teamPivot);
        $model->unsetRelation('roles');
    } else {
        ...
    }

    ...
}
```

Hopefully we can come to some resolution, if this isn't clear or you have any questions then please feel free to reach out.

Thanks!