### PR TITLE
Hopefully fix issue for testing locally

### DIFF
--- a/src/Middleware/PermissionMiddleware.php
+++ b/src/Middleware/PermissionMiddleware.php
@@ -16,7 +16,7 @@ class PermissionMiddleware
         $user = $authGuard->user();
 
         // For machine-to-machine Passport clients
-        if (! $user && $request->bearerToken() && config('permission.use_passport_client_credentials')) {
+        if (! $user && ($request->bearerToken() || auth()?->client()) && config('permission.use_passport_client_credentials')) {
             $user = Guard::getPassportClient($guard);
         }
 

--- a/src/Middleware/RoleMiddleware.php
+++ b/src/Middleware/RoleMiddleware.php
@@ -16,7 +16,7 @@ class RoleMiddleware
         $user = $authGuard->user();
 
         // For machine-to-machine Passport clients
-        if (! $user && $request->bearerToken() && config('permission.use_passport_client_credentials')) {
+        if (! $user && ($request->bearerToken() || auth()?->client()) && config('permission.use_passport_client_credentials')) {
             $user = Guard::getPassportClient($guard);
         }
 

--- a/src/Middleware/RoleOrPermissionMiddleware.php
+++ b/src/Middleware/RoleOrPermissionMiddleware.php
@@ -16,7 +16,7 @@ class RoleOrPermissionMiddleware
         $user = $authGuard->user();
 
         // For machine-to-machine Passport clients
-        if (! $user && $request->bearerToken() && config('permission.use_passport_client_credentials')) {
+        if (! $user && ($request->bearerToken() || auth()?->client()) && config('permission.use_passport_client_credentials')) {
             $user = Guard::getPassportClient($guard);
         }
 


### PR DESCRIPTION
While testing locally I noticed that I got an `403` error even though I was using `Passport::actingAsClient()`. That error occurs because there is no `$user` and no `bearerToken()` provided. But I did notice that `auth()?->client()` returned the `Passport::actingAsClient()` `Client` instance.  

So I'm hoping that with this change testing works as expected. It should now check for either the `bearerToken()` or the loggedin Client provided by  `Passport::actingAsClient()`.