### PR TITLE
Support guard_name on middleware

### DIFF
--- a/src/Middleware/PermissionMiddleware.php
+++ b/src/Middleware/PermissionMiddleware.php
@@ -32,7 +32,7 @@ class PermissionMiddleware
             ? $permission
             : explode('|', $permission);
 
-        if (! $user->canAny($permissions)) {
+        if (! $user->canAny($permissions, $guard)) {
             throw UnauthorizedException::forPermissions($permissions);
         }
 

--- a/src/Middleware/RoleOrPermissionMiddleware.php
+++ b/src/Middleware/RoleOrPermissionMiddleware.php
@@ -32,7 +32,7 @@ class RoleOrPermissionMiddleware
             ? $roleOrPermission
             : explode('|', $roleOrPermission);
 
-        if (! $user->canAny($rolesOrPermissions) && ! $user->hasAnyRole($rolesOrPermissions)) {
+        if (! $user->canAny($rolesOrPermissions, $guard) && ! $user->hasAnyRole($rolesOrPermissions)) {
             throw UnauthorizedException::forRolesOrPermissions($rolesOrPermissions);
         }
 

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -129,6 +129,21 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    public function multiple_guard_user_can_access_a_route_protected_by_permission_middleware_using_specific_guard(): void
+    {
+        config()->set('auth.guards.api.driver', 'session');
+        Auth::guard('api')->login($this->testUser);
+
+        $testClientPermission = app(Permission::class)->create(['name' => 'apiPermission', 'guard_name' => 'api']);
+        $this->testUser->givePermissionTo($testClientPermission);
+
+        $this->assertEquals(
+            200,
+            $this->runMiddleware($this->permissionMiddleware, 'apiPermission', 'api')
+        );
+    }
+
+    /** @test */
     public function a_client_can_access_a_route_protected_by_permission_middleware_if_have_this_permission(): void
     {
         if ($this->getLaravelVersion() < 9) {

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use Laravel\Passport\Passport;
+use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Tests\TestModels\UserWithoutHasRoles;
@@ -295,6 +296,21 @@ class RoleMiddlewareTest extends TestCase
         $this->assertEquals(
             403,
             $this->runMiddleware($this->roleMiddleware, 'testRole', 'admin')
+        );
+    }
+
+    /** @test */
+    public function multiple_guard_user_can_access_role_while_login_using_specific_guard(): void
+    {
+        config()->set('auth.guards.api.driver', 'session');
+        Auth::guard('api')->login($this->testUser);
+
+        $testClientRole = app(Role::class)->create(['name' => 'apiRole', 'guard_name' => 'api']);
+        $this->testUser->assignRole($testClientRole);
+
+        $this->assertEquals(
+            200,
+            $this->runMiddleware($this->roleMiddleware, 'apiRole', 'api')
         );
     }
 


### PR DESCRIPTION
I add some tests
When a model uses more than one guard, it seems that the permissions cannot be reached

I don't know if it is an issue or expected behavior

----

Also, on next test, `testRole` has `web` guard_name, but login and `roleMiddleware` uses `api`, 
give me `200`,Shouldn't it be 403?
```php
/** @test */
public function multiple_guard_user_can_access_role_while_login_using_specific_guard2(): void
{
    config()->set('auth.guards.api.driver', 'session');
    Auth::guard('api')->login($this->testUser);

    $this->testUser->assignRole('testRole');

    $this->assertEquals(
        403,
        $this->runMiddleware($this->roleMiddleware, 'testRole', 'api')
    );
}
```