### PR TITLE
Fix comment formatting in permission.php

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -73,10 +73,12 @@ return [
 
     'column_names' => [
         /*
-         * Change this if you want to name the related pivots other than defaults
+         * Change this if you want to name the related pivots other than defaults,
+         * which are `role_id` and `permission_id` respectively.
          */
-        'role_pivot_key' => null, //default 'role_id',
-        'permission_pivot_key' => null, //default 'permission_id',
+    
+        'role_pivot_key' => null,
+        'permission_pivot_key' => null,
 
         /*
          * Change this if you want to name the related model primary key other than


### PR DESCRIPTION
This more closely resembles the formatting elsewhere in the file by adding an empty line and moving all comments to within the block.

Note: it might even be better to actually use the default values instead of `null` in the config file to make them explicit.