### PR TITLE
Fixes middleware namespace in docs

### DIFF
--- a/docs/basic-usage/middleware.md
+++ b/docs/basic-usage/middleware.md
@@ -34,9 +34,9 @@ Note the property name difference between Laravel 10 and older versions of Larav
 // Laravel 10+ uses $middlewareAliases = [
 protected $middlewareAliases = [
     // ...
-    'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
-    'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
-    'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+    'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+    'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+    'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
 ];
 ```
 


### PR DESCRIPTION
The middleware namespace shown in the documentation was incorrect (missing an "s")