### PR TITLE
laravel-pint-action to major version tag

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.3.0
+        uses: aglipanci/laravel-pint-action@v2
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
https://github.com/aglipanci/laravel-pint-action/releases/tag/v2
using major tag gets the latest version of the branch