### PR TITLE
Added Team-Knowledge to Permission-Model roles relation

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -57,12 +57,20 @@ class Permission extends Model implements PermissionContract
      */
     public function roles(): BelongsToMany
     {
-        return $this->belongsToMany(
+        $relation = $this->belongsToMany(
             config('permission.models.role'),
             config('permission.table_names.role_has_permissions'),
             app(PermissionRegistrar::class)->pivotPermission,
             app(PermissionRegistrar::class)->pivotRole
         );
+
+        if (! app(PermissionRegistrar::class)->teams) {
+            return $relation;
+        }
+
+        $teamField = config('permission.table_names.roles').'.'.app(PermissionRegistrar::class)->teamsKey;
+
+        return $relation->whereNull($teamField)->orWhere($teamField, getPermissionsTeamId());
     }
 
     /**


### PR DESCRIPTION
In huge team-environments the Permission-Model eager loads always all roles of all teams independent of a current used team-id. This can lead to much ram usage due to multiple thousands loaded role-models.

This fix finally reduces amount of loaded role-models significantly.