### PR TITLE
fix(team): Add nullable team_id

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -109,7 +109,7 @@ class PermissionRegistrar
     }
 
     /**
-     * @return int|string
+     * @return int|string|null
      */
     public function getPermissionsTeamId()
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,7 +14,7 @@ if (! function_exists('getModelForGuard')) {
 
 if (! function_exists('setPermissionsTeamId')) {
     /**
-     * @param  int|string|\Illuminate\Database\Eloquent\Model  $id
+     * @param  int|string|null|\Illuminate\Database\Eloquent\Model  $id
      */
     function setPermissionsTeamId($id)
     {
@@ -24,7 +24,7 @@ if (! function_exists('setPermissionsTeamId')) {
 
 if (! function_exists('getPermissionsTeamId')) {
     /**
-     * @return int|string
+     * @return int|string|null
      */
     function getPermissionsTeamId()
     {


### PR DESCRIPTION
Added `null` to helpers `getPermissionsTeamId` and `setPermissionsTeamId` and in the `PermissionRegistrar`.

This is to fix a PHPStan problem : 

`Parameter #1 $id of function setPermissionsTeamId expects Illuminate\Database\Eloquent\Model|int|string, null given.`

But when you put `''`, my tests are failing because it expects a `null` as per the doc.