### PR TITLE
Cover wilcard permission instance verification based on its own guard

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -231,6 +231,7 @@ trait HasPermissions
         }
 
         if ($permission instanceof Permission) {
+            $guardName = $permission->guard_name ?? $guardName;
             $permission = $permission->name;
         }
 

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -20,6 +20,20 @@ class HasPermissionsTest extends TestCase
         $this->assertTrue($this->testUser->hasPermissionTo($this->testUserPermission));
     }
 
+
+    /** @test */
+    public function it_can_assign_a_permission_to_a_user_with_a_non_default_guard()
+    {
+        $testUserPermission = app(Permission::class)->create([
+            'name'       => 'edit-articles',
+            'guard_name' => 'api',
+        ]);
+
+        $this->testUser->givePermissionTo($testUserPermission);
+
+        $this->assertTrue($this->testUser->hasPermissionTo($testUserPermission));
+    }
+
     /** @test */
     public function it_throws_an_exception_when_assigning_a_permission_that_does_not_exist()
     {

--- a/tests/WildcardHasPermissionsTest.php
+++ b/tests/WildcardHasPermissionsTest.php
@@ -31,6 +31,47 @@ class WildcardHasPermissionsTest extends TestCase
         $this->assertFalse($user1->hasPermissionTo('projects.view'));
     }
 
+    /** @test */
+    public function it_can_check_wildcard_permission_for_a_non_default_guard()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $permission1 = Permission::create(['name' => 'articles.edit,view,create', 'guard_name' => 'api']);
+        $permission2 = Permission::create(['name' => 'news.*', 'guard_name' => 'api']);
+        $permission3 = Permission::create(['name' => 'posts.*', 'guard_name' => 'api']);
+
+        $user1->givePermissionTo([$permission1, $permission2, $permission3]);
+
+        $this->assertTrue($user1->hasPermissionTo('posts.create', 'api'));
+        $this->assertTrue($user1->hasPermissionTo('posts.create.123', 'api'));
+        $this->assertTrue($user1->hasPermissionTo('posts.*', 'api'));
+        $this->assertTrue($user1->hasPermissionTo('articles.view', 'api'));
+        $this->assertFalse($user1->hasPermissionTo('projects.view', 'api'));
+    }
+
+    /** @test */
+    public function it_can_check_wildcard_permission_from_instance_without_explicit_guard_argument()
+    {
+        app('config')->set('permission.enable_wildcard_permission', true);
+
+        $user1 = User::create(['email' => 'user1@test.com']);
+
+        $permission2 = Permission::create(['name' => 'articles.view']);
+        $permission1 = Permission::create(['name' => 'articles.edit', 'guard_name' => 'api']);
+        $permission3 = Permission::create(['name' => 'news.*', 'guard_name' => 'api']);
+        $permission4 = Permission::create(['name' => 'posts.*', 'guard_name' => 'api']);
+
+        $user1->givePermissionTo([$permission1, $permission2, $permission3]);
+
+        $this->assertTrue($user1->hasPermissionTo($permission1));
+        $this->assertTrue($user1->hasPermissionTo($permission2));
+        $this->assertTrue($user1->hasPermissionTo($permission3));
+        $this->assertFalse($user1->hasPermissionTo($permission4));
+        $this->assertFalse($user1->hasPermissionTo('articles.edit'));
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
Added a behavior that uses by default the permission model's guard to execute the `implies` logic over a wildcard permission in `HasPermissions`'s `hasWildcardPermission()`. If it's not a model, then it uses the default guard.

[Linked discussion](https://github.com/spatie/laravel-permission/discussions/2596) to this PR.

Fixes #2596 