### PR TITLE
feat(Roles): Support for casting role names to enums

### DIFF
--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -59,6 +59,10 @@ class HasRolesTest extends TestCase
         $this->assertFalse($this->testUser->hasRole($enum2));
         $this->assertFalse($this->testUser->hasRole($enum3));
         $this->assertFalse($this->testUser->hasRole($enum4));
+        $this->assertFalse($this->testUser->hasRole('user-manager'));
+        $this->assertFalse($this->testUser->hasRole('writer'));
+        $this->assertFalse($this->testUser->hasRole('casted_enum-1'));
+        $this->assertFalse($this->testUser->hasRole('casted_enum-2'));
 
         $this->testUser->assignRole($enum1);
         $this->testUser->assignRole($enum2);
@@ -70,10 +74,16 @@ class HasRolesTest extends TestCase
         $this->assertTrue($this->testUser->hasRole($enum3));
         $this->assertTrue($this->testUser->hasRole($enum4));
 
+        $this->assertTrue($this->testUser->hasRole([$enum1, 'writer']));
+        $this->assertTrue($this->testUser->hasRole([$enum3, 'casted_enum-2']));
+
         $this->assertTrue($this->testUser->hasAllRoles([$enum1, $enum2, $enum3, $enum4]));
+        $this->assertTrue($this->testUser->hasAllRoles(['user-manager', 'writer', 'casted_enum-1', 'casted_enum-2']));
         $this->assertFalse($this->testUser->hasAllRoles([$enum1, $enum2, $enum3, $enum4, 'not exist']));
+        $this->assertFalse($this->testUser->hasAllRoles(['user-manager', 'writer', 'casted_enum-1', 'casted_enum-2', 'not exist']));
 
         $this->assertTrue($this->testUser->hasExactRoles([$enum4, $enum3, $enum2, $enum1]));
+        $this->assertTrue($this->testUser->hasExactRoles(['user-manager', 'writer', 'casted_enum-1', 'casted_enum-2']));
 
         $this->testUser->removeRole($enum1);
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -47,23 +47,33 @@ class HasRolesTest extends TestCase
     {
         $enum1 = TestModels\TestRolePermissionsEnum::USERMANAGER;
         $enum2 = TestModels\TestRolePermissionsEnum::WRITER;
+        $enum3 = TestModels\TestRolePermissionsEnum::CASTED_ENUM_1;
+        $enum4 = TestModels\TestRolePermissionsEnum::CASTED_ENUM_2;
 
         app(Role::class)->findOrCreate($enum1->value, 'web');
         app(Role::class)->findOrCreate($enum2->value, 'web');
+        app(Role::class)->findOrCreate($enum3->value, 'web');
+        app(Role::class)->findOrCreate($enum4->value, 'web');
 
         $this->assertFalse($this->testUser->hasRole($enum1));
         $this->assertFalse($this->testUser->hasRole($enum2));
+        $this->assertFalse($this->testUser->hasRole($enum3));
+        $this->assertFalse($this->testUser->hasRole($enum4));
 
         $this->testUser->assignRole($enum1);
         $this->testUser->assignRole($enum2);
+        $this->testUser->assignRole($enum3);
+        $this->testUser->assignRole($enum4);
 
         $this->assertTrue($this->testUser->hasRole($enum1));
         $this->assertTrue($this->testUser->hasRole($enum2));
+        $this->assertTrue($this->testUser->hasRole($enum3));
+        $this->assertTrue($this->testUser->hasRole($enum4));
 
-        $this->assertTrue($this->testUser->hasAllRoles([$enum1, $enum2]));
-        $this->assertFalse($this->testUser->hasAllRoles([$enum1, $enum2, 'not exist']));
+        $this->assertTrue($this->testUser->hasAllRoles([$enum1, $enum2, $enum3, $enum4]));
+        $this->assertFalse($this->testUser->hasAllRoles([$enum1, $enum2, $enum3, $enum4, 'not exist']));
 
-        $this->assertTrue($this->testUser->hasExactRoles([$enum2, $enum1]));
+        $this->assertTrue($this->testUser->hasExactRoles([$enum4, $enum3, $enum2, $enum1]));
 
         $this->testUser->removeRole($enum1);
 

--- a/tests/TestModels/Role.php
+++ b/tests/TestModels/Role.php
@@ -18,6 +18,20 @@ class Role extends \Spatie\Permission\Models\Role
     const HIERARCHY_TABLE = 'roles_hierarchy';
 
     /**
+     * @return string|\BackedEnum
+     */
+    public function getNameAttribute()
+    {
+        $name = $this->attributes['name'];
+
+        if (str_contains($name, 'casted_enum')) {
+            return TestRolePermissionsEnum::from($name);
+        }
+
+        return $name;
+    }
+
+    /**
      * @return BelongsToMany
      */
     public function parents()

--- a/tests/TestModels/TestRolePermissionsEnum.php
+++ b/tests/TestModels/TestRolePermissionsEnum.php
@@ -28,6 +28,8 @@ enum TestRolePermissionsEnum: string
     case EDITOR = 'editor';
     case USERMANAGER = 'user-manager';
     case ADMIN = 'administrator';
+    case CASTED_ENUM_1 = 'casted_enum-1';
+    case CASTED_ENUM_2 = 'casted_enum-2';
 
     case VIEWARTICLES = 'view articles';
     case EDITARTICLES = 'edit articles';


### PR DESCRIPTION
fixes #2609

It's more like a new feature because @schnetzi extended base **Role** model and did:
```php
protected $casts = [
    'name' => UserRoleEnum::class,
];
```

I used a custom accesor to dynamically cast it into the corresponding enum. Otherwise, it returns the original `name` attribute value.
```php
/**
 * @return string|\BackedEnum
 */
public function getNameAttribute()
{
    $name = $this->attributes['name'];

    if (str_contains($name, 'casted_enum')) {
        return TestRolePermissionsEnum::from($name);
    }

    return $name;
}
```