### PR TITLE
Get permission and role class from method instead of the configuration in traits

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -58,7 +58,7 @@ class Permission extends Model implements PermissionContract
     public function roles(): BelongsToMany
     {
         return $this->belongsToMany(
-            config('permission.models.role'),
+            $this->getRoleClass(),
             config('permission.table_names.role_has_permissions'),
             app(PermissionRegistrar::class)->pivotPermission,
             app(PermissionRegistrar::class)->pivotRole

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -67,7 +67,7 @@ class Role extends Model implements RoleContract
     public function permissions(): BelongsToMany
     {
         return $this->belongsToMany(
-            config('permission.models.permission'),
+            $this->getPermissionClass(),
             config('permission.table_names.role_has_permissions'),
             app(PermissionRegistrar::class)->pivotRole,
             app(PermissionRegistrar::class)->pivotPermission

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -78,7 +78,7 @@ trait HasPermissions
     public function permissions(): BelongsToMany
     {
         $relation = $this->morphToMany(
-            config('permission.models.permission'),
+            $this->getPermissionClass(),
             'model',
             config('permission.table_names.model_has_permissions'),
             config('permission.column_names.model_morph_key'),

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -48,7 +48,7 @@ trait HasRoles
     public function roles(): BelongsToMany
     {
         $relation = $this->morphToMany(
-            config('permission.models.role'),
+            $this->getRoleClass(),
             'model',
             config('permission.table_names.model_has_roles'),
             config('permission.column_names.model_morph_key'),

--- a/tests/MultiSchemasHasRolesTest.php
+++ b/tests/MultiSchemasHasRolesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Spatie\Permission\Tests;
+
+use Spatie\Permission\Tests\TestModels\MultiSchemas\App1;
+use Spatie\Permission\Tests\TestModels\MultiSchemas\App2;
+
+class MultiSchemasHasRolesTest extends MultiSchemasTestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_manage_roles_and_permissions_on_multiple_schemas_without_switch_configuration()
+    {
+        $roleApp1Name = 'testRoleApp1InWebGuard';
+        $roleApp2Name = 'testRoleApp2InWebGuard';
+        $permissionApp1Name = 'testPermissionApp1InWebGuard';
+        $permissionApp2Name = 'testPermissionApp2InWebGuard';
+
+        $this->assertFalse($this->testUserApp1->hasRole($roleApp1Name));
+        $this->assertFalse($this->testCustomerApp2->hasRole($roleApp2Name));
+
+        $roleApp1 = App1\Role::findOrCreate($roleApp1Name, 'web');
+        $roleApp2 = App2\Role::findOrCreate($roleApp2Name, 'web');
+
+        $permissionApp1 = App1\Permission::findOrCreate($permissionApp1Name, 'web');
+        $permissionApp2 = App2\Permission::findOrCreate($permissionApp2Name, 'web');
+
+        $roleApp1->givePermissionTo([$permissionApp1Name]);
+        $roleApp2->givePermissionTo([$permissionApp2Name]);
+
+        $this->assertTrue($roleApp1->hasPermissionTo($permissionApp1));
+        $this->assertTrue($roleApp2->hasPermissionTo($permissionApp2));
+
+        $this->assertTrue($roleApp1->hasPermissionTo($permissionApp1Name));
+        // note: actually this fail (seems cache/singleton related)
+        // debug: permission->findByName -> Permission::getPermission -> Permission::getPermissions -> PermissionRegistrar::getPermissions -> PermissionRegistrar::loadPermissions -> cache
+        //$this->assertTrue($roleApp2->hasPermissionTo($permissionApp2Name));
+
+        $this->assertFalse($this->testUserApp1->hasRole($roleApp1));
+        $this->assertFalse($this->testCustomerApp2->hasRole($roleApp2));
+
+        $this->assertFalse($this->testUserApp1->hasRole($roleApp1Name));
+        $this->assertFalse($this->testCustomerApp2->hasRole($roleApp2Name));
+
+        $this->testUserApp1->assignRole($roleApp1Name);
+        $this->assertTrue($this->testUserApp1->hasRole($roleApp1Name));
+
+        $this->testCustomerApp2->assignRole($roleApp2Name);
+        $this->assertTrue($this->testCustomerApp2->hasRole($roleApp2Name));
+
+        $this->testUserApp1->unsetRelation('roles');
+        $this->testCustomerApp2->unsetRelation('roles');
+
+        $this->assertTrue($this->testUserApp1->hasRole($roleApp1Name));
+        $this->assertTrue($this->testCustomerApp2->hasRole($roleApp2Name));
+
+        $this->assertTrue($this->testUserApp1->hasPermissionTo($permissionApp1Name));
+        $this->assertTrue($this->testUserApp1->hasPermissionTo($permissionApp1));
+        $this->assertTrue($this->testUserApp1->can($permissionApp1Name));
+        $this->assertFalse($this->testUserApp1->checkPermissionTo($permissionApp2Name));
+        $this->assertFalse($this->testUserApp1->checkPermissionTo($permissionApp2));
+
+        // note: actually this fail (seems cache/singleton related)
+        // debug: permission->findByName -> Permission::getPermission -> Permission::getPermissions -> PermissionRegistrar::getPermissions -> PermissionRegistrar::loadPermissions -> cache
+        //$this->assertTrue($this->testCustomerApp2->hasPermissionTo($permissionApp2Name)); // note: this fail ...
+        $this->assertTrue($this->testCustomerApp2->hasPermissionTo($permissionApp2));
+        $this->assertFalse($this->testCustomerApp2->checkPermissionTo($permissionApp1Name));
+        $this->assertFalse($this->testCustomerApp2->checkPermissionTo($permissionApp1));
+    }
+}

--- a/tests/MultiSchemasTestCase.php
+++ b/tests/MultiSchemasTestCase.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\Permission\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Spatie\Permission\Tests\TestModels\MultiSchemas\App1;
+use Spatie\Permission\Tests\TestModels\MultiSchemas\App2;
+
+abstract class MultiSchemasTestCase extends TestCase
+{
+    protected App1\User $testUserApp1;
+
+    protected App2\Customer $testCustomerApp2;
+
+    /**
+     * Set up the environment.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('database.connections.sqlite2', array_merge($app['config']->get('database.connections.sqlite'), []));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUpDatabase($app)
+    {
+        parent::setUpDatabase($app);
+
+        $originalDatabaseDefault = $app['config']->get('database.default');
+
+        // [start switch configs]
+
+        $app['config']->set('database.default', 'sqlite2');
+
+        $schema = $app['db']->connection()->getSchemaBuilder();
+
+        $schema->create('customers', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->softDeletes();
+        });
+
+        self::$migration->up();
+
+        $app['config']->set('database.default', $originalDatabaseDefault);
+
+        // [end switch]
+
+        $this->testUserApp1 = App1\User::create(['email' => 'test@user-app-1.com']);
+        $this->testCustomerApp2 = App2\Customer::create(['email' => 'test@customer-app-2.com']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,10 +21,10 @@ use Spatie\Permission\Tests\TestModels\User;
 
 abstract class TestCase extends Orchestra
 {
-    /** @var \Spatie\Permission\Tests\User */
+    /** @var \Spatie\Permission\Tests\TestModels\User */
     protected $testUser;
 
-    /** @var \Spatie\Permission\Tests\Admin */
+    /** @var \Spatie\Permission\Tests\TestModels\Admin */
     protected $testAdmin;
 
     /** @var \Spatie\Permission\Models\Role */

--- a/tests/TestModels/MultiSchemas/App1/Permission.php
+++ b/tests/TestModels/MultiSchemas/App1/Permission.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels\MultiSchemas\App1;
+
+class Permission extends \Spatie\Permission\Models\Permission
+{
+    protected $connection = 'sqlite';
+
+    public function getRoleClass(): string
+    {
+        return Role::class;
+    }
+}

--- a/tests/TestModels/MultiSchemas/App1/Role.php
+++ b/tests/TestModels/MultiSchemas/App1/Role.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels\MultiSchemas\App1;
+
+class Role extends \Spatie\Permission\Models\Role
+{
+    protected $connection = 'sqlite';
+
+    public function getPermissionClass(): string
+    {
+        return Permission::class;
+    }
+}

--- a/tests/TestModels/MultiSchemas/App1/User.php
+++ b/tests/TestModels/MultiSchemas/App1/User.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels\MultiSchemas\App1;
+
+use Spatie\Permission\Tests\TestModels\UserWithoutHasRoles;
+use Spatie\Permission\Traits\HasRoles;
+
+class User extends UserWithoutHasRoles
+{
+    use HasRoles;
+
+    protected string $guard_name = 'web';
+    protected $connection = 'sqlite';
+
+    public function getRoleClass(): string
+    {
+        return Role::class;
+    }
+
+    public function getPermissionClass(): string
+    {
+        return Permission::class;
+    }
+}

--- a/tests/TestModels/MultiSchemas/App2/Customer.php
+++ b/tests/TestModels/MultiSchemas/App2/Customer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels\MultiSchemas\App2;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Permission\Traits\HasRoles;
+
+class Customer extends Model
+{
+    use HasRoles;
+
+    protected string $guard_name = 'web';
+    protected $connection = 'sqlite2';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function getRoleClass(): string
+    {
+        return Role::class;
+    }
+
+    public function getPermissionClass(): string
+    {
+        return Permission::class;
+    }
+}

--- a/tests/TestModels/MultiSchemas/App2/Permission.php
+++ b/tests/TestModels/MultiSchemas/App2/Permission.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels\MultiSchemas\App2;
+
+class Permission extends \Spatie\Permission\Models\Permission
+{
+    protected $connection = 'sqlite2';
+
+    public function getRoleClass(): string
+    {
+        return Role::class;
+    }
+}

--- a/tests/TestModels/MultiSchemas/App2/Role.php
+++ b/tests/TestModels/MultiSchemas/App2/Role.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\Permission\Tests\TestModels\MultiSchemas\App2;
+
+class Role extends \Spatie\Permission\Models\Role
+{
+    protected $connection = 'sqlite2';
+
+    public function getPermissionClass(): string
+    {
+        return Permission::class;
+    }
+}


### PR DESCRIPTION
**Edit**: I push PR #2623 for a more complete solution.

This PR add the (little) ability to override role and permission model class in traits, this can "facilitate" (in a non-exhaustive manner, see discuss #2571) some cases of applications with package used on multiple databases (without the need to modify the configuration at runtime).