### PR TITLE
[feat] simplify the definition of multiple Blade "if" directives

### DIFF
--- a/docs/advanced-usage/uuid.md
+++ b/docs/advanced-usage/uuid.md
@@ -1,13 +1,15 @@
 ---
-title: UUID
+title: UUID/ULID
 weight: 7
 ---
 
-If you're using UUIDs for your User models there are a few considerations to note.
+If you're using UUIDs (ULID, GUID, etc) for your User models or Role/Permission models there are a few considerations to note.
 
-> THIS IS NOT A FULL LESSON ON HOW TO IMPLEMENT UUIDs IN YOUR APP.
+> NOTE: THIS IS NOT A FULL LESSON ON HOW TO IMPLEMENT UUIDs IN YOUR APP.
 
 Since each UUID implementation approach is different, some of these may or may not benefit you. As always, your implementation may vary.
+
+We use "uuid" in the examples below. Adapt for ULID or GUID as needed.
 
 ## Migrations
 You will need to update the `create_permission_tables.php` migration after creating it with `php artisan vendor:publish`. After making your edits, be sure to run the migration!

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -124,30 +124,19 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerBladeExtensions($bladeCompiler): void
     {
+        /** @var BladeCompiler $bladeCompiler */
         $bladeMethodWrapper = '\\Spatie\\Permission\\PermissionServiceProvider::bladeMethodWrapper';
 
-        $bladeCompiler->directive('role', fn ($args) => "<?php if({$bladeMethodWrapper}('hasRole', {$args})): ?>");
-        $bladeCompiler->directive('elserole', fn ($args) => "<?php elseif({$bladeMethodWrapper}('hasRole', {$args})): ?>");
-        $bladeCompiler->directive('endrole', fn () => '<?php endif; ?>');
+        // permission checks
+        $bladeCompiler->if('haspermission', fn ($args) => $bladeMethodWrapper('checkPermissionTo', $args));
 
-        $bladeCompiler->directive('haspermission', fn ($args) => "<?php if({$bladeMethodWrapper}('checkPermissionTo', {$args})): ?>");
-        $bladeCompiler->directive('elsehaspermission', fn ($args) => "<?php elseif({$bladeMethodWrapper}('checkPermissionTo', {$args})): ?>");
-        $bladeCompiler->directive('endhaspermission', fn () => '<?php endif; ?>');
-
-        $bladeCompiler->directive('hasrole', fn ($args) => "<?php if({$bladeMethodWrapper}('hasRole', {$args})): ?>");
-        $bladeCompiler->directive('endhasrole', fn () => '<?php endif; ?>');
-
-        $bladeCompiler->directive('hasanyrole', fn ($args) => "<?php if({$bladeMethodWrapper}('hasAnyRole', {$args})): ?>");
-        $bladeCompiler->directive('endhasanyrole', fn () => '<?php endif; ?>');
-
-        $bladeCompiler->directive('hasallroles', fn ($args) => "<?php if({$bladeMethodWrapper}('hasAllRoles', {$args})): ?>");
-        $bladeCompiler->directive('endhasallroles', fn () => '<?php endif; ?>');
-
-        $bladeCompiler->directive('unlessrole', fn ($args) => "<?php if(! {$bladeMethodWrapper}('hasRole', {$args})): ?>");
-        $bladeCompiler->directive('endunlessrole', fn () => '<?php endif; ?>');
-
-        $bladeCompiler->directive('hasexactroles', fn ($args) => "<?php if({$bladeMethodWrapper}('hasExactRoles', {$args})): ?>");
-        $bladeCompiler->directive('endhasexactroles', fn () => '<?php endif; ?>');
+        // role checks
+        $bladeCompiler->if('role', fn ($args) => $bladeMethodWrapper('hasRole', $args));
+        $bladeCompiler->if('hasrole', fn ($args) => $bladeMethodWrapper('hasRole', $args));
+        $bladeCompiler->if('hasanyrole', fn ($args) => $bladeMethodWrapper('hasAnyRole', $args));
+        $bladeCompiler->if('hasanyrole', fn ($args) => $bladeMethodWrapper('hasAnyRole', $args));
+        $bladeCompiler->if('hasallroles', fn ($args) => $bladeMethodWrapper('hasAllRoles', $args));
+        $bladeCompiler->if('hasexactroles', fn ($args) => $bladeMethodWrapper('hasExactRoles', $args));
     }
 
     protected function registerMacroHelpers(): void


### PR DESCRIPTION
Hi,

This pull request simplifies the definition of a Blade directive. documentation on custom Blade directives [here](https://laravel.com/docs/10.x/blade#custom-if-statements).

This change adds support for the following directives:

- `@haspermission`, `@unlesshaspermission`, `@elsehaspermission`, `@endhaspermission`
- `@role`, `@unlessrole`, `@elserole`, `@endrole`
- `@hasrole`, `@unlesshasrole`, `@elsehasrole`, `@endhasrole` (and keeps previous `@endunlessrole`)
- `@hasanyrole`, `@unlesshasanyrole`, `@elsehasanyrole`, `@endhasanyrole`
- `@hasallroles`, `@unlesshasallroles`, `@elsehasallroles`, `@endhasallroles`
- `@hasexactroles`, `@unlesshasexactroles`, `@elsehasexactroles`, `@endhasexactroles`
