### PR TITLE
Fix wrong octane event listener

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -96,7 +96,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         $dispatcher = $this->app[Dispatcher::class];
         // @phpstan-ignore-next-line
-        $dispatcher->listen(function (\Laravel\Octane\Events\OperationTerminated $event) {
+        $dispatcher->listen(function (\Laravel\Octane\Contracts\OperationTerminated $event) {
             // @phpstan-ignore-next-line
             $event->sandbox->make(PermissionRegistrar::class)->setPermissionsTeamId(null);
         });


### PR DESCRIPTION
Closes #2599
>changing `\Laravel\Octane\Events\OperationTerminated` to `\Laravel\Octane\Contracts\OperationTerminated` works.