### PR TITLE
Fix can't save the same model twice

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -401,14 +401,16 @@ trait HasPermissions
             $model->unsetRelation('permissions');
         } else {
             $class = \get_class($model);
+            $saved = false;
 
             $class::saved(
-                function ($object) use ($permissions, $model, $teamPivot) {
-                    if ($model->getKey() != $object->getKey()) {
+                function ($object) use ($permissions, $model, $teamPivot, &$saved) {
+                    if ($saved || $model->getKey() != $object->getKey()) {
                         return;
                     }
                     $model->permissions()->attach($permissions, $teamPivot);
                     $model->unsetRelation('permissions');
+                    $saved = true;
                 }
             );
         }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -159,14 +159,16 @@ trait HasRoles
             $model->unsetRelation('roles');
         } else {
             $class = \get_class($model);
+            $saved = false;
 
             $class::saved(
-                function ($object) use ($roles, $model, $teamPivot) {
-                    if ($model->getKey() != $object->getKey()) {
+                function ($object) use ($roles, $model, $teamPivot, &$saved) {
+                    if ($saved || $model->getKey() != $object->getKey()) {
                         return;
                     }
                     $model->roles()->attach($roles, $teamPivot);
                     $model->unsetRelation('roles');
+                    $saved = true;
                 }
             );
         }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -636,6 +636,7 @@ class HasPermissionsTest extends TestCase
         $user = new User(['email' => 'test@user.com']);
         $user->syncPermissions('edit-articles');
         $user->save();
+        $user->save(); // test save same model twice 
 
         $this->assertTrue($user->hasPermissionTo('edit-articles'));
 

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -341,6 +341,7 @@ class HasRolesTest extends TestCase
         $user = new User(['email' => 'test@user.com']);
         $user->syncRoles([$this->testUserRole]);
         $user->save();
+        $user->save(); // test save same model twice 
 
         $this->assertTrue($user->hasRole($this->testUserRole));
 


### PR DESCRIPTION
- Closes #2638

~This doesn't solve the problem completely~ **Another approach seems to work**
 
```php
$user->save();
//$user = $user->fresh();
$user->save();
```
