### PR TITLE
[v7] Update Role contract to match implementation and fix PhpStan errors

### DIFF
--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -24,7 +24,7 @@ interface Role
      *
      * @throws \Spatie\Permission\Exceptions\RoleDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName): self;
+    public static function findByName(string $name, ?string $guardName = null): self;
 
     /**
      * Find a role by its id and guard name.
@@ -32,17 +32,17 @@ interface Role
      *
      * @throws \Spatie\Permission\Exceptions\RoleDoesNotExist
      */
-    public static function findById(int|string $id, ?string $guardName): self;
+    public static function findById(int|string $id, ?string $guardName = null): self;
 
     /**
      * Find or create a role by its name and guard name.
      */
-    public static function findOrCreate(string $name, ?string $guardName): self;
+    public static function findOrCreate(string $name, ?string $guardName = null): self;
 
     /**
      * Determine if the user may perform the given permission.
      *
-     * @param  string|\Spatie\Permission\Contracts\Permission  $permission
+     * @param  string|\Spatie\Permission\Contracts\Permission|\BackedEnum  $permission
      */
-    public function hasPermissionTo($permission, ?string $guardName): bool;
+    public function hasPermissionTo($permission, ?string $guardName = null): bool;
 }


### PR DESCRIPTION
Allow BackedEnum and set default guardName

Fixes the following PhpStan error:
```
 ------ -------------------------------------------------------------------- 
  Line   app/Console/Commands/EnsureRolesAndPermissionsAreSetCommand.php     
 ------ -------------------------------------------------------------------- 
  29     Method Spatie\Permission\Contracts\Role::hasPermissionTo() invoked  
         with 1 parameter, 2 required.                                       
         ✏️  app/Console/Commands/EnsureRolesAndPermissionsAreSetCommand.php  
  29     Parameter #1 $permission of method                                  
         Spatie\Permission\Contracts\Role::hasPermissionTo() expects         
         Spatie\Permission\Contracts\Permission|string,                      
         App\Enums\Permissions\PermissionEnum::LOGIN_AS_ANY given.           
         ✏️  app/Console/Commands/EnsureRolesAndPermissionsAreSetCommand.php  
 ------ -------------------------------------------------------------------- 
```

caused by this line in my application:
`$role->hasPermissionTo(PermissionEnum::LOGIN_AS_ANY)`

I am passing an enum instance which is allowed according to the docs, and works, but the interface Docblock does not support this. The other error says I am required to pass two parameters, while the second param (`$guardName`) is optional according to the implementations, but not according to the interface 