### PR TITLE
Use ->withPivot() for teamed relationships

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -89,7 +89,10 @@ trait HasPermissions
             return $relation;
         }
 
-        return $relation->wherePivot(app(PermissionRegistrar::class)->teamsKey, getPermissionsTeamId());
+        $teamsKey = app(PermissionRegistrar::class)->teamsKey;
+        $relation->withPivot($teamsKey);
+
+        return $relation->wherePivot($teamsKey, getPermissionsTeamId());
     }
 
     /**

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -55,16 +55,12 @@ trait HasRoles
             app(PermissionRegistrar::class)->pivotRole
         );
 
-        $teamsKey = app(PermissionRegistrar::class)->teamsKey;
-
-        if ($teamsKey) {
-            $relation->withPivot($teamsKey);
-        }
-
         if (! app(PermissionRegistrar::class)->teams) {
             return $relation;
         }
-
+        
+        $teamsKey = app(PermissionRegistrar::class)->teamsKey;
+        $relation->withPivot($teamsKey);
         $teamField = config('permission.table_names.roles').'.'.$teamsKey;
 
         return $relation->wherePivot($teamsKey, getPermissionsTeamId())

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -55,13 +55,19 @@ trait HasRoles
             app(PermissionRegistrar::class)->pivotRole
         );
 
+        $teamsKey = app(PermissionRegistrar::class)->teamsKey;
+
+        if ($teamsKey) {
+            $relation->withPivot($teamsKey);
+        }
+
         if (! app(PermissionRegistrar::class)->teams) {
             return $relation;
         }
 
-        $teamField = config('permission.table_names.roles').'.'.app(PermissionRegistrar::class)->teamsKey;
+        $teamField = config('permission.table_names.roles').'.'.$teamsKey;
 
-        return $relation->wherePivot(app(PermissionRegistrar::class)->teamsKey, getPermissionsTeamId())
+        return $relation->wherePivot($teamsKey, getPermissionsTeamId())
             ->where(fn ($q) => $q->whereNull($teamField)->orWhere($teamField, getPermissionsTeamId()));
     }
 


### PR DESCRIPTION
The previous implementation is giving me issues when querying ->getPivotColumns() for example. It should probably use ->withPivot() to indicate there is a pivot value.