### PR TITLE
Check for 'all' or 'any' permissions before specific permissions

### DIFF
--- a/docs/best-practices/using-policies.md
+++ b/docs/best-practices/using-policies.md
@@ -49,23 +49,23 @@ class PostPolicy
 
     public function update(User $user, Post $post)
     {
-        if ($user->can('edit own posts')) {
-            return $user->id == $post->user_id;
-        }
-
         if ($user->can('edit all posts')) {
             return true;
+        }
+
+        if ($user->can('edit own posts')) {
+            return $user->id == $post->user_id;
         }
     }
 
     public function delete(User $user, Post $post)
     {
-        if ($user->can('delete own posts')) {
-            return $user->id == $post->user_id;
-        }
-
         if ($user->can('delete any post')) {
             return true;
+        }
+
+        if ($user->can('delete own posts')) {
+            return $user->id == $post->user_id;
         }
     }
 }


### PR DESCRIPTION
Shouldn't the check for `edit all posts` or `delete any post` be done first, before checking if a user can edit or delete their own posts?

The original code checked if the user can edit their own posts and, if so, would return false if they were not the post author, **even though they have the permission to edit any post**.

By performing the `all`/`any` check first, these permissions still work correctly when the user also has permissions to edit or delete their own posts.