### PR TITLE
Do not show as error when no cache exists

### DIFF
--- a/src/Commands/CacheReset.php
+++ b/src/Commands/CacheReset.php
@@ -13,10 +13,8 @@ class CacheReset extends Command
 
     public function handle()
     {
-        if (app(PermissionRegistrar::class)->forgetCachedPermissions()) {
-            $this->info('Permission cache flushed.');
-        } else {
-            $this->error('Unable to flush cache.');
-        }
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        
+        $this->info('Permission cache flushed successfully.');
     }
 }


### PR DESCRIPTION
I refresh the permission cache on each application deploy.

However this sometimes results in a error, e.g. when the cache hasn't been created yet.

I don't think the check is needed here. :)