### PR TITLE
Only show error if cache key exists and forgetCachedPermissions fails

### DIFF
--- a/src/Commands/CacheReset.php
+++ b/src/Commands/CacheReset.php
@@ -13,9 +13,12 @@ class CacheReset extends Command
 
     public function handle()
     {
-        if (app(PermissionRegistrar::class)->forgetCachedPermissions()) {
+        $permissionRegistrar = app(PermissionRegistrar::class);
+        $cacheExists = $permissionRegistrar->getCacheRepository()->has($permissionRegistrar->cacheKey);
+
+        if ($permissionRegistrar->forgetCachedPermissions()) {
             $this->info('Permission cache flushed.');
-        } else {
+        } else if ($cacheExists) {
             $this->error('Unable to flush cache.');
         }
     }


### PR DESCRIPTION
Alternative to and closes #2702

>I refresh the permission cache on each application deploy.
>However this sometimes results in a error, e.g. when the cache hasn't been created yet.
>I don't think the check is needed here. :)