### PR TITLE
[Docs] use more modern syntax for nullable return type

### DIFF
--- a/docs/basic-usage/super-admin.md
+++ b/docs/basic-usage/super-admin.md
@@ -51,7 +51,7 @@ use App\Models\User; // could be any Authorizable model
 /**
  * Perform pre-authorization checks on the model.
  */
-public function before(User $user, string $ability): bool|null
+public function before(User $user, string $ability): ?bool
 {
     if ($user->hasRole('Super Admin')) {
         return true;


### PR DESCRIPTION
This pull request updates the return type of the `before` method in the docs from `bool|null` to `?bool`. This change ensures that the method correctly reflects its possible return values, including true, false, and null.