### PR TITLE
4 events for adding and removing roles or permissions

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -111,6 +111,17 @@ return [
     'register_octane_reset_listener' => false,
 
     /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
      * Teams Feature.
      * When set to true the package implements teams using the 'team_foreign_key'.
      * If you want the migrations to register the 'team_foreign_key', you must

--- a/src/Events/PermissionAttached.php
+++ b/src/Events/PermissionAttached.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PermissionAttached
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public Model $model)
+    {}
+}

--- a/src/Events/PermissionAttached.php
+++ b/src/Events/PermissionAttached.php
@@ -8,6 +8,8 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Spatie\Permission\Contracts\Permission;
 
 class PermissionAttached
 {
@@ -15,6 +17,12 @@ class PermissionAttached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model, public array $permissionIds)
-    {}
+    /**
+     * Internally the HasPermissions trait passes an array of permission ids (eg: int's or uuid's)
+     * Theoretically one could register the event to other places and pass an Eloquent record.
+     * So a Listener should inspect the type of $permissionsOrIds received before using.
+     *
+     * @param  array|int[]|string[]|Permission|Permission[]|Collection  $permissionsOrIds
+     */
+    public function __construct(public Model $model, public mixed $permissionsOrIds) {}
 }

--- a/src/Events/PermissionAttached.php
+++ b/src/Events/PermissionAttached.php
@@ -15,6 +15,6 @@ class PermissionAttached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model)
+    public function __construct(public Model $model, public array $permissionIds)
     {}
 }

--- a/src/Events/PermissionDetached.php
+++ b/src/Events/PermissionDetached.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PermissionDetached
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public Model $model)
+    {}
+}

--- a/src/Events/PermissionDetached.php
+++ b/src/Events/PermissionDetached.php
@@ -18,9 +18,11 @@ class PermissionDetached
     use SerializesModels;
 
     /**
-     * @param Model $model
-     * @param Permission|Permission[]|Collection $permission
+     * Internally the HasPermissions trait passes $permissionsOrIds as an Eloquent record.
+     * Theoretically one could register the event to other places and pass an array etc.
+     * So a Listener should inspect the type of $permissionsOrIds received before using.
+     *
+     * @param  array|int[]|string[]|Permission|Permission[]|Collection  $permissionsOrIds
      */
-    public function __construct(public Model $model, public mixed $permission)
-    {}
+    public function __construct(public Model $model, public mixed $permissionsOrIds) {}
 }

--- a/src/Events/PermissionDetached.php
+++ b/src/Events/PermissionDetached.php
@@ -8,6 +8,8 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Spatie\Permission\Contracts\Permission;
 
 class PermissionDetached
 {
@@ -15,6 +17,10 @@ class PermissionDetached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model)
+    /**
+     * @param Model $model
+     * @param Permission|Permission[]|Collection $permission
+     */
+    public function __construct(public Model $model, public mixed $permission)
     {}
 }

--- a/src/Events/RoleAttached.php
+++ b/src/Events/RoleAttached.php
@@ -15,6 +15,6 @@ class RoleAttached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model)
+    public function __construct(public Model $model, public array $roleIds)
     {}
 }

--- a/src/Events/RoleAttached.php
+++ b/src/Events/RoleAttached.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class RoleAttached
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public Model $model)
+    {}
+}

--- a/src/Events/RoleAttached.php
+++ b/src/Events/RoleAttached.php
@@ -8,6 +8,8 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Spatie\Permission\Contracts\Role;
 
 class RoleAttached
 {
@@ -15,6 +17,12 @@ class RoleAttached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model, public array $roleIds)
-    {}
+    /**
+     * Internally the HasRoles trait passes an array of role ids (eg: int's or uuid's)
+     * Theoretically one could register the event to other places passing other types
+     * So a Listener should inspect the type of $rolesOrIds received before using.
+     *
+     * @param  array|int[]|string[]|Role|Role[]|Collection  $rolesOrIds
+     */
+    public function __construct(public Model $model, public mixed $rolesOrIds) {}
 }

--- a/src/Events/RoleDetached.php
+++ b/src/Events/RoleDetached.php
@@ -8,6 +8,7 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Spatie\Permission\Contracts\Role;
 
 class RoleDetached
 {
@@ -15,6 +16,6 @@ class RoleDetached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model)
+    public function __construct(public Model $model, public Role $role)
     {}
 }

--- a/src/Events/RoleDetached.php
+++ b/src/Events/RoleDetached.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spatie\Permission\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class RoleDetached
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(public Model $model)
+    {}
+}

--- a/src/Events/RoleDetached.php
+++ b/src/Events/RoleDetached.php
@@ -8,6 +8,7 @@ use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Role;
 
 class RoleDetached
@@ -16,6 +17,12 @@ class RoleDetached
     use InteractsWithSockets;
     use SerializesModels;
 
-    public function __construct(public Model $model, public Role $role)
-    {}
+    /**
+     * Internally the HasRoles trait passes $rolesOrIds as a single  Eloquent record
+     * Theoretically one could register the event to other places with an array etc
+     * So a Listener should inspect the type of $rolesOrIds received before using.
+     *
+     * @param  array|int[]|string[]|Role|Role[]|Collection  $rolesOrIds
+     */
+    public function __construct(public Model $model, public mixed $rolesOrIds) {}
 }

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -425,7 +425,9 @@ trait HasPermissions
             $this->forgetCachedPermissions();
         }
 
-        event(new PermissionAttached($this->getModel(), $permissions));
+        if (config('permission.events_enabled')) {
+            event(new PermissionAttached($this->getModel(), $permissions));
+        }
 
         $this->forgetWildcardPermissionIndex();
 
@@ -472,7 +474,9 @@ trait HasPermissions
             $this->forgetCachedPermissions();
         }
 
-        event(new PermissionDetached($this->getModel(), $storedPermission));
+        if (config('permission.events_enabled')) {
+            event(new PermissionDetached($this->getModel(), $storedPermission));
+        }
 
         $this->forgetWildcardPermissionIndex();
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Contracts\Wildcard;
+use Spatie\Permission\Events\PermissionAttached;
+use Spatie\Permission\Events\PermissionDetached;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
@@ -422,6 +424,8 @@ trait HasPermissions
             $this->forgetCachedPermissions();
         }
 
+        event(new PermissionAttached($this->getModel()));
+
         $this->forgetWildcardPermissionIndex();
 
         return $this;
@@ -464,6 +468,8 @@ trait HasPermissions
         if (is_a($this, Role::class)) {
             $this->forgetCachedPermissions();
         }
+
+        event(new PermissionDetached($this->getModel()));
 
         $this->forgetWildcardPermissionIndex();
 

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -424,7 +424,7 @@ trait HasPermissions
             $this->forgetCachedPermissions();
         }
 
-        event(new PermissionAttached($this->getModel()));
+        event(new PermissionAttached($this->getModel(), $permissions));
 
         $this->forgetWildcardPermissionIndex();
 
@@ -463,13 +463,15 @@ trait HasPermissions
      */
     public function revokePermissionTo($permission)
     {
-        $this->permissions()->detach($this->getStoredPermission($permission));
+        $storedPermission = $this->getStoredPermission($permission);
+
+        $this->permissions()->detach($storedPermission);
 
         if (is_a($this, Role::class)) {
             $this->forgetCachedPermissions();
         }
 
-        event(new PermissionDetached($this->getModel()));
+        event(new PermissionDetached($this->getModel(), $storedPermission));
 
         $this->forgetWildcardPermissionIndex();
 

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Events\RoleAttached;
+use Spatie\Permission\Events\RoleDetached;
 use Spatie\Permission\PermissionRegistrar;
 
 trait HasRoles
@@ -179,6 +181,8 @@ trait HasRoles
             $this->forgetCachedPermissions();
         }
 
+        event(new RoleAttached($this->getModel()));
+
         return $this;
     }
 
@@ -196,6 +200,8 @@ trait HasRoles
         if (is_a($this, Permission::class)) {
             $this->forgetCachedPermissions();
         }
+
+        event(new RoleDetached($this->getModel()));
 
         return $this;
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -181,7 +181,7 @@ trait HasRoles
             $this->forgetCachedPermissions();
         }
 
-        event(new RoleAttached($this->getModel()));
+        event(new RoleAttached($this->getModel(), $roles));
 
         return $this;
     }
@@ -193,7 +193,9 @@ trait HasRoles
      */
     public function removeRole($role)
     {
-        $this->roles()->detach($this->getStoredRole($role));
+        $storedRole = $this->getStoredRole($role);
+
+        $this->roles()->detach($storedRole);
 
         $this->unsetRelation('roles');
 
@@ -201,7 +203,7 @@ trait HasRoles
             $this->forgetCachedPermissions();
         }
 
-        event(new RoleDetached($this->getModel()));
+        event(new RoleDetached($this->getModel(), $storedRole));
 
         return $this;
     }

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -178,7 +178,9 @@ trait HasRoles
             $this->forgetCachedPermissions();
         }
 
-        event(new RoleAttached($this->getModel(), $roles));
+        if (config('permission.events_enabled')) {
+            event(new RoleAttached($this->getModel(), $roles));
+        }
 
         return $this;
     }
@@ -200,7 +202,9 @@ trait HasRoles
             $this->forgetCachedPermissions();
         }
 
-        event(new RoleDetached($this->getModel(), $storedRole));
+        if (config('permission.events_enabled')) {
+            event(new RoleDetached($this->getModel(), $storedRole));
+        }
 
         return $this;
     }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -833,7 +833,8 @@ class HasPermissionsTest extends TestCase
     public function it_fires_an_event_when_a_permission_is_added()
     {
         Event::fake();
-
+        app('config')->set('permission.events_enabled', true);
+        
         $this->testUser->givePermissionTo(['edit-articles', 'edit-news']);
 
         $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-news'])
@@ -850,10 +851,27 @@ class HasPermissionsTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_does_not_fire_an_event_when_events_are_not_enabled()
+    {
+        Event::fake();
+        app('config')->set('permission.events_enabled', false);
+        
+        $this->testUser->givePermissionTo(['edit-articles', 'edit-news']);
+
+        $ids = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-news'])
+            ->pluck($this->testUserPermission->getKeyName())
+            ->toArray();
+
+        Event::assertNotDispatched(PermissionAttached::class);
+    }
+
+    /** @test */
+    #[Test]
     public function it_fires_an_event_when_a_permission_is_removed()
     {
         Event::fake();
-
+        app('config')->set('permission.events_enabled', true);
+        
         $permissions = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-news'])->get();
 
         $this->testUser->givePermissionTo($permissions);

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Events\PermissionAttached;
+use Spatie\Permission\Events\PermissionDetached;
 use Spatie\Permission\Events\RoleAttached;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
@@ -778,6 +779,20 @@ class HasPermissionsTest extends TestCase
 
         Event::assertDispatched(PermissionAttached::class, function ($event) {
             return $event->model instanceof User && $event->model->hasPermissionTo('edit-news');
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_when_a_permission_is_removed()
+    {
+        Event::fake();
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        $this->testUser->revokePermissionTo('edit-news');
+
+        Event::assertDispatched(PermissionDetached::class, function ($event) {
+            return $event->model instanceof User && !$event->model->hasPermissionTo('edit-news');
         });
     }
 }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -845,7 +845,7 @@ class HasPermissionsTest extends TestCase
             return $event->model instanceof User
                 && $event->model->hasPermissionTo('edit-news')
                 && $event->model->hasPermissionTo('edit-articles')
-                && $ids === $event->permissionIds;
+                && $ids === $event->permissionsOrIds;
         });
     }
 
@@ -882,7 +882,7 @@ class HasPermissionsTest extends TestCase
             return $event->model instanceof User
                 && !$event->model->hasPermissionTo('edit-news')
                 && !$event->model->hasPermissionTo('edit-articles')
-                && $event->permission === $permissions;
+                && $event->permissionsOrIds === $permissions;
         });
     }
   

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -3,8 +3,11 @@
 namespace Spatie\Permission\Tests;
 
 use DB;
+use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Events\PermissionAttached;
+use Spatie\Permission\Events\RoleAttached;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Tests\TestModels\SoftDeletingUser;
@@ -764,5 +767,17 @@ class HasPermissionsTest extends TestCase
         $response->assertJson([
             'status' => false,
         ]);
+    }
+
+    /** @test */
+    public function it_fires_an_event_when_a_permission_is_added()
+    {
+        Event::fake();
+
+        $this->testUser->givePermissionTo('edit-news');
+
+        Event::assertDispatched(PermissionAttached::class, function ($event) {
+            return $event->model instanceof User && $event->model->hasPermissionTo('edit-news');
+        });
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -3,7 +3,9 @@
 namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Role;
+use Spatie\Permission\Events\RoleAttached;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Tests\TestModels\Admin;
@@ -855,5 +857,17 @@ class HasRolesTest extends TestCase
         $user = SoftDeletingUser::withTrashed()->find($user->id);
 
         $this->assertTrue($user->hasRole('testRole'));
+    }
+
+    /** @test */
+    public function it_fires_an_event_when_a_role_is_added()
+    {
+        Event::fake();
+
+        $this->testUser->assignRole('testRole');
+
+        Event::assertDispatched(RoleAttached::class, function ($event) {
+            return $event->model instanceof User && $event->model->hasRole('testRole');
+        });
     }
 }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -925,7 +925,8 @@ class HasRolesTest extends TestCase
     public function it_fires_an_event_when_a_role_is_added()
     {
         Event::fake();
-
+        app('config')->set('permission.events_enabled', true);
+        
         $this->testUser->assignRole(['testRole', 'testRole2']);
 
         $roleIds = app(Role::class)::whereIn('name', ['testRole', 'testRole2'])
@@ -945,7 +946,8 @@ class HasRolesTest extends TestCase
     public function it_fires_an_event_when_a_role_is_removed()
     {
         Event::fake();
-
+        app('config')->set('permission.events_enabled', true);
+        
         $this->testUser->assignRole('testRole');
 
         $this->testUser->removeRole('testRole');

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -937,7 +937,7 @@ class HasRolesTest extends TestCase
             return $event->model instanceof User
                 && $event->model->hasRole('testRole')
                 && $event->model->hasRole('testRole2')
-                && $event->roleIds === $roleIds;
+                && $event->rolesOrIds === $roleIds;
         });
     }
 
@@ -955,7 +955,7 @@ class HasRolesTest extends TestCase
         Event::assertDispatched(RoleDetached::class, function ($event) {
             return $event->model instanceof User
                 && !$event->model->hasRole('testRole')
-                && $event->role->name === 'testRole';
+                && $event->rolesOrIds->name === 'testRole';
         });
     }
   

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Events\RoleAttached;
+use Spatie\Permission\Events\RoleDetached;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Tests\TestModels\Admin;
@@ -868,6 +869,20 @@ class HasRolesTest extends TestCase
 
         Event::assertDispatched(RoleAttached::class, function ($event) {
             return $event->model instanceof User && $event->model->hasRole('testRole');
+        });
+    }
+
+    /** @test */
+    public function it_fires_an_event_when_a_role_is_removed()
+    {
+        Event::fake();
+
+        $this->testUser->assignRole('testRole');
+
+        $this->testUser->removeRole('testRole');
+
+        Event::assertDispatched(RoleDetached::class, function ($event) {
+            return $event->model instanceof User && !$event->model->hasRole('testRole');
         });
     }
 }


### PR DESCRIPTION
First of all: This is my first pull request. If everything is not correct, please give me feedback!

**Why I created this pull request**

In my company we have an API and a UI. If changes have been made to permissions or roles (e.g. because an additional service has been booked), the UI wants to be informed about this. In my opinion, events are perfect for this!

Unfortunately, this package does not currently offer such events, as the `HasRoles::roles()` and `HasPermissions::permissions()` methods do not fire any. There is also no observer, as there is no `Model` class for the pivot table.

This pull request adds 4 events `PermissionAttached`, `PermissionDetached`, `RoleAttached` and `RoleDetached` for adding and removing roles or permission.

You can then have a listener listen to these in the main instance or work directly with sockets.