### PR TITLE
Allow LDAP model lookup from Auth provider

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -39,6 +39,25 @@ class Guard
     }
 
     /**
+     * Get the model class associated with a given provider.
+     *
+     * @param  string  $provider
+     * @return string|null
+     */
+    protected static function getProviderModel(string $provider): ?string
+    {
+        // Get the provider configuration
+        $providerConfig = config("auth.providers.{$provider}");
+
+        // Handle LDAP provider or standard Eloquent provider
+        if (isset($providerConfig['driver']) && $providerConfig['driver'] === 'ldap') {
+            return $providerConfig['database']['model'] ?? null;
+        }
+
+        return $providerConfig['model'] ?? null;
+    }
+
+    /**
      * Get list of relevant guards for the $class model based on config(auth) settings.
      *
      * Lookup flow:
@@ -50,9 +69,35 @@ class Guard
     protected static function getConfigAuthGuards(string $class): Collection
     {
         return collect(config('auth.guards'))
-            ->map(fn ($guard) => isset($guard['provider']) ? config("auth.providers.{$guard['provider']}.model") : null)
+            ->map(function ($guard) {
+                if (!isset($guard['provider'])) {
+                    return null;
+                }
+
+                // Use the new getProviderModel method to fetch the model
+                return static::getProviderModel($guard['provider']);
+            })
             ->filter(fn ($model) => $class === $model)
             ->keys();
+    }
+
+    /**
+     * Get the model associated with a given guard name.
+     *
+     * @param  string  $guard
+     * @return string|null
+     */
+    public static function getModelForGuard(string $guard): ?string
+    {
+        // Get the provider configuration for the given guard
+        $provider = config("auth.guards.{$guard}.provider");
+
+        if (!$provider) {
+            return null;
+        }
+
+        // Use the new getProviderModel method to fetch the model
+        return static::getProviderModel($provider);
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,28 +4,9 @@ if (! function_exists('getModelForGuard')) {
     /**
      * @return string|null
      */
-    function getModelForGuard(string $guard)
+    function getModelForGuard(string $guard): ?string
     {
-        // Get the guard configuration
-        $guardConfig = config("auth.guards.{$guard}");
-        
-        // If the guard has a provider and the provider is defined
-        if (isset($guardConfig['provider'])) {
-            $provider = $guardConfig['provider'];
-            
-            // Check if the provider uses LDAP
-            $providerConfig = config("auth.providers.{$provider}");
-    
-            if (isset($providerConfig['driver']) && $providerConfig['driver'] === 'ldap') {
-                // Return the Eloquent model defined in the LDAP provider's database configuration
-                return $providerConfig['database']['model'] ?? null;
-            }
-    
-            // Otherwise, return the standard Eloquent model
-            return config("auth.providers.{$provider}.model");
-        }
-    
-        return null;
+        return Spatie\Permission\Guard::getModelForGuard($guard);
     }
 
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,10 +6,28 @@ if (! function_exists('getModelForGuard')) {
      */
     function getModelForGuard(string $guard)
     {
-        return collect(config('auth.guards'))
-            ->map(fn ($guard) => isset($guard['provider']) ? config("auth.providers.{$guard['provider']}.model") : null)
-            ->get($guard);
+        // Get the guard configuration
+        $guardConfig = config("auth.guards.{$guard}");
+        
+        // If the guard has a provider and the provider is defined
+        if (isset($guardConfig['provider'])) {
+            $provider = $guardConfig['provider'];
+            
+            // Check if the provider uses LDAP
+            $providerConfig = config("auth.providers.{$provider}");
+    
+            if (isset($providerConfig['driver']) && $providerConfig['driver'] === 'ldap') {
+                // Return the Eloquent model defined in the LDAP provider's database configuration
+                return $providerConfig['database']['model'] ?? null;
+            }
+    
+            // Otherwise, return the standard Eloquent model
+            return config("auth.providers.{$provider}.model");
+        }
+    
+        return null;
     }
+
 }
 
 if (! function_exists('setPermissionsTeamId')) {


### PR DESCRIPTION
allows for ldap authentication where the model differs from the database model - ldap still uses the App\Models\User, just indirectly.