### PR TITLE
Improve performance for hydrated collections

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -360,7 +360,7 @@ class PermissionRegistrar
         $permissionInstance = new ($this->getPermissionClass())();
 
         return Collection::make(array_map(
-            fn ($item) => $permissionInstance->newInstance([], true)
+            fn ($item) => (clone $permissionInstance)
                 ->setRawAttributes($this->aliasedArray(array_diff_key($item, ['r' => 0])), true)
                 ->setRelation('roles', $this->getHydratedRoleCollection($item['r'] ?? [])),
             $this->permissions['permissions']
@@ -379,7 +379,7 @@ class PermissionRegistrar
         $roleInstance = new ($this->getRoleClass())();
 
         array_map(function ($item) use ($roleInstance) {
-            $role = $roleInstance->newInstance([], true)
+            $role = (clone $roleInstance)
                 ->setRawAttributes($this->aliasedArray($item), true);
             $this->cachedRoles[$role->getKey()] = $role;
         }, $this->permissions['roles']);


### PR DESCRIPTION
After profiling our application it appeared that a lot of time of a request was wasted in the PermissionRegistrar. When creating a collection of Permission objects the array_map method is used to create these objects from the items in cache. However everytime the newInstance method is called on the permission instance.

In this PR I've replaced this call by using the native clone method, this performs about 3 times faster!

For e.g. in our application we have about 400 permissions; which takes +/- 18ms to create the hydrated permission collection. By using the native clone method it only takes 6ms. (Executed on a dev environment, without xDebug and xhProf enabled)
