### PR TITLE
LDAP model lookup from Auth Provider

### DIFF
--- a/src/Guard.php
+++ b/src/Guard.php
@@ -74,7 +74,6 @@ class Guard
                     return null;
                 }
 
-                // Fetch the model for this guard
                 return static::getProviderModel($guard['provider']);
             })
             ->filter(fn ($model) => $class === $model)
@@ -96,7 +95,6 @@ class Guard
             return null;
         }
 
-        // Use the new getProviderModel method to fetch the model
         return static::getProviderModel($provider);
     }
 

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -39,6 +39,25 @@ class Guard
     }
 
     /**
+     * Get the model class associated with a given provider.
+     *
+     * @param  string  $provider
+     * @return string|null
+     */
+    protected static function getProviderModel(string $provider): ?string
+    {
+        // Get the provider configuration
+        $providerConfig = config("auth.providers.{$provider}");
+
+        // Handle LDAP provider or standard Eloquent provider
+        if (isset($providerConfig['driver']) && $providerConfig['driver'] === 'ldap') {
+            return $providerConfig['database']['model'] ?? null;
+        }
+
+        return $providerConfig['model'] ?? null;
+    }
+
+    /**
      * Get list of relevant guards for the $class model based on config(auth) settings.
      *
      * Lookup flow:
@@ -50,9 +69,35 @@ class Guard
     protected static function getConfigAuthGuards(string $class): Collection
     {
         return collect(config('auth.guards'))
-            ->map(fn ($guard) => isset($guard['provider']) ? config("auth.providers.{$guard['provider']}.model") : null)
+            ->map(function ($guard) {
+                if (!isset($guard['provider'])) {
+                    return null;
+                }
+
+                // Use the new getProviderModel method to fetch the model
+                return static::getProviderModel($guard['provider']);
+            })
             ->filter(fn ($model) => $class === $model)
             ->keys();
+    }
+
+    /**
+     * Get the model associated with a given guard name.
+     *
+     * @param  string  $guard
+     * @return string|null
+     */
+    public static function getModelForGuard(string $guard): ?string
+    {
+        // Get the provider configuration for the given guard
+        $provider = config("auth.guards.{$guard}.provider");
+
+        if (!$provider) {
+            return null;
+        }
+
+        // Use the new getProviderModel method to fetch the model
+        return static::getProviderModel($provider);
     }
 
     /**

--- a/src/Guard.php
+++ b/src/Guard.php
@@ -74,7 +74,7 @@ class Guard
                     return null;
                 }
 
-                // Use the new getProviderModel method to fetch the model
+                // Fetch the model for this guard
                 return static::getProviderModel($guard['provider']);
             })
             ->filter(fn ($model) => $class === $model)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,12 +4,11 @@ if (! function_exists('getModelForGuard')) {
     /**
      * @return string|null
      */
-    function getModelForGuard(string $guard)
+    function getModelForGuard(string $guard): ?string
     {
-        return collect(config('auth.guards'))
-            ->map(fn ($guard) => isset($guard['provider']) ? config("auth.providers.{$guard['provider']}.model") : null)
-            ->get($guard);
+        return Spatie\Permission\Guard::getModelForGuard($guard);
     }
+
 }
 
 if (! function_exists('setPermissionsTeamId')) {


### PR DESCRIPTION
include ldap check to get the correct model - when using ldap, check for the database model.
(ldap still uses the App\Models\User, just indirectly)

Replaces #2744