### PR TITLE
Include larastan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "illuminate/database": "^8.12|^9.0|^10.0|^11.0"
     },
     "require-dev": {
+        "larastan/larastan": "^2.9",
         "laravel/passport": "^11.0|^12.0",
         "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.4|^10.1"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/database": "^8.12|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^1.0|^2.0",
         "laravel/passport": "^11.0|^12.0",
         "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.4|^10.1"


### PR DESCRIPTION
Undecided whether I want to do this or not. 
It helps let IDEs properly integrate phpstan and give feedback. So in that regard I'm okay with it.

I don't love allowing for very old versions, but that's required due to supporting older Laravel versions (ie: 8) ... which is temporary, and will change with next major version.
But it's a `--dev` thing, so shouldn't impact anything negatively.