### PR TITLE
Fix: #2749 bug "Can no longer delete permissions"

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -349,7 +349,7 @@ class PermissionRegistrar
 
     private function getHydratedPermissionCollection(): Collection
     {
-        $permissionInstance = new ($this->getPermissionClass())();
+        $permissionInstance = (new ($this->getPermissionClass())())->newInstance([], true);
 
         return Collection::make(array_map(
             fn ($item) => (clone $permissionInstance)
@@ -368,7 +368,7 @@ class PermissionRegistrar
 
     private function hydrateRolesCache(): void
     {
-        $roleInstance = new ($this->getRoleClass())();
+        $roleInstance = (new ($this->getRoleClass())())->newInstance([], true);
 
         array_map(function ($item) use ($roleInstance) {
             $role = (clone $roleInstance)

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -67,4 +67,15 @@ class PermissionTest extends TestCase
 
         $this->assertEquals($this->testUserPermission->id, $permission_by_id->id);
     }
+
+    /** @test */
+    public function it_can_delete_hydrated_permissions()
+    {
+        $this->reloadPermissions();
+
+        $permission = app(Permission::class)->findByName($this->testUserPermission->name);
+        $permission->delete();
+
+        $this->assertCount(0, app(Permission::class)->where($this->testUserPermission->getKeyName(), $this->testUserPermission->getKey())->get());
+    }
 }


### PR DESCRIPTION
[Illuminate/Database/Eloquent/Model.php#L615-L619](https://github.com/laravel/framework/blob/37f96f1d6b515f55ea7dfef144fd41519cca38b6/src/Illuminate/Database/Eloquent/Model.php#L615-L619)
```php
public function newInstance($attributes = [], $exists = false)
{
// This method just provides a convenient way for us to generate fresh model
// instances of this current model. It is particularly useful during the
// hydration of new objects via the Eloquent query builder instances.
```

- `newInstance` was removed on #2749
- Closes #2758