### PR TITLE
[Docs] Include Laravel 11 example in exceptions.md

### DIFF
--- a/docs/advanced-usage/exceptions.md
+++ b/docs/advanced-usage/exceptions.md
@@ -23,3 +23,18 @@ public function register()
     });
 }
 ```
+
+**If you are running Laravel v11**
+```php
+
+// bootstrap/app.php
+
+->withExceptions(function (Exceptions $exceptions) {
+    $exceptions->render(function (\Spatie\Permission\Exceptions\UnauthorizedException $e, $request) {
+        return response()->json([
+            'responseMessage' => 'You do not have the required authorization.',
+            'responseStatus'  => 403,
+        ]);
+    });
+}
+```

--- a/docs/advanced-usage/exceptions.md
+++ b/docs/advanced-usage/exceptions.md
@@ -3,14 +3,14 @@ title: Exceptions
 weight: 3
 ---
 
-If you need to override exceptions thrown by this package, you can simply use normal [Laravel practices for handling exceptions](https://laravel.com/docs/10.x/errors#rendering-exceptions).
+If you need to override exceptions thrown by this package, you can simply use normal [Laravel practices for handling exceptions](https://laravel.com/docs/errors#rendering-exceptions).
 
 An example is shown below for your convenience, but nothing here is specific to this package other than the name of the exception.
 
 You can find all the exceptions added by this package in the code here: [https://github.com/spatie/laravel-permission/tree/main/src/Exceptions](https://github.com/spatie/laravel-permission/tree/main/src/Exceptions)
 
 
-**app/Exceptions/Handler.php**
+**Laravel 10: app/Exceptions/Handler.php**
 ```php
 
 public function register()
@@ -24,10 +24,8 @@ public function register()
 }
 ```
 
-**If you are running Laravel v11**
+**Laravel 11: bootstrap/app.php**
 ```php
-
-// bootstrap/app.php
 
 ->withExceptions(function (Exceptions $exceptions) {
     $exceptions->render(function (\Spatie\Permission\Exceptions\UnauthorizedException $e, $request) {


### PR DESCRIPTION
This PR includes a documentation for customizing  exception in laravel 11, since there was a change in file structure in Laravel 11.