### PR TITLE
Php cs fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "illuminate/database": "^8.12|^9.0|^10.0|^11.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.65",
         "larastan/larastan": "^1.0|^2.0",
         "laravel/passport": "^11.0|^12.0",
         "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0",
@@ -55,7 +56,7 @@
     "extra": {
         "branch-alias": {
             "dev-main": "6.x-dev",
-            "dev-master": "6.x-dev"
+        "dev-master": "6.x-dev"
         },
         "laravel": {
             "providers": [
@@ -65,7 +66,7 @@
     },
     "scripts": {
         "test": "phpunit",
-        "format": "php-cs-fixer fix --allow-risky=yes",
+        "format": "php-cs-fixer fix --allow-risky=yes .",
         "analyse": "phpstan analyse"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "extra": {
         "branch-alias": {
             "dev-main": "6.x-dev",
-        "dev-master": "6.x-dev"
+            "dev-master": "6.x-dev"
         },
         "laravel": {
             "providers": [

--- a/src/Commands/Show.php
+++ b/src/Commands/Show.php
@@ -47,9 +47,10 @@ class Show extends Command
 
             $permissions = $permissionClass::whereGuardName($guard)->orderBy('name')->pluck('name', $permissionClass->getKeyName());
 
-            $body = $permissions->map(fn ($permission, $id) => $roles->map(
-                fn (array $role_data) => $role_data['permissions']->contains($id) ? ' ✔' : ' ·'
-            )->prepend($permission)
+            $body = $permissions->map(
+                fn ($permission, $id) => $roles->map(
+                    fn (array $role_data) => $role_data['permissions']->contains($id) ? ' ✔' : ' ·'
+                )->prepend($permission)
             );
 
             if ($teamsEnabled) {

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -107,7 +107,7 @@ class Permission extends Model implements PermissionContract
     public static function findById(int|string $id, ?string $guardName = null): PermissionContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
-        $permission = static::getPermission([(new static)->getKeyName() => $id, 'guard_name' => $guardName]);
+        $permission = static::getPermission([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
             throw PermissionDoesNotExist::withId($id, $guardName);

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -117,7 +117,7 @@ class Role extends Model implements RoleContract
     {
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
-        $role = static::findByParam([(new static)->getKeyName() => $id, 'guard_name' => $guardName]);
+        $role = static::findByParam([(new static())->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $role) {
             throw RoleDoesNotExist::withId($id, $guardName);
@@ -156,7 +156,8 @@ class Role extends Model implements RoleContract
         if (app(PermissionRegistrar::class)->teams) {
             $teamsKey = app(PermissionRegistrar::class)->teamsKey;
 
-            $query->where(fn ($q) => $q->whereNull($teamsKey)
+            $query->where(
+                fn ($q) => $q->whereNull($teamsKey)
                 ->orWhere($teamsKey, $params[$teamsKey] ?? getPermissionsTeamId())
             );
             unset($params[$teamsKey]);

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -196,7 +196,9 @@ class PermissionRegistrar
         }
 
         $this->permissions = $this->cache->remember(
-            $this->cacheKey, $this->cacheExpirationTime, fn () => $this->getSerializedPermissionsForCache()
+            $this->cacheKey,
+            $this->cacheExpirationTime,
+            fn () => $this->getSerializedPermissionsForCache()
         );
 
         $this->alias = $this->permissions['alias'];

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -112,12 +112,19 @@ trait HasPermissions
             array_reduce($permissions, fn ($result, $permission) => array_merge($result, $permission->roles->all()), [])
         );
 
-        return $query->where(fn (Builder $query) => $query
-            ->{! $without ? 'whereHas' : 'whereDoesntHave'}('permissions', fn (Builder $subQuery) => $subQuery
+        return $query->where(
+            fn (Builder $query) => $query
+            ->{! $without ? 'whereHas' : 'whereDoesntHave'}(
+                'permissions',
+                fn (Builder $subQuery) => $subQuery
             ->whereIn(config('permission.table_names.permissions').".$permissionKey", \array_column($permissions, $permissionKey))
             )
-            ->when(count($rolesWithPermissions), fn ($whenQuery) => $whenQuery
-                ->{! $without ? 'orWhereHas' : 'whereDoesntHave'}('roles', fn (Builder $subQuery) => $subQuery
+            ->when(
+                count($rolesWithPermissions),
+                fn ($whenQuery) => $whenQuery
+                ->{! $without ? 'orWhereHas' : 'whereDoesntHave'}(
+                    'roles',
+                    fn (Builder $subQuery) => $subQuery
                 ->whereIn(config('permission.table_names.roles').".$roleKey", \array_column($rolesWithPermissions, $roleKey))
                 )
             )
@@ -190,7 +197,7 @@ trait HasPermissions
         }
 
         if (! $permission instanceof Permission) {
-            throw new PermissionDoesNotExist;
+            throw new PermissionDoesNotExist();
         }
 
         return $permission;

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -96,7 +96,9 @@ trait HasRoles
 
         $key = (new ($this->getRoleClass())())->getKeyName();
 
-        return $query->{! $without ? 'whereHas' : 'whereDoesntHave'}('roles', fn (Builder $subQuery) => $subQuery
+        return $query->{! $without ? 'whereHas' : 'whereDoesntHave'}(
+            'roles',
+            fn (Builder $subQuery) => $subQuery
             ->whereIn(config('permission.table_names.roles').".$key", \array_column($roles, $key))
         );
     }
@@ -362,7 +364,8 @@ trait HasRoles
             $roles = [$roles->name];
         }
 
-        $roles = collect()->make($roles)->map(fn ($role) => $role instanceof Role ? $role->name : $role
+        $roles = collect()->make($roles)->map(
+            fn ($role) => $role instanceof Role ? $role->name : $role
         );
 
         return $this->roles->count() == $roles->count() && $this->hasAllRoles($roles, $guard);

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -263,7 +263,7 @@ class HasPermissionsTest extends TestCase
 
         $this->expectException(PermissionDoesNotExist::class);
 
-        $user->hasPermissionTo(new \stdClass);
+        $user->hasPermissionTo(new \stdClass());
     }
 
     /** @test */
@@ -283,7 +283,7 @@ class HasPermissionsTest extends TestCase
 
         $this->expectException(PermissionDoesNotExist::class);
 
-        $user->hasDirectPermission(new \stdClass);
+        $user->hasDirectPermission(new \stdClass());
     }
 
     /** @test */
@@ -405,7 +405,7 @@ class HasPermissionsTest extends TestCase
     /** @test */
     public function it_can_reject_a_user_that_does_not_have_any_permissions_at_all()
     {
-        $user = new User;
+        $user = new User();
 
         $this->assertFalse($user->hasPermissionTo('edit-articles'));
     }

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -831,7 +831,7 @@ class HasRolesTest extends TestCase
     {
         $this->expectException(\TypeError::class);
 
-        $this->testUser->hasRole(new class {});
+        $this->testUser->hasRole(new class () {});
     }
 
     /** @test */

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -24,7 +24,7 @@ class PermissionMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->permissionMiddleware = new PermissionMiddleware;
+        $this->permissionMiddleware = new PermissionMiddleware();
     }
 
     /** @test */
@@ -305,8 +305,8 @@ class PermissionMiddlewareTest extends TestCase
         $requiredPermissions = [];
 
         try {
-            $this->permissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->permissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'some-permission');
         } catch (UnauthorizedException $e) {
             $message = $e->getMessage();
@@ -326,8 +326,8 @@ class PermissionMiddlewareTest extends TestCase
         $message = null;
 
         try {
-            $this->permissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->permissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'some-permission');
         } catch (UnauthorizedException $e) {
             $message = $e->getMessage();
@@ -342,8 +342,8 @@ class PermissionMiddlewareTest extends TestCase
         $class = null;
 
         try {
-            $this->permissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->permissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'edit-articles', 'xxx');
         } catch (InvalidArgumentException $e) {
             $class = get_class($e);

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -22,7 +22,7 @@ class RoleMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->roleMiddleware = new RoleMiddleware;
+        $this->roleMiddleware = new RoleMiddleware();
     }
 
     /** @test */
@@ -238,8 +238,8 @@ class RoleMiddlewareTest extends TestCase
         $requiredRoles = [];
 
         try {
-            $this->roleMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->roleMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'some-role');
         } catch (UnauthorizedException $e) {
             $message = $e->getMessage();
@@ -259,8 +259,8 @@ class RoleMiddlewareTest extends TestCase
         $message = null;
 
         try {
-            $this->roleMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->roleMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'some-role');
         } catch (UnauthorizedException $e) {
             $message = $e->getMessage();
@@ -275,8 +275,8 @@ class RoleMiddlewareTest extends TestCase
         $class = null;
 
         try {
-            $this->roleMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->roleMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'testRole', 'xxx');
         } catch (InvalidArgumentException $e) {
             $class = get_class($e);

--- a/tests/RoleOrPermissionMiddlewareTest.php
+++ b/tests/RoleOrPermissionMiddlewareTest.php
@@ -23,7 +23,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware;
+        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware();
     }
 
     /** @test */
@@ -177,8 +177,8 @@ class RoleOrPermissionMiddlewareTest extends TestCase
         $class = null;
 
         try {
-            $this->roleOrPermissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->roleOrPermissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'testRole', 'xxx');
         } catch (InvalidArgumentException $e) {
             $class = get_class($e);
@@ -242,8 +242,8 @@ class RoleOrPermissionMiddlewareTest extends TestCase
         $requiredRolesOrPermissions = [];
 
         try {
-            $this->roleOrPermissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->roleOrPermissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'some-permission|some-role');
         } catch (UnauthorizedException $e) {
             $message = $e->getMessage();
@@ -264,8 +264,8 @@ class RoleOrPermissionMiddlewareTest extends TestCase
         $message = null;
 
         try {
-            $this->roleOrPermissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->roleOrPermissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'some-permission|some-role');
         } catch (UnauthorizedException $e) {
             $message = $e->getMessage();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -285,14 +285,14 @@ abstract class TestCase extends Orchestra
     ////// TEST HELPERS
     public function runMiddleware($middleware, $permission, $guard = null, bool $client = false)
     {
-        $request = new Request;
+        $request = new Request();
         if ($client) {
             $request->headers->set('Authorization', 'Bearer '.str()->random(30));
         }
 
         try {
             return $middleware->handle($request, function () {
-                return (new Response)->setContent('<html></html>');
+                return (new Response())->setContent('<html></html>');
             }, $permission, $guard)->status();
         } catch (UnauthorizedException $e) {
             return $e->getStatusCode();
@@ -312,7 +312,7 @@ abstract class TestCase extends Orchestra
     public function getRouteResponse()
     {
         return function () {
-            return (new Response)->setContent('<html></html>');
+            return (new Response())->setContent('<html></html>');
         };
     }
 

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -16,8 +16,8 @@ class TestHelper
     public function testMiddleware($middleware, $parameter)
     {
         try {
-            return $middleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            return $middleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, $parameter)->status();
         } catch (HttpException $e) {
             return $e->getStatusCode();

--- a/tests/TestModels/Role.php
+++ b/tests/TestModels/Role.php
@@ -15,7 +15,7 @@ class Role extends \Spatie\Permission\Models\Role
         'name',
     ];
 
-    const HIERARCHY_TABLE = 'roles_hierarchy';
+    public const HIERARCHY_TABLE = 'roles_hierarchy';
 
     /**
      * @return string|\BackedEnum
@@ -40,7 +40,8 @@ class Role extends \Spatie\Permission\Models\Role
             static::class,
             static::HIERARCHY_TABLE,
             'child_id',
-            'parent_id');
+            'parent_id'
+        );
     }
 
     /**
@@ -52,7 +53,8 @@ class Role extends \Spatie\Permission\Models\Role
             static::class,
             static::HIERARCHY_TABLE,
             'parent_id',
-            'child_id');
+            'child_id'
+        );
     }
 
     protected static function boot()

--- a/tests/WildcardMiddlewareTest.php
+++ b/tests/WildcardMiddlewareTest.php
@@ -23,11 +23,11 @@ class WildcardMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->roleMiddleware = new RoleMiddleware;
+        $this->roleMiddleware = new RoleMiddleware();
 
-        $this->permissionMiddleware = new PermissionMiddleware;
+        $this->permissionMiddleware = new PermissionMiddleware();
 
-        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware;
+        $this->roleOrPermissionMiddleware = new RoleOrPermissionMiddleware();
 
         app('config')->set('permission.enable_wildcard_permission', true);
     }
@@ -146,8 +146,8 @@ class WildcardMiddlewareTest extends TestCase
         $requiredPermissions = [];
 
         try {
-            $this->permissionMiddleware->handle(new Request, function () {
-                return (new Response)->setContent('<html></html>');
+            $this->permissionMiddleware->handle(new Request(), function () {
+                return (new Response())->setContent('<html></html>');
             }, 'permission.some');
         } catch (UnauthorizedException $e) {
             $requiredPermissions = $e->getRequiredPermissions();


### PR DESCRIPTION
## Overview

I was checking out this package on my machine and came across an issue -- I noticed that the `format` script added to `composer.json` wouldn't run. There were two issues:

1. The package did not include the `friendsofphp/php-cs-fixer` development dependency, so there was an expectation that it would be installed globally
2. No path was set on the format command

## Changes

> NOTE: To start, I didn't want to make any bad assumptions. Since there was not an existing configuration for `php-cs-fixer`, I left it alone and only fixed what was already there.

### Add dependency

I added the current version of the dependency:

```json
"friendsofphp/php-cs-fixer": "^3.65",
```

### Update Composer script

The script was defined like this:

```json
"format": "php-cs-fixer fix --allow-risky=yes",
```

But since it needs a path, it's now changed to:

```json
"format": "php-cs-fixer fix --allow-risky=yes .",
```


### Run php-cs-fixer

Finally, I ran `composer format` and let it run through the project.

## Results

The changes are minimal, and all tests are passing.