### PR TITLE
Update installation-laravel.md to fix providers.php location.

### DIFF
--- a/docs/installation-laravel.md
+++ b/docs/installation-laravel.md
@@ -28,7 +28,7 @@ Package Version | Laravel Version
 
         composer require spatie/laravel-permission
 
-4. Optional: The **`Spatie\Permission\PermissionServiceProvider::class`** service provider will automatically get registered. Or you may manually add the service provider to the array in your `config/providers.php` (or `config/app.php` in Laravel 10 or older) file.
+4. Optional: The **`Spatie\Permission\PermissionServiceProvider::class`** service provider will automatically get registered. Or you may manually add the service provider to the array in your `bootstrap/providers.php` (or `config/app.php` in Laravel 10 or older) file.
 
 5. **You should publish** [the migration](https://github.com/spatie/laravel-permission/blob/main/database/migrations/create_permission_tables.php.stub) and the [`config/permission.php` config file](https://github.com/spatie/laravel-permission/blob/main/config/permission.php) with:
 


### PR DESCRIPTION
4. Optional: The **`Spatie\Permission\PermissionServiceProvider::class`** service provider will automatically get registered. Or you may manually add the service provider to the array in your `bootstrap/providers.php` (or `config/app.php` in Laravel 10 or older) file.