### PR TITLE
Add instructions to reinitialize cache for multi-tenancy key settings

### DIFF
--- a/docs/advanced-usage/cache.md
+++ b/docs/advanced-usage/cache.md
@@ -66,9 +66,13 @@ We recommend not changing the cache "key" name. Usually changing it is a bad ide
 
 Laravel Tip: If you are leveraging a caching service such as `redis` or `memcached` and there are other sites running on your server, you could run into cache clashes between apps. 
 
-To prevent other applications from accidentally using/changing your cached data, it is prudent to set your own cache `prefix` in Laravel's `/config/cache.php` to something unique for each application which shares the same caching service.
+To prevent other applications from accidentally using/changing your cached data, it is prudent to set your own cache `prefix` in Laravel's `/config/cache.php` to something unique for each application which shares the same caching service. 
 
-Most multi-tenant "packages" take care of this for you when switching tenants.
+Most multi-tenant "packages" take care of this for you when switching tenants. If you are switching cache keys / store during a request lifecycle in such multi-tenancy environments, please be sure to reinitialize the cache of the `PermissionRegistrar` so that your updated `CacheStore` is used for caching.
+
+```php
+app()->make(\Spatie\Permission\PermissionRegistrar::class)->initializeCache();
+```
 
 
 ### Custom Cache Store


### PR DESCRIPTION
When switching cache prefix/key/store during a request lifecycle, after the service provider has been loaded, the cache store should be reinitialized to make sure that the updated CacheStore with latest prefix/keys is used for upcoming cache hits.

```php
app()->make(\Spatie\Permission\PermissionRegistrar::class)->initializeCache();
```

---
### Context

I have recently integrated [laravel-multitenancy](https://spatie.be/docs/laravel-multitenancy/v4/introduction) in a project to use the per-tenant `cache.prefix`. I am using single-db multi-tenancy and was setting current Tenant during a request cycle using the Authentication events. This was working perfectly as `PermissionRegistrar` is a singleton and it was resolved with correct prefix when resolved from the service container. But in some of my flow, I needed to update the permissions for multiple tenants during a single request life cycle. I found out that my database was in correct state with respect to the latest permissions but the permissions cache was not. 

After a day or two debugging, I found out that the cache prefix during the `loadPermissions` was incorrect when updating the permissions of multiple tenants during a single request. Then I logged the `CacheStore->getPrefix()` and it was incorrect during Tenant switching. That meant the `CacheManager` was already resolved and was using the old keys in it's store. So I reinitialized the `CacheStore` in the `PermissionRegistrar` by calling `initializeCache` and it resulted in the correct store during TenantSwitching.

Please correct me if I am wrong. I hope this helps someone else as well.
