### PR TITLE
Add PHPUnit annotations, for future compatibility with PHPUnit 12

### DIFF
--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Role;
 
 class BladeTest extends TestCase
@@ -21,6 +22,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function all_blade_directives_will_evaluate_false_when_there_is_nobody_logged_in()
     {
         $permission = 'edit-articles';
@@ -40,6 +42,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function all_blade_directives_will_evaluate_false_when_somebody_without_roles_or_permissions_is_logged_in()
     {
         $permission = 'edit-articles';
@@ -59,6 +62,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function all_blade_directives_will_evaluate_false_when_somebody_with_another_guard_is_logged_in()
     {
         $permission = 'edit-articles';
@@ -79,6 +83,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_can_directive_can_accept_a_guard_name()
     {
         $user = $this->getWriter();
@@ -109,6 +114,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_can_directive_will_evaluate_true_when_the_logged_in_user_has_the_permission()
     {
         $user = $this->getWriter();
@@ -121,6 +127,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_haspermission_directive_will_evaluate_true_when_the_logged_in_user_has_the_permission()
     {
         $user = $this->getWriter();
@@ -145,6 +152,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_role_directive_will_evaluate_true_when_the_logged_in_user_has_the_role()
     {
         auth()->setUser($this->getWriter());
@@ -153,6 +161,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_elserole_directive_will_evaluate_true_when_the_logged_in_user_has_the_role()
     {
         auth()->setUser($this->getMember());
@@ -161,6 +170,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_role_directive_will_evaluate_true_when_the_logged_in_user_has_the_role_for_the_given_guard()
     {
         auth('admin')->setUser($this->getSuperAdmin());
@@ -169,6 +179,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasrole_directive_will_evaluate_true_when_the_logged_in_user_has_the_role()
     {
         auth()->setUser($this->getWriter());
@@ -177,6 +188,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasrole_directive_will_evaluate_true_when_the_logged_in_user_has_the_role_for_the_given_guard()
     {
         auth('admin')->setUser($this->getSuperAdmin());
@@ -185,6 +197,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_unlessrole_directive_will_evaluate_true_when_the_logged_in_user_does_not_have_the_role()
     {
         auth()->setUser($this->getWriter());
@@ -193,6 +206,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_unlessrole_directive_will_evaluate_true_when_the_logged_in_user_does_not_have_the_role_for_the_given_guard()
     {
         auth('admin')->setUser($this->getSuperAdmin());
@@ -202,6 +216,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasanyrole_directive_will_evaluate_false_when_the_logged_in_user_does_not_have_any_of_the_required_roles()
     {
         $roles = ['writer', 'intern'];
@@ -213,6 +228,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasanyrole_directive_will_evaluate_true_when_the_logged_in_user_does_have_some_of_the_required_roles()
     {
         $roles = ['member', 'writer', 'intern'];
@@ -224,6 +240,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasanyrole_directive_will_evaluate_true_when_the_logged_in_user_does_have_some_of_the_required_roles_for_the_given_guard()
     {
         $roles = ['super-admin', 'moderator'];
@@ -235,6 +252,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasanyrole_directive_will_evaluate_true_when_the_logged_in_user_does_have_some_of_the_required_roles_in_pipe()
     {
         $guard = 'admin';
@@ -245,6 +263,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasanyrole_directive_will_evaluate_false_when_the_logged_in_user_doesnt_have_some_of_the_required_roles_in_pipe()
     {
         $guard = '';
@@ -255,6 +274,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_false_when_the_logged_in_user_does_not_have_all_required_roles()
     {
         $roles = ['member', 'writer'];
@@ -266,6 +286,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_true_when_the_logged_in_user_does_have_all_required_roles()
     {
         $roles = ['member', 'writer'];
@@ -281,6 +302,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_true_when_the_logged_in_user_does_have_all_required_roles_for_the_given_guard()
     {
         $roles = ['super-admin', 'moderator'];
@@ -296,6 +318,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_true_when_the_logged_in_user_does_have_all_required_roles_in_pipe()
     {
         $guard = 'admin';
@@ -310,6 +333,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_false_when_the_logged_in_user_doesnt_have_all_required_roles_in_pipe()
     {
         $guard = '';
@@ -323,6 +347,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_true_when_the_logged_in_user_does_have_all_required_roles_in_array()
     {
         $guard = 'admin';
@@ -337,6 +362,7 @@ class BladeTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_hasallroles_directive_will_evaluate_false_when_the_logged_in_user_doesnt_have_all_required_roles_in_array()
     {
         $guard = '';

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
@@ -42,6 +43,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_cache_the_permissions()
     {
         $this->resetQueryCount();
@@ -52,6 +54,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_creating_a_permission()
     {
         app(Permission::class)->create(['name' => 'new']);
@@ -64,6 +67,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_updating_a_permission()
     {
         $permission = app(Permission::class)->create(['name' => 'new']);
@@ -79,6 +83,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_creating_a_role()
     {
         app(Role::class)->create(['name' => 'new']);
@@ -91,6 +96,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_updating_a_role()
     {
         $role = app(Role::class)->create(['name' => 'new']);
@@ -106,6 +112,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function removing_a_permission_from_a_user_should_not_flush_the_cache()
     {
         $this->testUser->givePermissionTo('edit-articles');
@@ -122,6 +129,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function removing_a_role_from_a_user_should_not_flush_the_cache()
     {
         $this->testUser->assignRole('testRole');
@@ -138,6 +146,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_removing_a_role_from_a_permission()
     {
         $this->testUserPermission->assignRole('testRole');
@@ -154,6 +163,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_assign_a_permission_to_a_role()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -166,6 +176,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_creation_should_not_flush_the_cache()
     {
         $this->registrar->getPermissions();
@@ -181,6 +192,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_flushes_the_cache_when_giving_a_permission_to_a_role()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);
@@ -193,6 +205,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function has_permission_to_should_use_the_cache()
     {
         $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news', 'Edit News']);
@@ -217,6 +230,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_cache_should_differentiate_by_guard_name()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -235,6 +249,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function get_all_permissions_should_use_the_cache()
     {
         $this->testUserRole->givePermissionTo($expected = ['edit-articles', 'edit-news']);
@@ -253,6 +268,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function get_all_permissions_should_not_over_hydrate_roles()
     {
         $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news']);
@@ -264,6 +280,7 @@ class CacheTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_reset_the_cache_with_artisan_command()
     {
         Artisan::call('permission:create-permission', ['name' => 'new-permission']);

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -5,12 +5,14 @@ namespace Spatie\Permission\Tests;
 use Composer\InstalledVersions;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
 class CommandTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_create_a_role()
     {
         Artisan::call('permission:create-role', ['name' => 'new-role']);
@@ -20,6 +22,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_create_a_role_with_a_specific_guard()
     {
         Artisan::call('permission:create-role', [
@@ -33,6 +36,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_create_a_permission()
     {
         Artisan::call('permission:create-permission', ['name' => 'new-permission']);
@@ -41,6 +45,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_create_a_permission_with_a_specific_guard()
     {
         Artisan::call('permission:create-permission', [
@@ -54,6 +59,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_create_a_role_and_permissions_at_same_time()
     {
         Artisan::call('permission:create-role', [
@@ -68,6 +74,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_create_a_role_without_duplication()
     {
         Artisan::call('permission:create-role', ['name' => 'new-role']);
@@ -78,6 +85,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_create_a_permission_without_duplication()
     {
         Artisan::call('permission:create-permission', ['name' => 'new-permission']);
@@ -87,6 +95,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_show_permission_tables()
     {
         Role::where('name', 'testRole2')->delete();
@@ -125,6 +134,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_show_permissions_for_guard()
     {
         Artisan::call('permission:show', ['guard' => 'web']);
@@ -136,6 +146,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_setup_teams_upgrade()
     {
         config()->set('permission.teams', true);
@@ -163,6 +174,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_show_roles_by_teams()
     {
         config()->set('permission.teams', true);
@@ -188,6 +200,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_respond_to_about_command_with_default()
     {
         if (! class_exists(InstalledVersions::class) || ! class_exists(AboutCommand::class)) {
@@ -211,6 +224,7 @@ class CommandTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_respond_to_about_command_with_teams()
     {
         if (! class_exists(InstalledVersions::class) || ! class_exists(AboutCommand::class)) {

--- a/tests/CustomGateTest.php
+++ b/tests/CustomGateTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Tests;
 
 use Illuminate\Contracts\Auth\Access\Gate;
+use PHPUnit\Framework\Attributes\Test;
 
 class CustomGateTest extends TestCase
 {
@@ -14,6 +15,7 @@ class CustomGateTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_doesnt_register_the_method_for_checking_permissions_on_the_gate()
     {
         $this->testUser->givePermissionTo('edit-articles');
@@ -23,6 +25,7 @@ class CustomGateTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_authorize_using_custom_method_for_checking_permissions()
     {
         app(Gate::class)->define('edit-articles', function () {

--- a/tests/GateTest.php
+++ b/tests/GateTest.php
@@ -3,17 +3,21 @@
 namespace Spatie\Permission\Tests;
 
 use Illuminate\Contracts\Auth\Access\Gate;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 
 class GateTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_determine_if_a_user_does_not_have_a_permission()
     {
         $this->assertFalse($this->testUser->can('edit-articles'));
     }
 
     /** @test */
+    #[Test]
     public function it_allows_other_gate_before_callbacks_to_run_if_a_user_does_not_have_a_permission()
     {
         $this->assertFalse($this->testUser->can('edit-articles'));
@@ -27,6 +31,7 @@ class GateTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_allows_gate_after_callback_to_grant_denied_privileges()
     {
         $this->assertFalse($this->testUser->can('edit-articles'));
@@ -39,6 +44,7 @@ class GateTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_if_a_user_has_a_direct_permission()
     {
         $this->testUser->givePermissionTo('edit-articles');
@@ -55,6 +61,8 @@ class GateTest extends TestCase
      *
      * @requires PHP >= 8.1
      */
+    #[RequiresPhp('>= 8.1')]
+    #[Test]
     public function it_can_determine_if_a_user_has_a_direct_permission_using_enums()
     {
         $enum = TestModels\TestRolePermissionsEnum::VIEWARTICLES;
@@ -73,6 +81,7 @@ class GateTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_if_a_user_has_a_permission_through_roles()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);
@@ -89,6 +98,7 @@ class GateTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_if_a_user_with_a_different_guard_has_a_permission_when_using_roles()
     {
         $this->testAdminRole->givePermissionTo($this->testAdminPermission);

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -4,6 +4,8 @@ namespace Spatie\Permission\Tests;
 
 use DB;
 use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -14,6 +16,7 @@ use Spatie\Permission\Tests\TestModels\User;
 class HasPermissionsTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_assign_a_permission_to_a_user()
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
@@ -22,6 +25,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_a_permission_to_a_user_with_a_non_default_guard()
     {
         $testUserPermission = app(Permission::class)->create([
@@ -35,6 +39,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_assigning_a_permission_that_does_not_exist()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -43,6 +48,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_assigning_a_permission_to_a_user_from_a_different_guard()
     {
         $this->expectException(GuardDoesNotMatch::class);
@@ -55,6 +61,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_revoke_a_permission_from_a_user()
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
@@ -71,6 +78,8 @@ class HasPermissionsTest extends TestCase
      *
      * @requires PHP >= 8.1
      */
+    #[RequiresPhp('>= 8.1')]
+    #[Test]
     public function it_can_assign_and_remove_a_permission_using_enums()
     {
         $enum = TestModels\TestRolePermissionsEnum::VIEWARTICLES;
@@ -95,6 +104,8 @@ class HasPermissionsTest extends TestCase
      *
      * @requires PHP >= 8.1
      */
+    #[RequiresPhp('>= 8.1')]
+    #[Test]
     public function it_can_scope_users_using_enums()
     {
         $enum1 = TestModels\TestRolePermissionsEnum::VIEWARTICLES;
@@ -122,6 +133,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_string()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -142,6 +154,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_int()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -162,6 +175,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_an_array()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -183,6 +197,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_collection()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -204,6 +219,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_an_object()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -222,6 +238,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_without_direct_permissions_only_role()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -241,6 +258,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_with_only_direct_permission()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -258,6 +276,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_calling_hasPermissionTo_with_an_invalid_type()
     {
         $user = User::create(['email' => 'user1@test.com']);
@@ -268,6 +287,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_calling_hasPermissionTo_with_null()
     {
         $user = User::create(['email' => 'user1@test.com']);
@@ -278,6 +298,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_calling_hasDirectPermission_with_an_invalid_type()
     {
         $user = User::create(['email' => 'user1@test.com']);
@@ -288,6 +309,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_calling_hasDirectPermission_with_null()
     {
         $user = User::create(['email' => 'user1@test.com']);
@@ -298,6 +320,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_trying_to_scope_a_non_existing_permission()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -310,6 +333,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_trying_to_scope_a_permission_from_another_guard()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -330,6 +354,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_doesnt_detach_permissions_when_user_soft_deleting()
     {
         $user = SoftDeletingUser::create(['email' => 'test@example.com']);
@@ -342,6 +367,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_give_and_revoke_multiple_permissions()
     {
         $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news']);
@@ -354,6 +380,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_give_and_revoke_permissions_models_array()
     {
         $models = [app(Permission::class)::where('name', 'edit-articles')->first(), app(Permission::class)::where('name', 'edit-news')->first()];
@@ -368,6 +395,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_give_and_revoke_permissions_models_collection()
     {
         $models = app(Permission::class)::whereIn('name', ['edit-articles', 'edit-news'])->get();
@@ -382,12 +410,14 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_does_not_have_a_permission()
     {
         $this->assertFalse($this->testUser->hasPermissionTo('edit-articles'));
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_the_permission_does_not_exist()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -396,6 +426,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_the_permission_does_not_exist_for_this_guard()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -404,6 +435,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_reject_a_user_that_does_not_have_any_permissions_at_all()
     {
         $user = new User;
@@ -412,6 +444,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_has_any_of_the_permissions_directly()
     {
         $this->assertFalse($this->testUser->hasAnyPermission('edit-articles'));
@@ -429,6 +462,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_has_any_of_the_permissions_directly_using_an_array()
     {
         $this->assertFalse($this->testUser->hasAnyPermission(['edit-articles']));
@@ -445,6 +479,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_has_any_of_the_permissions_via_role()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -456,6 +491,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_has_all_of_the_permissions_directly()
     {
         $this->testUser->givePermissionTo('edit-articles', 'edit-news');
@@ -469,6 +505,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_has_all_of_the_permissions_directly_using_an_array()
     {
         $this->assertFalse($this->testUser->hasAllPermissions(['edit-articles', 'edit-news']));
@@ -485,6 +522,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_has_all_of_the_permissions_via_role()
     {
         $this->testUserRole->givePermissionTo('edit-articles', 'edit-news');
@@ -495,6 +533,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_user_has_direct_permission()
     {
         $this->testUser->givePermissionTo('edit-articles');
@@ -513,6 +552,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_list_all_the_permissions_via_roles_of_user()
     {
         $roleModel = app(Role::class);
@@ -528,6 +568,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_list_all_the_coupled_permissions_both_directly_and_via_roles()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -542,6 +583,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_multiple_permissions()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -556,6 +598,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_avoid_sync_duplicated_permissions()
     {
         $this->testUser->syncPermissions('edit-articles', 'edit-blog', 'edit-blog');
@@ -566,6 +609,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_multiple_permissions_by_id()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -582,6 +626,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function sync_permission_ignores_null_inputs()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -600,6 +645,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function sync_permission_error_does_not_detach_permissions()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -612,6 +658,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_remove_already_associated_permissions_when_assigning_new_permissions()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -622,6 +669,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_throw_an_exception_when_assigning_a_permission_that_is_already_assigned()
     {
         $this->testUser->givePermissionTo('edit-news');
@@ -632,6 +680,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_permissions_to_a_model_that_is_not_persisted()
     {
         $user = new User(['email' => 'test@user.com']);
@@ -647,6 +696,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_run_unnecessary_sqls_when_assigning_new_permissions()
     {
         $permission2 = app(Permission::class)->where('name', ['edit-news'])->first();
@@ -659,6 +709,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function calling_givePermissionTo_before_saving_object_doesnt_interfere_with_other_objects()
     {
         $user = new User(['email' => 'test@user.com']);
@@ -681,6 +732,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function calling_syncPermissions_before_saving_object_doesnt_interfere_with_other_objects()
     {
         $user = new User(['email' => 'test@user.com']);
@@ -703,6 +755,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_retrieve_permission_names()
     {
         $this->testUser->givePermissionTo('edit-news', 'edit-articles');
@@ -713,6 +766,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_many_direct_permissions()
     {
         $this->testUser->givePermissionTo(['edit-articles', 'edit-news']);
@@ -723,6 +777,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_if_there_is_any_of_the_direct_permissions_given()
     {
         $this->testUser->givePermissionTo(['edit-articles', 'edit-news']);
@@ -732,6 +787,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_permission_based_on_logged_in_user_guard()
     {
         $this->testUser->givePermissionTo(app(Permission::class)::create([
@@ -746,6 +802,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_reject_permission_based_on_logged_in_user_guard()
     {
         $unassignedPermission = app(Permission::class)::create([
@@ -768,6 +825,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_permission_on_role_when_lazy_loading_is_restricted()
     {
         $this->assertTrue(Model::preventsLazyLoading());
@@ -784,6 +842,7 @@ class HasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_permission_on_user_when_lazy_loading_is_restricted()
     {
         $this->assertTrue(Model::preventsLazyLoading());

--- a/tests/HasPermissionsWithCustomModelsTest.php
+++ b/tests/HasPermissionsWithCustomModelsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Tests\TestModels\Admin;
 use Spatie\Permission\Tests\TestModels\Permission;
@@ -27,12 +28,14 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_use_custom_model_permission()
     {
         $this->assertSame(get_class($this->testUserPermission), Permission::class);
     }
 
     /** @test */
+    #[Test]
     public function it_can_use_custom_fields_from_cache()
     {
         DB::connection()->getSchemaBuilder()->table(config('permission.table_names.roles'), function ($table) {
@@ -54,6 +57,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_int()
     {
         // Skipped because custom model uses uuid,
@@ -62,6 +66,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_uuid()
     {
         $uuid1 = $this->testUserPermission->getKey();
@@ -81,6 +86,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_doesnt_detach_roles_when_soft_deleting()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);
@@ -97,6 +103,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_doesnt_detach_users_when_soft_deleting()
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
@@ -113,6 +120,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_does_detach_roles_and_users_when_force_deleting()
     {
         $permission_id = $this->testUserPermission->getKey();
@@ -133,6 +141,7 @@ class HasPermissionsWithCustomModelsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_should_touch_when_assigning_new_permissions()
     {
         Carbon::setTestNow('2021-07-19 10:13:14');

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -4,6 +4,8 @@ namespace Spatie\Permission\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
@@ -15,6 +17,7 @@ use Spatie\Permission\Tests\TestModels\User;
 class HasRolesTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_determine_that_the_user_does_not_have_a_role()
     {
         $this->assertFalse($this->testUser->hasRole('testRole'));
@@ -45,6 +48,8 @@ class HasRolesTest extends TestCase
      *
      * @requires PHP >= 8.1
      */
+    #[RequiresPhp('>= 8.1')]
+    #[Test]
     public function it_can_assign_and_remove_a_role_using_enums()
     {
         $enum1 = TestModels\TestRolePermissionsEnum::USERMANAGER;
@@ -97,6 +102,8 @@ class HasRolesTest extends TestCase
      *
      * @requires PHP >= 8.1
      */
+    #[RequiresPhp('>= 8.1')]
+    #[Test]
     public function it_can_scope_a_role_using_enums()
     {
         $enum1 = TestModels\TestRolePermissionsEnum::USERMANAGER;
@@ -124,6 +131,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_and_remove_a_role()
     {
         $this->assertFalse($this->testUser->hasRole('testRole'));
@@ -138,6 +146,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_removes_a_role_and_returns_roles()
     {
         $this->testUser->assignRole('testRole');
@@ -154,6 +163,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_and_remove_a_role_on_a_permission()
     {
         $this->testUserPermission->assignRole('testRole');
@@ -166,6 +176,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_a_role_using_an_object()
     {
         $this->testUser->assignRole($this->testUserRole);
@@ -174,6 +185,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_a_role_using_an_id()
     {
         $this->testUser->assignRole($this->testUserRole->getKey());
@@ -182,6 +194,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_multiple_roles_at_once()
     {
         $this->testUser->assignRole($this->testUserRole->getKey(), 'testRole2');
@@ -192,6 +205,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_multiple_roles_using_an_array()
     {
         $this->testUser->assignRole([$this->testUserRole->getKey(), 'testRole2']);
@@ -202,6 +216,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_remove_already_associated_roles_when_assigning_new_roles()
     {
         $this->testUser->assignRole($this->testUserRole->getKey());
@@ -212,6 +227,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_throw_an_exception_when_assigning_a_role_that_is_already_assigned()
     {
         $this->testUser->assignRole($this->testUserRole->getKey());
@@ -222,6 +238,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_assigning_a_role_that_does_not_exist()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -230,6 +247,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_only_assign_roles_from_the_correct_guard()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -238,6 +256,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_assigning_a_role_from_a_different_guard()
     {
         $this->expectException(GuardDoesNotMatch::class);
@@ -246,6 +265,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_ignores_null_roles_when_syncing()
     {
         $this->testUser->assignRole('testRole');
@@ -258,6 +278,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_roles_from_a_string()
     {
         $this->testUser->assignRole('testRole');
@@ -270,6 +291,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_roles_from_a_string_on_a_permission()
     {
         $this->testUserPermission->assignRole('testRole');
@@ -282,6 +304,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_avoid_sync_duplicated_roles()
     {
         $this->testUser->syncRoles('testRole', 'testRole', 'testRole2');
@@ -292,6 +315,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_multiple_roles()
     {
         $this->testUser->syncRoles('testRole', 'testRole2');
@@ -302,6 +326,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_multiple_roles_from_an_array()
     {
         $this->testUser->syncRoles(['testRole', 'testRole2']);
@@ -312,6 +337,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_will_remove_all_roles_when_an_empty_array_is_passed_to_sync_roles()
     {
         $this->testUser->assignRole('testRole');
@@ -326,6 +352,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function sync_roles_error_does_not_detach_roles()
     {
         $this->testUser->assignRole('testRole');
@@ -338,6 +365,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_will_sync_roles_to_a_model_that_is_not_persisted()
     {
         $user = new User(['email' => 'test@user.com']);
@@ -353,6 +381,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_run_unnecessary_sqls_when_assigning_new_roles()
     {
         $role2 = app(Role::class)->where('name', ['testRole2'])->first();
@@ -365,6 +394,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function calling_syncRoles_before_saving_object_doesnt_interfere_with_other_objects()
     {
         $user = new User(['email' => 'test@user.com']);
@@ -387,6 +417,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function calling_assignRole_before_saving_object_doesnt_interfere_with_other_objects()
     {
         $user = new User(['email' => 'test@user.com']);
@@ -409,6 +440,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_syncing_a_role_from_another_guard()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -421,6 +453,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_deletes_pivot_table_entries_when_deleting_models()
     {
         $user = User::create(['email' => 'user@test.com']);
@@ -438,6 +471,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_string()
     {
         $user1 = User::create(['email' => 'user1@test.com']);
@@ -451,6 +485,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_withoutscope_users_using_a_string()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -467,6 +502,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_an_array()
     {
         $user1 = User::create(['email' => 'user1@test.com']);
@@ -482,6 +518,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_withoutscope_users_using_an_array()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -500,6 +537,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_an_array_of_ids_and_names()
     {
         $user1 = User::create(['email' => 'user1@test.com']);
@@ -516,6 +554,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_withoutscope_users_using_an_array_of_ids_and_names()
     {
         app(Role::class)->create(['name' => 'testRole3']);
@@ -537,6 +576,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_a_collection()
     {
         $user1 = User::create(['email' => 'user1@test.com']);
@@ -552,6 +592,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_withoutscope_users_using_a_collection()
     {
         app(Role::class)->create(['name' => 'testRole3']);
@@ -572,6 +613,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_using_an_object()
     {
         $user1 = User::create(['email' => 'user1@test.com']);
@@ -589,6 +631,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_withoutscope_users_using_an_object()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -609,6 +652,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_against_a_specific_guard()
     {
         $user1 = User::create(['email' => 'user1@test.com']);
@@ -635,6 +679,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_withoutscope_against_a_specific_guard()
     {
         User::all()->each(fn ($item) => $item->delete());
@@ -665,6 +710,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_trying_to_scope_a_role_from_another_guard()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -677,6 +723,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_trying_to_call_withoutscope_on_a_role_from_another_guard()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -689,6 +736,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_trying_to_scope_a_non_existing_role()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -697,6 +745,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_trying_to_use_withoutscope_on_a_non_existing_role()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -705,6 +754,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_a_user_has_one_of_the_given_roles()
     {
         $roleModel = app(Role::class);
@@ -733,6 +783,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_a_user_has_all_of_the_given_roles()
     {
         $roleModel = app(Role::class);
@@ -762,6 +813,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_a_user_has_exact_all_of_the_given_roles()
     {
         $roleModel = app(Role::class);
@@ -801,6 +853,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_determine_that_a_user_does_not_have_a_role_from_another_guard()
     {
         $this->assertFalse($this->testUser->hasRole('testAdminRole'));
@@ -815,6 +868,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_against_any_multiple_roles_using_multiple_arguments()
     {
         $this->testUser->assignRole('testRole');
@@ -823,12 +877,14 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_instead_of_an_exception_when_checking_against_any_undefined_roles_using_multiple_arguments()
     {
         $this->assertFalse($this->testUser->hasAnyRole('This Role Does Not Even Exist', $this->testAdminRole));
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_if_an_unsupported_type_is_passed_to_hasRoles()
     {
         $this->expectException(\TypeError::class);
@@ -837,6 +893,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_retrieve_role_names()
     {
         $this->testUser->assignRole('testRole', 'testRole2');
@@ -848,6 +905,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_does_not_detach_roles_when_user_soft_deleting()
     {
         $user = SoftDeletingUser::create(['email' => 'test@example.com']);
@@ -860,6 +918,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_role_on_permission_when_lazy_loading_is_restricted()
     {
         $this->assertTrue(Model::preventsLazyLoading());
@@ -876,6 +935,7 @@ class HasRolesTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_role_on_user_when_lazy_loading_is_restricted()
     {
         $this->assertTrue(Model::preventsLazyLoading());

--- a/tests/HasRolesWithCustomModelsTest.php
+++ b/tests/HasRolesWithCustomModelsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Tests;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Tests\TestModels\Admin;
 use Spatie\Permission\Tests\TestModels\Role;
 
@@ -25,12 +26,14 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_use_custom_model_role()
     {
         $this->assertSame(get_class($this->testUserRole), Role::class);
     }
 
     /** @test */
+    #[Test]
     public function it_doesnt_detach_permissions_when_soft_deleting()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);
@@ -47,6 +50,7 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_doesnt_detach_users_when_soft_deleting()
     {
         $this->testUser->assignRole($this->testUserRole);
@@ -63,6 +67,7 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_does_detach_permissions_and_users_when_force_deleting()
     {
         $role_id = $this->testUserRole->getKey();
@@ -83,6 +88,7 @@ class HasRolesWithCustomModelsTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_should_touch_when_assigning_new_roles()
     {
         Carbon::setTestNow('2021-07-19 10:13:14');

--- a/tests/MultipleGuardsTest.php
+++ b/tests/MultipleGuardsTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Permission\Tests;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Tests\TestModels\Manager;
 
@@ -37,6 +38,7 @@ class MultipleGuardsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_give_a_permission_to_a_model_that_is_used_by_multiple_guards()
     {
         $this->testUser->givePermissionTo(app(Permission::class)::create([
@@ -55,6 +57,7 @@ class MultipleGuardsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_gate_can_grant_permission_to_a_user_by_passing_a_guard_name()
     {
         $this->testUser->givePermissionTo(app(Permission::class)::create([
@@ -96,6 +99,7 @@ class MultipleGuardsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_honour_guardName_function_on_model_for_overriding_guard_name_property()
     {
         $user = Manager::create(['email' => 'manager@test.com']);

--- a/tests/PermissionMiddlewareTest.php
+++ b/tests/PermissionMiddlewareTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middleware\PermissionMiddleware;
@@ -28,6 +29,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_guest_cannot_access_a_route_protected_by_the_permission_middleware()
     {
         $this->assertEquals(
@@ -37,6 +39,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_the_permission_middleware_of_a_different_guard()
     {
         // These permissions are created fresh here in reverse order of guard being applied, so they are not "found first" in the db lookup when matching
@@ -75,6 +78,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_the_permission_middleware_of_a_different_guard(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -101,6 +105,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_super_admin_user_can_access_a_route_protected_by_permission_middleware()
     {
         Auth::login($this->testUser);
@@ -116,6 +121,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_permission_middleware_if_have_this_permission()
     {
         Auth::login($this->testUser);
@@ -129,6 +135,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_access_a_route_protected_by_permission_middleware_if_have_this_permission(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -146,6 +153,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_this_permission_middleware_if_have_one_of_the_permissions()
     {
         Auth::login($this->testUser);
@@ -164,6 +172,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_access_a_route_protected_by_this_permission_middleware_if_have_one_of_the_permissions(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -186,6 +195,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_the_permission_middleware_if_have_not_has_roles_trait()
     {
         $userWithoutHasRoles = UserWithoutHasRoles::create(['email' => 'test_not_has_roles@user.com']);
@@ -199,6 +209,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_the_permission_middleware_if_have_a_different_permission()
     {
         Auth::login($this->testUser);
@@ -212,6 +223,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_the_permission_middleware_if_have_a_different_permission(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -229,6 +241,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_permission_middleware_if_have_not_permissions()
     {
         Auth::login($this->testUser);
@@ -240,6 +253,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_permission_middleware_if_have_not_permissions(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -255,6 +269,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_permission_middleware_if_has_permission_via_role()
     {
         Auth::login($this->testUser);
@@ -274,6 +289,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_access_a_route_protected_by_permission_middleware_if_has_permission_via_role(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -297,6 +313,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_permissions_can_be_fetched_from_the_exception()
     {
         Auth::login($this->testUser);
@@ -318,6 +335,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_permissions_can_be_displayed_in_the_exception()
     {
         Auth::login($this->testUser);
@@ -337,6 +355,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function use_not_existing_custom_guard_in_permission()
     {
         $class = null;
@@ -353,6 +372,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_can_not_access_permission_with_guard_admin_while_login_using_default_guard()
     {
         Auth::login($this->testUser);
@@ -366,6 +386,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function client_can_not_access_permission_with_guard_admin_while_login_using_default_guard(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -383,6 +404,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_can_access_permission_with_guard_admin_while_login_using_admin_guard()
     {
         Auth::guard('admin')->login($this->testAdmin);
@@ -396,6 +418,7 @@ class PermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_middleware_can_be_created_with_static_using_method()
     {
         $this->assertSame(

--- a/tests/PermissionRegistrarTest.php
+++ b/tests/PermissionRegistrarTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission as PermissionContract;
 use Spatie\Permission\Contracts\Role as RoleContract;
 use Spatie\Permission\Models\Permission as SpatiePermission;
@@ -13,6 +14,7 @@ use Spatie\Permission\Tests\TestModels\Role as TestRole;
 class PermissionRegistrarTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_clear_loaded_permissions_collection()
     {
         $reflectedClass = new \ReflectionClass(app(PermissionRegistrar::class));
@@ -29,6 +31,7 @@ class PermissionRegistrarTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_uids()
     {
         $uids = [
@@ -72,6 +75,7 @@ class PermissionRegistrarTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_get_permission_class()
     {
         $this->assertSame(SpatiePermission::class, app(PermissionRegistrar::class)->getPermissionClass());
@@ -79,6 +83,7 @@ class PermissionRegistrarTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_change_permission_class()
     {
         $this->assertSame(SpatiePermission::class, config('permission.models.permission'));
@@ -93,6 +98,7 @@ class PermissionRegistrarTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_get_role_class()
     {
         $this->assertSame(SpatieRole::class, app(PermissionRegistrar::class)->getRoleClass());
@@ -100,6 +106,7 @@ class PermissionRegistrarTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_change_role_class()
     {
         $this->assertSame(SpatieRole::class, config('permission.models.role'));
@@ -114,6 +121,7 @@ class PermissionRegistrarTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_change_team_id()
     {
         $team_id = '00000000-0000-0000-0000-000000000000';

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
 use Spatie\Permission\Tests\TestModels\User;
@@ -9,6 +10,7 @@ use Spatie\Permission\Tests\TestModels\User;
 class PermissionTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_get_user_models_using_with()
     {
         $this->testUser->givePermissionTo($this->testUserPermission);
@@ -23,6 +25,7 @@ class PermissionTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_the_permission_already_exists()
     {
         $this->expectException(PermissionAlreadyExists::class);
@@ -32,6 +35,7 @@ class PermissionTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_belongs_to_a_guard()
     {
         $permission = app(Permission::class)->create(['name' => 'can-edit', 'guard_name' => 'admin']);
@@ -40,6 +44,7 @@ class PermissionTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_belongs_to_the_default_guard_by_default()
     {
         $this->assertEquals(
@@ -49,6 +54,7 @@ class PermissionTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_has_user_models_of_the_right_class()
     {
         $this->testAdmin->givePermissionTo($this->testAdminPermission);
@@ -61,6 +67,7 @@ class PermissionTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_is_retrievable_by_id()
     {
         $permission_by_id = app(Permission::class)->findById($this->testUserPermission->id);
@@ -69,6 +76,7 @@ class PermissionTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_delete_hydrated_permissions()
     {
         $this->reloadPermissions();

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -4,11 +4,13 @@ namespace Spatie\Permission\Tests;
 
 use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Access\Gate;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Tests\TestModels\Content;
 
 class PolicyTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function policy_methods_and_before_intercepts_can_allow_and_deny()
     {
         $record1 = Content::create(['content' => 'special admin content']);

--- a/tests/RoleMiddlewareTest.php
+++ b/tests/RoleMiddlewareTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Tests\TestModels\UserWithoutHasRoles;
@@ -26,6 +27,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_guest_cannot_access_a_route_protected_by_rolemiddleware()
     {
         $this->assertEquals(
@@ -35,6 +37,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_role_middleware_of_another_guard()
     {
         Auth::login($this->testUser);
@@ -48,6 +51,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_role_middleware_of_another_guard(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -65,6 +69,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_role_middleware_if_have_this_role()
     {
         Auth::login($this->testUser);
@@ -78,6 +83,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_access_a_route_protected_by_role_middleware_if_have_this_role(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -95,6 +101,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_this_role_middleware_if_have_one_of_the_roles()
     {
         Auth::login($this->testUser);
@@ -113,6 +120,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_access_a_route_protected_by_this_role_middleware_if_have_one_of_the_roles(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -135,6 +143,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_the_role_middleware_if_have_not_has_roles_trait()
     {
         $userWithoutHasRoles = UserWithoutHasRoles::create(['email' => 'test_not_has_roles@user.com']);
@@ -148,6 +157,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_the_role_middleware_if_have_a_different_role()
     {
         Auth::login($this->testUser);
@@ -161,6 +171,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_the_role_middleware_if_have_a_different_role(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -178,6 +189,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_role_middleware_if_have_not_roles()
     {
         Auth::login($this->testUser);
@@ -189,6 +201,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_role_middleware_if_have_not_roles(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -204,6 +217,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_role_middleware_if_role_is_undefined()
     {
         Auth::login($this->testUser);
@@ -215,6 +229,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_cannot_access_a_route_protected_by_role_middleware_if_role_is_undefined(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -230,6 +245,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_roles_can_be_fetched_from_the_exception()
     {
         Auth::login($this->testUser);
@@ -251,6 +267,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_roles_can_be_displayed_in_the_exception()
     {
         Auth::login($this->testUser);
@@ -270,6 +287,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function use_not_existing_custom_guard_in_role()
     {
         $class = null;
@@ -286,6 +304,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_can_not_access_role_with_guard_admin_while_login_using_default_guard()
     {
         Auth::login($this->testUser);
@@ -299,6 +318,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function client_can_not_access_role_with_guard_admin_while_login_using_default_guard(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -316,6 +336,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_can_access_role_with_guard_admin_while_login_using_admin_guard()
     {
         Auth::guard('admin')->login($this->testAdmin);
@@ -329,6 +350,7 @@ class RoleMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_middleware_can_be_created_with_static_using_method()
     {
         $this->assertSame(

--- a/tests/RoleOrPermissionMiddlewareTest.php
+++ b/tests/RoleOrPermissionMiddlewareTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 use Laravel\Passport\Passport;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
 use Spatie\Permission\Tests\TestModels\UserWithoutHasRoles;
@@ -27,6 +28,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_guest_cannot_access_a_route_protected_by_the_role_or_permission_middleware()
     {
         $this->assertEquals(
@@ -36,6 +38,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_permission_or_role_middleware_if_has_this_permission_or_role()
     {
         Auth::login($this->testUser);
@@ -70,6 +73,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_access_a_route_protected_by_permission_or_role_middleware_if_has_this_permission_or_role(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -108,6 +112,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_super_admin_user_can_access_a_route_protected_by_permission_or_role_middleware()
     {
         Auth::login($this->testUser);
@@ -123,6 +128,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_not_access_a_route_protected_by_permission_or_role_middleware_if_have_not_has_roles_trait()
     {
         $userWithoutHasRoles = UserWithoutHasRoles::create(['email' => 'test_not_has_roles@user.com']);
@@ -136,6 +142,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_not_access_a_route_protected_by_permission_or_role_middleware_if_have_not_this_permission_and_role()
     {
         Auth::login($this->testUser);
@@ -152,6 +159,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_client_can_not_access_a_route_protected_by_permission_or_role_middleware_if_have_not_this_permission_and_role(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -172,6 +180,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function use_not_existing_custom_guard_in_role_or_permission()
     {
         $class = null;
@@ -188,6 +197,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_can_not_access_permission_or_role_with_guard_admin_while_login_using_default_guard()
     {
         Auth::login($this->testUser);
@@ -202,6 +212,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function client_can_not_access_permission_or_role_with_guard_admin_while_login_using_default_guard(): void
     {
         if ($this->getLaravelVersion() < 9) {
@@ -220,6 +231,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function user_can_access_permission_or_role_with_guard_admin_while_login_using_admin_guard()
     {
         Auth::guard('admin')->login($this->testAdmin);
@@ -234,6 +246,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_permissions_or_roles_can_be_fetched_from_the_exception()
     {
         Auth::login($this->testUser);
@@ -255,6 +268,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_permissions_or_roles_can_be_displayed_in_the_exception()
     {
         Auth::login($this->testUser);
@@ -275,6 +289,7 @@ class RoleOrPermissionMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_middleware_can_be_created_with_static_using_method()
     {
         $this->assertSame(

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Exceptions\GuardDoesNotMatch;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
@@ -25,6 +26,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_get_user_models_using_with()
     {
         $this->testUser->assignRole($this->testUserRole);
@@ -38,6 +40,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_has_user_models_of_the_right_class()
     {
         $this->testAdmin->assignRole($this->testAdminRole);
@@ -54,6 +57,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_the_role_already_exists()
     {
         $this->expectException(RoleAlreadyExists::class);
@@ -63,6 +67,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_permission()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -71,6 +76,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_given_a_permission_that_does_not_exist()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -79,6 +85,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_given_a_permission_that_belongs_to_another_guard()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -91,6 +98,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_multiple_permissions_using_an_array()
     {
         $this->testUserRole->givePermissionTo(['edit-articles', 'edit-news']);
@@ -100,6 +108,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_multiple_permissions_using_multiple_arguments()
     {
         $this->testUserRole->givePermissionTo('edit-articles', 'edit-news');
@@ -109,6 +118,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_permissions()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -121,6 +131,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_syncing_permissions_that_do_not_exist()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -131,6 +142,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_syncing_permissions_that_belong_to_a_different_guard()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -145,6 +157,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_will_remove_all_permissions_when_passing_an_empty_array_to_sync_permissions()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -159,6 +172,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function sync_permission_error_does_not_detach_permissions()
     {
         $this->testUserRole->givePermissionTo('edit-news');
@@ -171,6 +185,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_revoke_a_permission()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -185,6 +200,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_permission_using_objects()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);
@@ -193,12 +209,14 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_if_it_does_not_have_the_permission()
     {
         $this->assertFalse($this->testUserRole->hasPermissionTo('other-permission'));
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_if_the_permission_does_not_exist()
     {
         $this->expectException(PermissionDoesNotExist::class);
@@ -207,6 +225,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_if_it_does_not_have_a_permission_object()
     {
         $permission = app(Permission::class)->findByName('other-permission');
@@ -215,6 +234,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_creates_permission_object_with_findOrCreate_if_it_does_not_have_a_permission_object()
     {
         $permission = app(Permission::class)->findOrCreate('another-permission');
@@ -229,6 +249,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_creates_a_role_with_findOrCreate_if_the_named_role_does_not_exist()
     {
         $this->expectException(RoleDoesNotExist::class);
@@ -243,6 +264,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_an_exception_when_a_permission_of_the_wrong_guard_is_passed_in()
     {
         $this->expectException(GuardDoesNotMatch::class);
@@ -253,6 +275,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_belongs_to_a_guard()
     {
         $role = app(Role::class)->create(['name' => 'admin', 'guard_name' => 'admin']);
@@ -261,6 +284,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_belongs_to_the_default_guard_by_default()
     {
         $this->assertEquals(
@@ -270,6 +294,7 @@ class RoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_change_role_class_on_runtime()
     {
         $role = app(Role::class)->create(['name' => 'test-role-old']);

--- a/tests/RoleWithNestingTest.php
+++ b/tests/RoleWithNestingTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Tests\TestModels\Role;
 
 class RoleWithNestingTest extends TestCase
@@ -62,6 +64,8 @@ class RoleWithNestingTest extends TestCase
     /** @test
      * @dataProvider roles_list
      */
+    #[DataProvider('roles_list')]
+    #[Test]
     public function it_returns_correct_withCount_of_nested_roles($role_group, $index, $relation, $expectedCount)
     {
         $role = $this->$role_group[$index];

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -2,9 +2,12 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class RouteTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function test_role_function()
     {
         $router = $this->getRouter();
@@ -17,6 +20,7 @@ class RouteTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function test_permission_function()
     {
         $router = $this->getRouter();
@@ -29,6 +33,7 @@ class RouteTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function test_role_and_permission_function_together()
     {
         $router = $this->getRouter();

--- a/tests/TeamHasPermissionsTest.php
+++ b/tests/TeamHasPermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Tests\TestModels\User;
 
 class TeamHasPermissionsTest extends HasPermissionsTest
@@ -10,6 +11,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     protected $hasTeams = true;
 
     /** @test */
+    #[Test]
     public function it_can_assign_same_and_different_permission_on_same_user_on_different_teams()
     {
         setPermissionsTeamId(1);
@@ -38,6 +40,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_list_all_the_coupled_permissions_both_directly_and_via_roles_on_same_user_on_different_teams()
     {
         $this->testUserRole->givePermissionTo('edit-articles');
@@ -68,6 +71,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_or_remove_permission_without_detach_on_different_teams()
     {
         setPermissionsTeamId(1);
@@ -99,6 +103,7 @@ class TeamHasPermissionsTest extends HasPermissionsTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_on_different_teams()
     {
         $user1 = User::create(['email' => 'user1@test.com']);

--- a/tests/TeamHasRolesTest.php
+++ b/tests/TeamHasRolesTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Role;
 use Spatie\Permission\Tests\TestModels\User;
 
@@ -11,6 +12,7 @@ class TeamHasRolesTest extends HasRolesTest
     protected $hasTeams = true;
 
     /** @test */
+    #[Test]
     public function it_deletes_pivot_table_entries_when_deleting_models()
     {
         $user1 = User::create(['email' => 'user2@test.com']);
@@ -37,6 +39,7 @@ class TeamHasRolesTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_assign_same_and_different_roles_on_same_user_different_teams()
     {
         app(Role::class)->create(['name' => 'testRole3']); // team_test_id = 1 by main class
@@ -84,6 +87,7 @@ class TeamHasRolesTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_sync_or_remove_roles_without_detach_on_different_teams()
     {
         app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
@@ -118,6 +122,7 @@ class TeamHasRolesTest extends HasRolesTest
     }
 
     /** @test */
+    #[Test]
     public function it_can_scope_users_on_different_teams()
     {
         User::all()->each(fn ($item) => $item->delete());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,10 +23,10 @@ use Spatie\Permission\Tests\TestModels\User;
 
 abstract class TestCase extends Orchestra
 {
-    /** @var \Spatie\Permission\Tests\User */
+    /** @var \Spatie\Permission\Tests\TestModels\User */
     protected $testUser;
 
-    /** @var \Spatie\Permission\Tests\Admin */
+    /** @var \Spatie\Permission\Tests\TestModels\Admin */
     protected $testAdmin;
 
     /** @var \Spatie\Permission\Models\Role */

--- a/tests/TestModels/Client.php
+++ b/tests/TestModels/Client.php
@@ -14,8 +14,6 @@ class Client extends BaseClient implements AuthorizableContract
 
     /**
      * Required to make clear that the client requires the api guard
-     *
-     * @var string
      */
-    protected $guard_name = 'api';
+    protected string $guard_name = 'api';
 }

--- a/tests/TestModels/Manager.php
+++ b/tests/TestModels/Manager.php
@@ -6,11 +6,11 @@ class Manager extends User
 {
     // this function is added here to support the unit tests verifying it works
     // When present, it takes precedence over the $guard_name property.
-    public function guardName()
+    public function guardName(): string
     {
         return 'jwt';
     }
 
     // intentionally different property value for the sake of unit tests
-    protected $guard_name = 'web';
+    protected string $guard_name = 'web';
 }

--- a/tests/TestModels/Permission.php
+++ b/tests/TestModels/Permission.php
@@ -3,6 +3,7 @@
 namespace Spatie\Permission\Tests\TestModels;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Permission extends \Spatie\Permission\Models\Permission
 {
@@ -18,19 +19,19 @@ class Permission extends \Spatie\Permission\Models\Permission
     protected static function boot()
     {
         parent::boot();
-        static::creating(function ($model) {
+        static::creating(static function ($model) {
             if (empty($model->{$model->getKeyName()})) {
-                $model->{$model->getKeyName()} = \Str::uuid()->toString();
+                $model->{$model->getKeyName()} = Str::uuid()->toString();
             }
         });
     }
 
-    public function getIncrementing()
+    public function getIncrementing(): bool
     {
         return false;
     }
 
-    public function getKeyType()
+    public function getKeyType(): string
     {
         return 'string';
     }

--- a/tests/TestModels/Role.php
+++ b/tests/TestModels/Role.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\Permission\Tests\TestModels;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class Role extends \Spatie\Permission\Models\Role
 {
@@ -17,10 +19,7 @@ class Role extends \Spatie\Permission\Models\Role
 
     const HIERARCHY_TABLE = 'roles_hierarchy';
 
-    /**
-     * @return string|\BackedEnum
-     */
-    public function getNameAttribute()
+    public function getNameAttribute(): \BackedEnum|string
     {
         $name = $this->attributes['name'];
 
@@ -31,10 +30,7 @@ class Role extends \Spatie\Permission\Models\Role
         return $name;
     }
 
-    /**
-     * @return BelongsToMany
-     */
-    public function parents()
+    public function parents(): BelongsToMany
     {
         return $this->belongsToMany(
             static::class,
@@ -43,10 +39,7 @@ class Role extends \Spatie\Permission\Models\Role
             'parent_id');
     }
 
-    /**
-     * @return BelongsToMany
-     */
-    public function children()
+    public function children(): BelongsToMany
     {
         return $this->belongsToMany(
             static::class,
@@ -58,19 +51,19 @@ class Role extends \Spatie\Permission\Models\Role
     protected static function boot()
     {
         parent::boot();
-        static::creating(function ($model) {
+        static::creating(static function ($model) {
             if (empty($model->{$model->getKeyName()})) {
-                $model->{$model->getKeyName()} = \Str::uuid()->toString();
+                $model->{$model->getKeyName()} = Str::uuid()->toString();
             }
         });
     }
 
-    public function getIncrementing()
+    public function getIncrementing(): bool
     {
         return false;
     }
 
-    public function getKeyType()
+    public function getKeyType(): string
     {
         return 'string';
     }

--- a/tests/TestModels/SoftDeletingUser.php
+++ b/tests/TestModels/SoftDeletingUser.php
@@ -8,5 +8,5 @@ class SoftDeletingUser extends User
 {
     use SoftDeletes;
 
-    protected $guard_name = 'web';
+    protected string $guard_name = 'web';
 }

--- a/tests/TestModels/TestRolePermissionsEnum.php
+++ b/tests/TestModels/TestRolePermissionsEnum.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Permission\Tests\TestModels;
 
+use Illuminate\Support\Str;
+
 /**
  * Enum example
  *
@@ -53,6 +55,8 @@ enum TestRolePermissionsEnum: string
 
             self::VIEWARTICLES => 'View Articles',
             self::EDITARTICLES => 'Edit Articles',
+
+            default => Str::words($this->name)
         };
     }
 }

--- a/tests/TestModels/WildcardPermission.php
+++ b/tests/TestModels/WildcardPermission.php
@@ -9,9 +9,9 @@ class WildcardPermission extends BaseWildcardPermission
     /** @var string */
     public const WILDCARD_TOKEN = '@';
 
-    /** @var string */
+    /** @var non-empty-string */
     public const PART_DELIMITER = ':';
 
-    /** @var string */
+    /** @var non-empty-string */
     public const SUBPART_DELIMITER = ';';
 }

--- a/tests/WildcardHasPermissionsTest.php
+++ b/tests/WildcardHasPermissionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Exceptions\WildcardPermissionInvalidArgument;
 use Spatie\Permission\Exceptions\WildcardPermissionNotProperlyFormatted;
@@ -12,6 +14,7 @@ use Spatie\Permission\Tests\TestModels\WildcardPermission;
 class WildcardHasPermissionsTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_check_wildcard_permission()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -32,6 +35,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_wildcard_permission_for_a_non_default_guard()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -52,6 +56,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_wildcard_permission_from_instance_without_explicit_guard_argument()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -77,6 +82,8 @@ class WildcardHasPermissionsTest extends TestCase
      *
      * @requires PHP >= 8.1
      */
+    #[RequiresPhp('>= 8.1')]
+    #[Test]
     public function it_can_assign_wildcard_permissions_using_enums()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -114,6 +121,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_wildcard_permissions_via_roles()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -137,6 +145,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_custom_wildcard_permission()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -160,6 +169,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_custom_wildcard_permissions_via_roles()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -186,6 +196,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_check_non_wildcard_permissions()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -204,6 +215,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_verify_complex_wildcard_permissions()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -224,6 +236,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_exception_when_wildcard_permission_is_not_properly_formatted()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -240,6 +253,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_verify_permission_instances_not_assigned_to_user()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -258,6 +272,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_verify_permission_instances_assigned_to_user()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -276,6 +291,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_verify_integers_as_strings()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -290,6 +306,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_exception_when_permission_has_invalid_arguments()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -302,6 +319,7 @@ class WildcardHasPermissionsTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_throws_exception_when_permission_id_not_exists()
     {
         app('config')->set('permission.enable_wildcard_permission', true);

--- a/tests/WildcardMiddlewareTest.php
+++ b/tests/WildcardMiddlewareTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Permission\Tests;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Exceptions\UnauthorizedException;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 use Spatie\Permission\Middleware\RoleMiddleware;
@@ -33,6 +34,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_guest_cannot_access_a_route_protected_by_the_permission_middleware()
     {
         $this->assertEquals(
@@ -42,6 +44,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_permission_middleware_if_have_this_permission()
     {
         Auth::login($this->testUser);
@@ -57,6 +60,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_this_permission_middleware_if_have_one_of_the_permissions()
     {
         Auth::login($this->testUser);
@@ -77,6 +81,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_the_permission_middleware_if_have_a_different_permission()
     {
         Auth::login($this->testUser);
@@ -92,6 +97,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_cannot_access_a_route_protected_by_permission_middleware_if_have_not_permissions()
     {
         Auth::login($this->testUser);
@@ -103,6 +109,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function a_user_can_access_a_route_protected_by_permission_or_role_middleware_if_has_this_permission_or_role()
     {
         Auth::login($this->testUser);
@@ -139,6 +146,7 @@ class WildcardMiddlewareTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function the_required_permissions_can_be_fetched_from_the_exception()
     {
         Auth::login($this->testUser);

--- a/tests/WildcardRoleTest.php
+++ b/tests/WildcardRoleTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Models\Permission;
 
 class WildcardRoleTest extends TestCase
@@ -18,6 +19,7 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_permission()
     {
         Permission::create(['name' => 'posts.*']);
@@ -27,6 +29,7 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_multiple_permissions_using_an_array()
     {
         Permission::create(['name' => 'posts.*']);
@@ -39,6 +42,7 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_multiple_permissions_using_multiple_arguments()
     {
         Permission::create(['name' => 'posts.*']);
@@ -51,6 +55,7 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_can_be_given_a_permission_using_objects()
     {
         $this->testUserRole->givePermissionTo($this->testUserPermission);
@@ -59,18 +64,21 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_if_it_does_not_have_the_permission()
     {
         $this->assertFalse($this->testUserRole->hasPermissionTo('other-permission'));
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_if_permission_does_not_exists()
     {
         $this->assertFalse($this->testUserRole->hasPermissionTo('doesnt-exist'));
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_if_it_does_not_have_a_permission_object()
     {
         $permission = app(Permission::class)->findByName('other-permission');
@@ -79,6 +87,7 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_creates_permission_object_with_findOrCreate_if_it_does_not_have_a_permission_object()
     {
         $permission = app(Permission::class)->findOrCreate('another-permission');
@@ -93,6 +102,7 @@ class WildcardRoleTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function it_returns_false_when_a_permission_of_the_wrong_guard_is_passed_in()
     {
         $permission = app(Permission::class)->findByName('wrong-guard-permission', 'admin');

--- a/tests/WildcardRouteTest.php
+++ b/tests/WildcardRouteTest.php
@@ -2,9 +2,12 @@
 
 namespace Spatie\Permission\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
+
 class WildcardRouteTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function test_permission_function()
     {
         app('config')->set('permission.enable_wildcard_permission', true);
@@ -19,6 +22,7 @@ class WildcardRouteTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function test_role_and_permission_function_together()
     {
         app('config')->set('permission.enable_wildcard_permission', true);


### PR DESCRIPTION
Annotations supported since PHPUnit 10
Docblock comments will be ignored in future

In a later release of this package (probably `v7.0`), will remove PHPUnit 9 support and all associated doc-comments.