### PR TITLE
Added backed enum as possible role and permission name when finding or creating them

### DIFF
--- a/src/Contracts/Permission.php
+++ b/src/Contracts/Permission.php
@@ -26,7 +26,7 @@ interface Permission
      *
      * @throws \Spatie\Permission\Exceptions\PermissionDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName): self;
+    public static function findByName(string|\BackedEnum $name, ?string $guardName): self;
 
     /**
      * Find a permission by its id.
@@ -39,5 +39,5 @@ interface Permission
     /**
      * Find or Create a permission by its name and guard name.
      */
-    public static function findOrCreate(string $name, ?string $guardName): self;
+    public static function findOrCreate(string|\BackedEnum $name, ?string $guardName): self;
 }

--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -26,7 +26,7 @@ interface Role
      *
      * @throws \Spatie\Permission\Exceptions\RoleDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName): self;
+    public static function findByName(string|\BackedEnum $name, ?string $guardName): self;
 
     /**
      * Find a role by its id and guard name.
@@ -39,7 +39,7 @@ interface Role
     /**
      * Find or create a role by its name and guard name.
      */
-    public static function findOrCreate(string $name, ?string $guardName): self;
+    public static function findOrCreate(string|\BackedEnum $name, ?string $guardName): self;
 
     /**
      * Determine if the user may perform the given permission.

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -43,6 +43,10 @@ class Permission extends Model implements PermissionContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
+        $attributes['name'] = $attributes['name'] instanceof \BackedEnum
+            ? $attributes['name']->value
+            : $attributes['name'];
+
         $permission = static::getPermission(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']]);
 
         if ($permission) {
@@ -86,8 +90,12 @@ class Permission extends Model implements PermissionContract
      *
      * @throws PermissionDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName = null): PermissionContract
+    public static function findByName(string|\BackedEnum $name, ?string $guardName = null): PermissionContract
     {
+        if ($name instanceof \BackedEnum) {
+            $name = $name->value;
+        }
+
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
         if (! $permission) {
@@ -121,8 +129,12 @@ class Permission extends Model implements PermissionContract
      *
      * @return PermissionContract|Permission
      */
-    public static function findOrCreate(string $name, ?string $guardName = null): PermissionContract
+    public static function findOrCreate(string|\BackedEnum $name, ?string $guardName = null): PermissionContract
     {
+        if ($name instanceof \BackedEnum) {
+            $name = $name->value;
+        }
+
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -44,6 +44,10 @@ class Role extends Model implements RoleContract
     {
         $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
 
+        $attributes['name'] = $attributes['name'] instanceof \BackedEnum
+            ? $attributes['name']->value
+            : $attributes['name'];
+
         $params = ['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']];
         if (app(PermissionRegistrar::class)->teams) {
             $teamsKey = app(PermissionRegistrar::class)->teamsKey;
@@ -95,8 +99,12 @@ class Role extends Model implements RoleContract
      *
      * @throws RoleDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName = null): RoleContract
+    public static function findByName(string|\BackedEnum $name, ?string $guardName = null): RoleContract
     {
+        if ($name instanceof \BackedEnum) {
+            $name = $name->value;
+        }
+
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
@@ -131,14 +139,22 @@ class Role extends Model implements RoleContract
      *
      * @return RoleContract|Role
      */
-    public static function findOrCreate(string $name, ?string $guardName = null): RoleContract
+    public static function findOrCreate(string|\BackedEnum $name, ?string $guardName = null): RoleContract
     {
+        if ($name instanceof \BackedEnum) {
+            $name = $name->value;
+        }
+
         $guardName = $guardName ?? Guard::getDefaultName(static::class);
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $role) {
-            return static::query()->create(['name' => $name, 'guard_name' => $guardName] + (app(PermissionRegistrar::class)->teams ? [app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId()] : []));
+            return static::query()->create(
+                ['name' => $name, 'guard_name' => $guardName] + (app(PermissionRegistrar::class)->teams ? [
+                    app(PermissionRegistrar::class)->teamsKey => getPermissionsTeamId(),
+                ] : [])
+            );
         }
 
         return $role;
@@ -172,7 +188,7 @@ class Role extends Model implements RoleContract
     /**
      * Determine if the role may perform the given permission.
      *
-     * @param  string|int|\Spatie\Permission\Contracts\Permission|\BackedEnum  $permission
+     * @param string|int|\Spatie\Permission\Contracts\Permission|\BackedEnum $permission
      *
      * @throws PermissionDoesNotExist|GuardDoesNotMatch
      */
@@ -185,7 +201,10 @@ class Role extends Model implements RoleContract
         $permission = $this->filterPermission($permission, $guardName);
 
         if (! $this->getGuardNames()->contains($permission->guard_name)) {
-            throw GuardDoesNotMatch::create($permission->guard_name, $guardName ? collect([$guardName]) : $this->getGuardNames());
+            throw GuardDoesNotMatch::create(
+                $permission->guard_name,
+                $guardName ? collect([$guardName]) : $this->getGuardNames()
+            );
         }
 
         return $this->loadMissing('permissions')->permissions

--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -218,6 +218,10 @@ class PermissionRegistrar
 
         $permissions = $this->permissions->$method(static function ($permission) use ($params) {
             foreach ($params as $attr => $value) {
+                if ($value instanceof \BackedEnum) {
+                    $value = $value->value;
+                }
+
                 if ($permission->getAttribute($attr) != $value) {
                     return false;
                 }

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Permission\Tests;
 use PHPUnit\Framework\Attributes\Test;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
+use Spatie\Permission\Tests\TestModels\TestRolePermissionsEnum;
 use Spatie\Permission\Tests\TestModels\User;
 
 class PermissionTest extends TestCase
@@ -85,5 +86,26 @@ class PermissionTest extends TestCase
         $permission->delete();
 
         $this->assertCount(0, app(Permission::class)->where($this->testUserPermission->getKeyName(), $this->testUserPermission->getKey())->get());
+    }
+
+    /** @test */
+    #[Test]
+    public function it_can_find_or_create_permission_by_enum()
+    {
+        $permission = app(Permission::class)::findOrCreate(TestRolePermissionsEnum::VIEWARTICLES);
+
+        $this->assertEquals(TestRolePermissionsEnum::VIEWARTICLES->value, $permission->name);
+    }
+
+    /** @test */
+    #[Test]
+    public function it_can_find_permission_by_enum_name()
+    {
+        $permission = app(Permission::class)::create(['name' => TestRolePermissionsEnum::VIEWARTICLES]);
+        $foundPermission = app(Permission::class)::findByName(TestRolePermissionsEnum::VIEWARTICLES);
+
+        $this->assertEquals($permission->getKey(), $foundPermission->getKey());
+        $this->assertEquals(TestRolePermissionsEnum::VIEWARTICLES->value, $foundPermission->name);
+        $this->assertEquals($permission->name, $foundPermission->name);
     }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -12,6 +12,7 @@ use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Tests\TestModels\Admin;
 use Spatie\Permission\Tests\TestModels\RuntimeRole;
+use Spatie\Permission\Tests\TestModels\TestRolePermissionsEnum;
 use Spatie\Permission\Tests\TestModels\User;
 
 class RoleTest extends TestCase
@@ -317,5 +318,26 @@ class RoleTest extends TestCase
         $this->assertTrue($this->testUser->hasRole('test-role'));
         $this->assertInstanceOf(RuntimeRole::class, $this->testUser->roles[0]);
         $this->assertSame('test-role', $this->testUser->roles[0]->name);
+    }
+
+    /** @test */
+    #[Test]
+    public function it_can_find_or_create_role_by_enum()
+    {
+        $permission = app(Role::class)::findOrCreate(TestRolePermissionsEnum::ADMIN);
+
+        $this->assertEquals(TestRolePermissionsEnum::ADMIN->value, $permission->name);
+    }
+
+    /** @test */
+    #[Test]
+    public function it_can_find_role_by_enum_name()
+    {
+        $role = app(Role::class)::create(['name' => TestRolePermissionsEnum::ADMIN]);
+        $foundRole = app(Role::class)::findByName(TestRolePermissionsEnum::ADMIN);
+
+        $this->assertEquals($role->getKey(), $foundRole->getKey());
+        $this->assertEquals(TestRolePermissionsEnum::ADMIN->value, $foundRole->name);
+        $this->assertEquals($role->name, $foundRole->name);
     }
 }


### PR DESCRIPTION
When finding or creating roles and permissions, you can't use an enum like you can when assigning roles or permissions.
This PR adds support for backed enums when you find or create them. 

Like so:
```php
$permission = Permission::findOrCreate(PermissionEnum::VIEW_USERS);
$role = Role::findOrCreate(RoleEnum::ADMIN);
```