### PR TITLE
 Make hasPermissionViaRole method public in HasPermissions trait

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -305,7 +305,7 @@ trait HasPermissions
     /**
      * Determine if the model has, via roles, the given permission.
      */
-    protected function hasPermissionViaRole(Permission $permission): bool
+    public function hasPermissionViaRole(Permission $permission): bool
     {
         if (is_a($this, Role::class)) {
             return false;


### PR DESCRIPTION
## What's Changed
- Changed `hasPermissionViaRole` method from `protected` to `public`

## Why?
- Lets developers check role-based permissions directly
- Makes the package easier to use
- No breaking changes