### PR TITLE
Fix: Example in config comment includes `permission.` prefix on `wildcard_permission` key

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -172,7 +172,7 @@ return [
      * The class to use for interpreting wildcard permissions.
      * If you need to modify delimiters, override the class and specify its name here.
      */
-    // 'permission.wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
 
     /* Cache-specific settings */
 


### PR DESCRIPTION
In the `permission.php` template file, the example in the comments for how to override the `WildcardPermission` class incorrectly uses `permission.wildcard_permission` as the key instead of just `wildcard_permission`.

Developers attempting to point to a custom class who uncomment this line and only update the value will still be using the default provided `WildcardPermission` class.  This config entry is used in [src/Traits/HasPermissions.php](https://github.com/spatie/laravel-permission/blob/cc264a1d959e70742301156a1b06bbbcd262357e/src/Traits/HasPermissions.php#L66-L67) with the code `config('permission.wildcard_permission'...)`.  The convention of the `config` method is the value before the dot delimiter (`permission`) is the config file name (`permission.php`) and the value after the delimiter (`wildcard_permission`) is the key in the array returned to use. See https://laravel.com/docs/12.x/configuration#accessing-configuration-values for documentation.