### PR TITLE
Fix guard_name not used to set default attribute in Role and Permission model

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -26,7 +26,7 @@ class Permission extends Model implements PermissionContract
 
     public function __construct(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
+        $attributes['guard_name'] ??= Guard::getDefaultName(static::class);
 
         parent::__construct($attributes);
 
@@ -41,7 +41,7 @@ class Permission extends Model implements PermissionContract
      */
     public static function create(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
+        $attributes['guard_name'] ??= Guard::getDefaultName(static::class);
 
         $permission = static::getPermission(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']]);
 
@@ -88,7 +88,7 @@ class Permission extends Model implements PermissionContract
      */
     public static function findByName(string $name, ?string $guardName = null): PermissionContract
     {
-        $guardName = $guardName ?? Guard::getDefaultName(static::class);
+        $guardName ??= Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
         if (! $permission) {
             throw PermissionDoesNotExist::create($name, $guardName);
@@ -106,7 +106,7 @@ class Permission extends Model implements PermissionContract
      */
     public static function findById(int|string $id, ?string $guardName = null): PermissionContract
     {
-        $guardName = $guardName ?? Guard::getDefaultName(static::class);
+        $guardName ??= Guard::getDefaultName(static::class);
         $permission = static::getPermission([(new static)->getKeyName() => $id, 'guard_name' => $guardName]);
 
         if (! $permission) {
@@ -123,7 +123,7 @@ class Permission extends Model implements PermissionContract
      */
     public static function findOrCreate(string $name, ?string $guardName = null): PermissionContract
     {
-        $guardName = $guardName ?? Guard::getDefaultName(static::class);
+        $guardName ??= Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
 
         if (! $permission) {

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -27,7 +27,7 @@ class Role extends Model implements RoleContract
 
     public function __construct(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? config('auth.defaults.guard');
+        $attributes['guard_name'] ??= Guard::getDefaultName(static::class);
 
         parent::__construct($attributes);
 
@@ -42,7 +42,7 @@ class Role extends Model implements RoleContract
      */
     public static function create(array $attributes = [])
     {
-        $attributes['guard_name'] = $attributes['guard_name'] ?? Guard::getDefaultName(static::class);
+        $attributes['guard_name'] ??= Guard::getDefaultName(static::class);
 
         $params = ['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']];
         if (app(PermissionRegistrar::class)->teams) {
@@ -97,7 +97,7 @@ class Role extends Model implements RoleContract
      */
     public static function findByName(string $name, ?string $guardName = null): RoleContract
     {
-        $guardName = $guardName ?? Guard::getDefaultName(static::class);
+        $guardName ??= Guard::getDefaultName(static::class);
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 
@@ -115,7 +115,7 @@ class Role extends Model implements RoleContract
      */
     public static function findById(int|string $id, ?string $guardName = null): RoleContract
     {
-        $guardName = $guardName ?? Guard::getDefaultName(static::class);
+        $guardName ??= Guard::getDefaultName(static::class);
 
         $role = static::findByParam([(new static)->getKeyName() => $id, 'guard_name' => $guardName]);
 
@@ -133,7 +133,7 @@ class Role extends Model implements RoleContract
      */
     public static function findOrCreate(string $name, ?string $guardName = null): RoleContract
     {
-        $guardName = $guardName ?? Guard::getDefaultName(static::class);
+        $guardName ??= Guard::getDefaultName(static::class);
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
 


### PR DESCRIPTION
The Role and Permission model constructors don't use the $guard_name property to set $attributes['guard_name'] (through `Guard::getDefaultName()` as in all other methods).

Also, I believe the `getDefaultGuardName()` method and the `$guard_name` property should also be set in Role and Permission model, not just the User model as per the docs: https://spatie.be/docs/laravel-permission/v6/basic-usage/multiple-guards#content-forcing-use-of-a-single-guard