### PR TITLE
Remove `collectPermissions` that is not being assigned

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -450,7 +450,6 @@ trait HasPermissions
     public function syncPermissions(...$permissions)
     {
         if ($this->getModel()->exists) {
-            $this->collectPermissions($permissions);
             $this->permissions()->detach();
             $this->setRelation('permissions', collect());
         }


### PR DESCRIPTION
This is relatively straightforward. 

Because `syncPermissions` is calling `givePermissionTo` with the same passed permissions array directly, it does not need to call `collectPermissions`. 

In fact the call is not being assigned to any variable, so it is not really doing anything except wasting some time collecting the permissions, unless there is something I do not understand.

It does not seem to affect any tests so I think this should be fine!