### PR TITLE
Fix commented config key typo

### DIFF
--- a/config/permission.php
+++ b/config/permission.php
@@ -172,7 +172,7 @@ return [
      * The class to use for interpreting wildcard permissions.
      * If you need to modify delimiters, override the class and specify its name here.
      */
-    // 'permission.wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
 
     /* Cache-specific settings */
 


### PR DESCRIPTION
Closes #2843

>the correct key for this should just be "wildcard_permisson" without the permission. in front of it. If you uncomment this line and change to something custom (e.g. App\Models\CustomWildcardPermission::class) as recommended in the comment, it won't work