### PR TITLE
Remove `collectRoles` that is not being assigned

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -223,7 +223,6 @@ trait HasRoles
     public function syncRoles(...$roles)
     {
         if ($this->getModel()->exists) {
-            $this->collectRoles($roles);
             $this->roles()->detach();
             $this->setRelation('roles', collect());
         }


### PR DESCRIPTION
`syncRoles` does not need to call `collectRoles`.

The call is not being assigned to any variable, same as pull request https://github.com/spatie/laravel-permission/pull/2840 does but for roles.

It does not seem to affect any tests