### PR TITLE
Revert "Remove `collectPermissions` that is not being assigned"

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,3 +17,6 @@ parameters:
         # wildcard permissions:
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::getWildcardClass#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::getAllPermissions#'
+        # contract checks:
+        - '#Call to function is_a\(\) with (.*) and ''Spatie\\\\Permission\\\\Contracts\\\\Permission'' will always evaluate to true\.$#'
+        - '#Call to function is_a\(\) with (.*) and ''Spatie\\\\Permission\\\\Contracts\\\\Role'' will always evaluate to true\.$#'

--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -450,6 +450,7 @@ trait HasPermissions
     public function syncPermissions(...$permissions)
     {
         if ($this->getModel()->exists) {
+            $this->collectPermissions($permissions);
             $this->permissions()->detach();
             $this->setRelation('permissions', collect());
         }

--- a/tests/HasPermissionsTest.php
+++ b/tests/HasPermissionsTest.php
@@ -613,6 +613,23 @@ class HasPermissionsTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_can_avoid_detach_on_permission_that_does_not_exist_sync()
+    {
+        $this->testUser->syncPermissions('edit-articles');
+
+        try {
+            $this->testUser->syncPermissions('permission-does-not-exist');
+            $this->fail('Expected PermissionDoesNotExist exception was not thrown.');
+        } catch (PermissionDoesNotExist $e){
+            //
+        }
+
+        $this->assertTrue($this->testUser->hasDirectPermission('edit-articles'));
+        $this->assertFalse($this->testUser->checkPermissionTo('permission-does-not-exist'));
+    }
+
+    /** @test */
+    #[Test]
     public function it_can_sync_multiple_permissions_by_id()
     {
         $this->testUser->givePermissionTo('edit-news');

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -320,6 +320,23 @@ class HasRolesTest extends TestCase
 
     /** @test */
     #[Test]
+    public function it_can_avoid_detach_on_role_that_does_not_exist_sync()
+    {
+        $this->testUser->syncRoles('testRole');
+
+        try {
+            $this->testUser->syncRoles('role-does-not-exist');
+            $this->fail('Expected RoleDoesNotExist exception was not thrown.');
+        } catch (RoleDoesNotExist $e){
+            //
+        }
+
+        $this->assertTrue($this->testUser->hasRole('testRole'));
+        $this->assertFalse($this->testUser->hasRole('role-does-not-exist'));
+    }
+
+    /** @test */
+    #[Test]
     public function it_can_sync_multiple_roles()
     {
         $this->testUser->syncRoles('testRole', 'testRole2');


### PR DESCRIPTION
Reverts spatie/laravel-permission#2840

https://github.com/spatie/laravel-permission/pull/2850#issuecomment-2912742247
> @drbyte hi, I think #2840 should be reverted, and look for another type of optimization if I remember correctly, this line was there to avoid detaching in an error state.
> 
> I explain the problem better If you do `syncPermissions('permission doesnt exist')`, it will do a detach, then a `collectPermissions('permission doesnt exist')`, this step will generate `PermissionDoesNotExist` exception, so the detach is already permanent, the old permissions were lost, and the new ones were not added.
> 
> It was a quick solution that didn't add more queries to the process. Tests should have been added to prevent this problem from happening again. I'll add the tests.

