### PR TITLE
Allow removing multiple roles with the removeRole method

### DIFF
--- a/src/Events/RoleDetached.php
+++ b/src/Events/RoleDetached.php
@@ -18,8 +18,8 @@ class RoleDetached
     use SerializesModels;
 
     /**
-     * Internally the HasRoles trait passes $rolesOrIds as a single  Eloquent record
-     * Theoretically one could register the event to other places with an array etc
+     * Internally the HasRoles trait passes an array of role ids (eg: int's or uuid's)
+     * Theoretically one could register the event to other places passing other types
      * So a Listener should inspect the type of $rolesOrIds received before using.
      *
      * @param  array|int[]|string[]|Role|Role[]|Collection  $rolesOrIds

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -193,13 +193,14 @@ trait HasRoles
     /**
      * Revoke the given role from the model.
      *
-     * @param  string|int|Role|\BackedEnum  $role
+     * @param  string|int|array|Role|Collection|\BackedEnum  ...$role
+     * @return $this
      */
-    public function removeRole($role)
+    public function removeRole(...$role)
     {
-        $storedRole = $this->getStoredRole($role);
+        $roles = $this->collectRoles($role);
 
-        $this->roles()->detach($storedRole);
+        $this->roles()->detach($roles);
 
         $this->unsetRelation('roles');
 
@@ -208,7 +209,7 @@ trait HasRoles
         }
 
         if (config('permission.events_enabled')) {
-            event(new RoleDetached($this->getModel(), $storedRole));
+            event(new RoleDetached($this->getModel(), $roles));
         }
 
         return $this;

--- a/tests/HasRolesTest.php
+++ b/tests/HasRolesTest.php
@@ -181,42 +181,62 @@ class HasRolesTest extends TestCase
 
     /** @test */
     #[Test]
-    public function it_can_assign_a_role_using_an_object()
+    public function it_can_assign_and_remove_a_role_using_an_object()
     {
         $this->testUser->assignRole($this->testUserRole);
 
         $this->assertTrue($this->testUser->hasRole($this->testUserRole));
+
+        $this->testUser->removeRole($this->testUserRole);
+
+        $this->assertFalse($this->testUser->hasRole($this->testUserRole));
     }
 
     /** @test */
     #[Test]
-    public function it_can_assign_a_role_using_an_id()
+    public function it_can_assign_and_remove_a_role_using_an_id()
     {
         $this->testUser->assignRole($this->testUserRole->getKey());
 
         $this->assertTrue($this->testUser->hasRole($this->testUserRole));
+
+        $this->testUser->removeRole($this->testUserRole->getKey());
+
+        $this->assertFalse($this->testUser->hasRole($this->testUserRole));
     }
 
     /** @test */
     #[Test]
-    public function it_can_assign_multiple_roles_at_once()
+    public function it_can_assign_and_remove_multiple_roles_at_once()
     {
         $this->testUser->assignRole($this->testUserRole->getKey(), 'testRole2');
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
         $this->assertTrue($this->testUser->hasRole('testRole2'));
+
+        $this->testUser->removeRole($this->testUserRole->getKey(), 'testRole2');
+
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+
+        $this->assertFalse($this->testUser->hasRole('testRole2'));
     }
 
     /** @test */
     #[Test]
-    public function it_can_assign_multiple_roles_using_an_array()
+    public function it_can_assign_and_remove_multiple_roles_using_an_array()
     {
         $this->testUser->assignRole([$this->testUserRole->getKey(), 'testRole2']);
 
         $this->assertTrue($this->testUser->hasRole('testRole'));
 
         $this->assertTrue($this->testUser->hasRole('testRole2'));
+
+        $this->testUser->removeRole([$this->testUserRole->getKey(), 'testRole2']);
+
+        $this->assertFalse($this->testUser->hasRole('testRole'));
+
+        $this->assertFalse($this->testUser->hasRole('testRole2'));
     }
 
     /** @test */
@@ -973,14 +993,19 @@ class HasRolesTest extends TestCase
         Event::fake();
         app('config')->set('permission.events_enabled', true);
 
-        $this->testUser->assignRole('testRole');
+        $this->testUser->assignRole('testRole', 'testRole2');
 
-        $this->testUser->removeRole('testRole');
+        $this->testUser->removeRole('testRole', 'testRole2');
 
-        Event::assertDispatched(RoleDetached::class, function ($event) {
+        $roleIds = app(Role::class)::whereIn('name', ['testRole', 'testRole2'])
+            ->pluck($this->testUserRole->getKeyName())
+            ->toArray();
+
+        Event::assertDispatched(RoleDetached::class, function ($event) use ($roleIds) {
             return $event->model instanceof User
                 && ! $event->model->hasRole('testRole')
-                && $event->rolesOrIds->name === 'testRole';
+                && ! $event->model->hasRole('testRole2')
+                && $event->rolesOrIds === $roleIds;
         });
     }
 


### PR DESCRIPTION
This PR updates the `removeRole` method on the `HasRoles` trait, allowing the removal of one or multiple roles simultaneously, matching the behavior of the existing `assignRole` method.
It also adjusts the comment in the `RoleDetached` event to align with the existing `RoleAttached` event, clarifying that multiple roles or role IDs can be passed.

I have intentionally kept the parameter name $role (singular) in the method signature to avoid unnecessary breaking changes. The existing assignRole method, however, uses $roles (plural). Should we rename the parameter to $roles for consistency, or is keeping $role preferred to preserve backward compatibility?