### PR TITLE
[Docs] Correct middleware order for documentation example in `teams-permissions.md`

### DIFF
--- a/docs/basic-usage/teams-permissions.md
+++ b/docs/basic-usage/teams-permissions.md
@@ -77,8 +77,8 @@ class AppServiceProvider extends ServiceProvider
         $kernel = app()->make(Kernel::class);
 
         $kernel->addToMiddlewarePriorityBefore(
-            SubstituteBindings::class,
             YourCustomMiddlewareClass::class,
+            SubstituteBindings::class,
         );
     }
 }


### PR DESCRIPTION
Correct middleware order for documentation example in `teams-permissions.md`.