### PR TITLE
Add Missing roleOrPermission() route macro

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -164,6 +164,14 @@ class PermissionServiceProvider extends ServiceProvider
             /** @var Route $this */
             return $this->middleware('permission:'.implode('|', $permissions));
         });
+
+        Route::macro('roleOrPermission', function ($rolesOrPermissions = []) {
+            $rolesOrPermissions = Arr::wrap($rolesOrPermissions);
+            $rolesOrPermissions = array_map(fn ($item) => $item instanceof \BackedEnum ? $item->value : $item, $rolesOrPermissions);
+
+            /** @var Route $this */
+            return $this->middleware('role_or_permission:'.implode('|', $rolesOrPermissions));
+        });
     }
 
     /**

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -115,4 +115,69 @@ class RouteTest extends TestCase
             $this->getLastRouteMiddlewareFromRouter($router)
         );
     }
+
+    /** @test */
+    #[Test]
+    public function test_role_or_permission_function()
+    {
+        $router = $this->getRouter();
+
+        $router->get('role-or-permission-test', $this->getRouteResponse())
+            ->name('role-or-permission.test')
+            ->roleOrPermission('admin|edit articles');
+
+        $this->assertEquals(['role_or_permission:admin|edit articles'], $this->getLastRouteMiddlewareFromRouter($router));
+    }
+
+    /** @test */
+    #[Test]
+    public function test_role_or_permission_function_with_array()
+    {
+        $router = $this->getRouter();
+
+        $router->get('role-or-permission-array-test', $this->getRouteResponse())
+            ->name('role-or-permission-array.test')
+            ->roleOrPermission(['admin', 'edit articles']);
+
+        $this->assertEquals(['role_or_permission:admin|edit articles'], $this->getLastRouteMiddlewareFromRouter($router));
+    }
+
+    /**
+     * @test
+     *
+     * @requires PHP 8.1.0
+     */
+    #[RequiresPhp('>= 8.1.0')]
+    #[Test]
+    public function test_role_or_permission_function_with_backed_enum()
+    {
+        $router = $this->getRouter();
+
+        $router->get('role-or-permission-test.enum', $this->getRouteResponse())
+            ->name('role-or-permission.test.enum')
+            ->roleOrPermission(TestRolePermissionsEnum::USERMANAGER);
+
+        $this->assertEquals(['role_or_permission:'.TestRolePermissionsEnum::USERMANAGER->value], $this->getLastRouteMiddlewareFromRouter($router));
+    }
+
+    /**
+     * @test
+     *
+     * @requires PHP 8.1.0
+     */
+    #[RequiresPhp('>= 8.1.0')]
+    #[Test]
+    public function test_role_or_permission_function_with_backed_enum_array()
+    {
+        $router = $this->getRouter();
+
+        $router->get('role-or-permission-array-test.enum', $this->getRouteResponse())
+            ->name('role-or-permission-array.test.enum')
+            ->roleOrPermission([TestRolePermissionsEnum::USERMANAGER, TestRolePermissionsEnum::EDITARTICLES]); // @phpstan-ignore-line
+
+        $this->assertEquals(
+            ['role_or_permission:'.TestRolePermissionsEnum::USERMANAGER->value.'|'.TestRolePermissionsEnum::EDITARTICLES->value], // @phpstan-ignore-line
+            $this->getLastRouteMiddlewareFromRouter($router)
+        );
+    }
 }


### PR DESCRIPTION
The package provides route macro helpers for `role()` and `permission()`, but not for `roleOrPermission()`, creating an inconsistent API. This makes the developer experience inconsistent when trying to use the fluent route API for role-or-permission checks.

Github Issue: https://github.com/spatie/laravel-permission/issues/2892