### PR TITLE
Update minimum constraint for test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "laravel/passport": "^11.0|^12.0",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^6.23|^7.0|^8.0|^9.3|^10.0",
         "phpunit/phpunit": "^9.4|^10.1|^11.5"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Test Suite errors: `Error: Access to undeclared static property  $latestResponse` 
Only triggers with Laravel 11, with PHP 8.2+, in composer's `prefer-lowest` mode.

Suspecting a limitation in Orchestra Testbench 9.0 which may have been fixed in later versions, since it doesn't trigger in testbench 9.15.0.
Thus, this PR bumps the minimum 9.0 to 9.3 for testbench.