### PR TITLE
Skip prefer-lowest dependency version for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,8 @@ jobs:
             - laravel: "^12.0"
               php: 8.0
             - laravel: "^11.0"
+              dependency-version: prefer-lowest
+            - laravel: "^11.0"
               php: 8.1
             - laravel: "^11.0"
               php: 8.0


### PR DESCRIPTION
Orchestra Testbench triggering `Error: Access to undeclared static property  $latestResponse` in prefer-lowest with Laravel 11
