### PR TITLE
Fix deprecated usage of `null` as array key

### DIFF
--- a/src/WildcardPermission.php
+++ b/src/WildcardPermission.php
@@ -43,7 +43,7 @@ class WildcardPermission implements Wildcard
     protected function buildIndex(array $index, array $parts, string $permission): array
     {
         if (empty($parts)) {
-            $index[null] = true;
+            $index[''] = true;
 
             return $index;
         }


### PR DESCRIPTION
This is deprecated as of PHP 8.5; see also https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists.