### PR TITLE
Change PHP requirement from ^8.4 to ^8.3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.5, 8.4]
+        php: [8.5, 8.4, 8.3]
         laravel: ["^13", "^12"]
         dependency-version: [prefer-stable, prefer-lowest]
         include:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "homepage": "https://github.com/spatie/laravel-permission",
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "illuminate/auth": "^12.0|^13.0",
         "illuminate/container": "^12.0|^13.0",
         "illuminate/contracts": "^12.0|^13.0",


### PR DESCRIPTION
- Closes #2938
- Reverts https://github.com/spatie/laravel-permission/commit/e50fec4bd7db90cff4a69c045553b083784ff3e1

> The docs mention php version 8.3 or higher but v7.2.3 requires php 8.4.
And laravel core 13 still supports php 8.3.
Is php 8.4 really necessary?

https://laravel.com/docs/13.x/releases
<img width="303" height="212" alt="image" src="https://github.com/user-attachments/assets/d55642e5-fbfb-428d-8726-6a20d018fd1c" />

