### PR TITLE
Fix create-role handling when teams are disabled

### DIFF
--- a/src/Commands/CreateRoleCommand.php
+++ b/src/Commands/CreateRoleCommand.php
@@ -23,16 +23,20 @@ class CreateRoleCommand extends Command
         $roleClass = app(RoleContract::class);
 
         $teamIdAux = getPermissionsTeamId();
-        setPermissionsTeamId($this->option('team-id') ?: null);
 
         if (! $permissionRegistrar->teams && $this->option('team-id')) {
             $this->warn('Teams feature disabled, argument --team-id has no effect. Either enable it in permissions config file or remove --team-id parameter');
-
-            return self::SUCCESS;
         }
 
-        $role = $roleClass::findOrCreate($this->argument('name'), $this->argument('guard'));
-        setPermissionsTeamId($teamIdAux);
+        try {
+            if ($permissionRegistrar->teams) {
+                setPermissionsTeamId($this->option('team-id') ?: null);
+            }
+
+            $role = $roleClass::findOrCreate($this->argument('name'), $this->argument('guard'));
+        } finally {
+            setPermissionsTeamId($teamIdAux);
+        }
 
         $teams_key = $permissionRegistrar->teamsKey;
         if ($permissionRegistrar->teams && $this->option('team-id') && is_null($role->$teams_key)) {

--- a/tests/Commands/CommandTest.php
+++ b/tests/Commands/CommandTest.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
 
 it('can create a role', function () {
@@ -56,6 +57,21 @@ it('can create a role without duplication', function () {
 
     expect(Role::where('name', 'new-role')->get())->toHaveCount(1);
     expect(Role::where('name', 'new-role')->first()->permissions)->toHaveCount(0);
+});
+
+it('warns but still creates a role and preserves team id when team id is passed while teams are disabled', function () {
+    setPermissionsTeamId(5);
+
+    Artisan::call('permission:create-role', [
+        'name' => 'new-role',
+        '--team-id' => 1,
+    ]);
+
+    $output = Artisan::output();
+
+    expect($output)->toContain('Teams feature disabled');
+    expect(Role::where('name', 'new-role')->get())->toHaveCount(1);
+    expect(getPermissionsTeamId())->toEqual(5);
 });
 
 it('can create a permission without duplication', function () {
@@ -125,7 +141,7 @@ it('can setup teams upgrade', function () {
 
 it('can show roles by teams', function () {
     config()->set('permission.teams', true);
-    app(\Spatie\Permission\PermissionRegistrar::class)->initializeCache();
+    app(PermissionRegistrar::class)->initializeCache();
 
     Role::where('name', 'testRole2')->delete();
     Role::create(['name' => 'testRole_2']);
@@ -147,7 +163,7 @@ it('can respond to about command with default', function () {
         $this->markTestSkipped();
     }
 
-    app(\Spatie\Permission\PermissionRegistrar::class)->initializeCache();
+    app(PermissionRegistrar::class)->initializeCache();
 
     Artisan::call('about');
     $output = str_replace("\r\n", "\n", Artisan::output());
@@ -164,7 +180,7 @@ it('can respond to about command with teams', function () {
         $this->markTestSkipped();
     }
 
-    app(\Spatie\Permission\PermissionRegistrar::class)->initializeCache();
+    app(PermissionRegistrar::class)->initializeCache();
 
     config()->set('permission.teams', true);
 


### PR DESCRIPTION
This PR fixes `permission:create-role` when `--team-id` is passed while teams are disabled.

## Problem
The command warned that `--team-id` had no effect, but returned early before creating the role. It also left the in-process team context changed because the temporary team id was set before the early return.

## Changes
- keep warning when `--team-id` is used while teams are disabled
- continue creating the role instead of returning early
- restore the previous team context with a `try/finally`
- add a regression test covering role creation and team id restoration

## Tests
- `/opt/homebrew/opt/php@8.3/bin/php vendor/bin/pest tests/Commands/CommandTest.php`

This is a focused bug fix with a matching test, following the contribution guide requirement to include tests.