### PR TITLE
Expand HasRoles example and remove stray period in installation guide

### DIFF
--- a/docs/installation-laravel.md
+++ b/docs/installation-laravel.md
@@ -48,14 +48,21 @@ See the "Prerequisites" documentation page for compatibility details.
 
         php artisan migrate
 
-9. **Add the necessary trait to your User model**: 
+9. **Add the necessary trait to your User model**:
 
-        // The User model requires this trait
+    ```php
+    use Illuminate\Foundation\Auth\User as Authenticatable;
+    use Spatie\Permission\Traits\HasRoles;
+
+    class User extends Authenticatable
+    {
         use HasRoles;
 
-10. Consult the **Basic Usage** section of the docs to get started using the features of this package.
+        // ...
+    }
+    ```
 
-.
+10. Consult the **Basic Usage** section of the docs to get started using the features of this package.
 
 
 ## Default config file contents


### PR DESCRIPTION
## Summary

Two small documentation improvements in `docs/installation-laravel.md`:

### 1. Complete the `HasRoles` example in step 9

Previously step 9 showed only:

```php
// The User model requires this trait
use HasRoles;
```

This is ambiguous for first-time readers:
- The `Spatie\Permission\Traits\HasRoles` namespace import is missing
- There is no class context showing where the trait should be applied

The updated example now mirrors the full example already used in [`docs/prerequisites.md`](https://github.com/spatie/laravel-permission/blob/main/docs/prerequisites.md) and [`docs/basic-usage/basic-usage.md`](https://github.com/spatie/laravel-permission/blob/main/docs/basic-usage/basic-usage.md), improving consistency across the docs.

### 2. Remove stray `.` between step 10 and the next section

There was an orphan `.` line between step 10 and the `## Default config file contents` heading, which rendered as a lone period on its own line.

## Changes

- Only `docs/installation-laravel.md` touched
- No code changes, docs only
- No tests added (documentation-only change)