### PR TITLE
Do not throw from teams() when teams feature is disabled

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -117,9 +117,23 @@ trait HasRoles
 
     /**
      * A model may be part of multiple teams.
+     *
+     * When the teams feature is disabled this returns an empty BelongsToMany so
+     * tooling that introspects model relations (e.g. ide-helper:models) does not
+     * break. Querying it is a no-op and produces no rows.
      */
     public function teams(): BelongsToMany
     {
+        if (! Config::teamsEnabled()) {
+            return $this->morphToMany(
+                Config::permissionModel(),
+                'model',
+                Config::modelHasRolesTable(),
+                Config::morphKey(),
+                Config::teamForeignKey()
+            )->whereRaw('1 = 0');
+        }
+
         return $this->morphToMany(
             Config::teamModel(),
             'model',

--- a/tests/Traits/TeamScopeTest.php
+++ b/tests/Traits/TeamScopeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use Spatie\Permission\Exceptions\TeamModelNotConfigured;
@@ -25,13 +26,22 @@ afterEach(function () {
     Schema::dropIfExists('teams');
 });
 
-it('throws an exception when teams are not enabled', function () {
+it('throws an exception when team scopes are queried while teams are not enabled', function () {
     config()->set('permission.teams', false);
     app(PermissionRegistrar::class)->teams = false;
 
     expect(fn () => User::team(1)->get())->toThrow(TeamsNotEnabled::class);
     expect(fn () => User::withoutTeam(1)->get())->toThrow(TeamsNotEnabled::class);
-    expect(fn () => $this->testUser->teams()->get())->toThrow(TeamsNotEnabled::class);
+});
+
+it('returns an empty teams relation when teams are not enabled so model introspection does not break', function () {
+    config()->set('permission.teams', false);
+    app(PermissionRegistrar::class)->teams = false;
+
+    $relation = $this->testUser->teams();
+
+    expect($relation)->toBeInstanceOf(BelongsToMany::class);
+    expect($relation->get())->toHaveCount(0);
 });
 
 it('throws an exception when team model is not configured', function () {


### PR DESCRIPTION
## Summary

Calling `$user->teams()` with `permission.teams = false` (the default config) currently throws `TeamsNotEnabled`. This breaks tooling that introspects model relations by calling every public method on a model — most notably `barryvdh/laravel-ide-helper`'s `ide-helper:models` command, which is the regression reported in #2948.

This was introduced in 7.4.0 by #2928.

## Change

When the teams feature is disabled, `teams()` now returns an empty `BelongsToMany` instead of throwing. The relation is shaped as a `morphToMany` against the configured permission model with `whereRaw('1 = 0')`, so any introspection sees a real relation and any (unintended) query yields no rows. The `team` and `withoutTeam` query scopes still throw when invoked, since those are explicit calls.

Fixes #2948