### PR TITLE
Remove stale phpstan ignore HasPermission instanceof.alwaysFalse

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,9 +19,5 @@ parameters:
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::getAllPermissions#'
         # PermissionRegistrar accesses $roles on generic Model:
         - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$roles#'
-        # instanceof checks that are always false/true in specific trait contexts are intentional:
-        -
-            identifier: instanceof.alwaysFalse
-            path: src/Traits/HasPermissions.php
         # unreachable code in trait contexts is intentional — traits are used in multiple model contexts:
         - '#Unreachable statement - code above always terminates#'


### PR DESCRIPTION
Was running PHPStan as I tried to work on something and I noticed there  was a stale ignore:

```sh
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Traits/HasPermissions.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
         Ignored error pattern instanceof.alwaysFalse in path /Volumes/DataT7/Developer/Web/laravel-permission/src/Traits/HasPermissions.php was not matched in reported errors.
         🪪  ignore.unmatched (non-ignorable)
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Changes
- Remove the ignore rule from `phpstan.neon.dist`