### PR TITLE
Extend BackedEnum support on Role/Permission 

### DIFF
--- a/docs/advanced-usage/extending.md
+++ b/docs/advanced-usage/extending.md
@@ -95,3 +95,13 @@ In the rare case that you have need to REPLACE the existing `Role` or `Permissio
 - Your `Permission` model needs to implement the `Spatie\Permission\Contracts\Permission` contract
 - You need to update `config/permission.php` to specify your namespaced model
 
+### Tips
+
+If you override `findByName`, `findOrCreate`, or `create` on your model, you can use Laravel's `enum_value()` helper to resolve `BackedEnum` values:
+ ```php
+ public static function findByName(BackedEnum|string $name, ?string $guardName = null): self
+ {
+     $name = enum_value($name);
+     // ...
+ }
+ ```

--- a/docs/basic-usage/enums.md
+++ b/docs/basic-usage/enums.md
@@ -43,15 +43,19 @@ enum RolesEnum: string
 
 ## Creating Roles/Permissions using Enums
 
-When **creating** roles/permissions, you cannot pass an Enum name directly, because Eloquent expects a string for the name.
-
-Use Laravel's `enum_value()` function for simplicity: 
-
+You can pass a `BackedEnum` directly when creating, finding, or finding-or-creating roles and permissions.
+These use Laravel's `enum_value()` function under the hood.
 
 ```php
-  $role = app(Role::class)->findOrCreate(enum_value(RolesEnum::WRITER), 'web');
+$role = app(Role::class)->create(['name' => RolesEnum::WRITER]);
+$role = app(Role::class)->findByName(RolesEnum::WRITER);
+$role = app(Role::class)->findOrCreate(RolesEnum::WRITER);
+
+$permission = app(Permission::class)->create(['name' => PermissionsEnum::EDITPOSTS]);
+$permission = app(Permission::class)->findByName(PermissionsEnum::EDITPOSTS);
+$permission = app(Permission::class)->findOrCreate(PermissionsEnum::EDITPOSTS);
 ```
-Same with creating Permissions.
+
 
 ### Authorizing using Enums
 
@@ -75,6 +79,15 @@ $user->hasPermissionTo(enum_value(PermissionsEnum::VIEWPOSTS));
 The following methods of this package support passing `BackedEnum` parameters directly:
 
 ```php
+    // Creating
+    app(Role::class)->create(['name' => RolesEnum::WRITER]);
+    app(Role::class)->findByName(RolesEnum::WRITER);
+    app(Role::class)->findOrCreate(RolesEnum::WRITER);
+
+    app(Permission::class)->create(['name' => PermissionsEnum::EDITPOSTS]);
+    app(Permission::class)->findByName(PermissionsEnum::EDITPOSTS);
+    app(Permission::class)->findOrCreate(PermissionsEnum::EDITPOSTS);
+
 	$user->assignRole(RolesEnum::WRITER);
 	$user->removeRole(RolesEnum::EDITOR);
 

--- a/src/Contracts/Permission.php
+++ b/src/Contracts/Permission.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Contracts;
 
+use BackedEnum;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 
@@ -27,7 +28,7 @@ interface Permission
      *
      * @throws PermissionDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName): self;
+    public static function findByName(BackedEnum|string $name, ?string $guardName): self;
 
     /**
      * Find a permission by its id.
@@ -40,5 +41,5 @@ interface Permission
     /**
      * Find or Create a permission by its name and guard name.
      */
-    public static function findOrCreate(string $name, ?string $guardName): self;
+    public static function findOrCreate(BackedEnum|string $name, ?string $guardName): self;
 }

--- a/src/Contracts/Role.php
+++ b/src/Contracts/Role.php
@@ -28,7 +28,7 @@ interface Role
      *
      * @throws RoleDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName): self;
+    public static function findByName(BackedEnum|string $name, ?string $guardName): self;
 
     /**
      * Find a role by its id and guard name.
@@ -41,7 +41,7 @@ interface Role
     /**
      * Find or create a role by its name and guard name.
      */
-    public static function findOrCreate(string $name, ?string $guardName): self;
+    public static function findOrCreate(BackedEnum|string $name, ?string $guardName): self;
 
     /**
      * Determine if the user may perform the given permission.

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Permission\Models;
 
+use BackedEnum;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -14,6 +15,8 @@ use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Support\Config;
 use Spatie\Permission\Traits\HasRoles;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
+
+use function Illuminate\Support\enum_value;
 
 /**
  * @property int|string $id
@@ -49,6 +52,8 @@ class Permission extends Model implements PermissionContract
     public static function create(array $attributes = [])
     {
         $attributes['guard_name'] ??= Guard::getDefaultName(static::class);
+
+        $attributes['name'] = enum_value($attributes['name']);
 
         $permission = static::getPermission(['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']]);
 
@@ -95,8 +100,9 @@ class Permission extends Model implements PermissionContract
      *
      * @throws PermissionDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName = null): PermissionContract
+    public static function findByName(BackedEnum|string $name, ?string $guardName = null): PermissionContract
     {
+        $name = enum_value($name);
         $guardName ??= Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
         if (! $permission) {
@@ -130,8 +136,9 @@ class Permission extends Model implements PermissionContract
      *
      * @return PermissionContract|Permission
      */
-    public static function findOrCreate(string $name, ?string $guardName = null): PermissionContract
+    public static function findOrCreate(BackedEnum|string $name, ?string $guardName = null): PermissionContract
     {
+        $name = enum_value($name);
         $guardName ??= Guard::getDefaultName(static::class);
         $permission = static::getPermission(['name' => $name, 'guard_name' => $guardName]);
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -19,6 +19,8 @@ use Spatie\Permission\Traits\HasAssignedModels;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Traits\RefreshesPermissionCache;
 
+use function Illuminate\Support\enum_value;
+
 /**
  * @property int|string $id
  * @property string $name
@@ -54,6 +56,7 @@ class Role extends Model implements RoleContract
     public static function create(array $attributes = [])
     {
         $attributes['guard_name'] ??= Guard::getDefaultName(static::class);
+        $attributes['name'] = enum_value($attributes['name']);
 
         $params = ['name' => $attributes['name'], 'guard_name' => $attributes['guard_name']];
 
@@ -112,8 +115,9 @@ class Role extends Model implements RoleContract
      *
      * @throws RoleDoesNotExist
      */
-    public static function findByName(string $name, ?string $guardName = null): RoleContract
+    public static function findByName(BackedEnum|string $name, ?string $guardName = null): RoleContract
     {
+        $name = enum_value($name);
         $guardName ??= Guard::getDefaultName(static::class);
 
         $role = static::findByParam(['name' => $name, 'guard_name' => $guardName]);
@@ -148,8 +152,9 @@ class Role extends Model implements RoleContract
      *
      * @return RoleContract|Role
      */
-    public static function findOrCreate(string $name, ?string $guardName = null): RoleContract
+    public static function findOrCreate(BackedEnum|string $name, ?string $guardName = null): RoleContract
     {
+        $name = enum_value($name);
         $guardName ??= Guard::getDefaultName(static::class);
 
         $attributes = ['name' => $name, 'guard_name' => $guardName];

--- a/tests/Models/PermissionTest.php
+++ b/tests/Models/PermissionTest.php
@@ -2,6 +2,7 @@
 
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
+use Spatie\Permission\Tests\Models\TestPermissionEnum;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
 
 it('gets user models using with', function () {
@@ -16,12 +17,39 @@ it('gets user models using with', function () {
     expect($this->testUser->id)->toEqual($permission->users[0]->id);
 });
 
-it('throws an exception when the permission already exists', function () {
-    app(Permission::class)->create(['name' => 'test-permission']);
+it('can be created', function (string|BackedEnum $name, string $expected) {
+    $permission = app(Permission::class)->create(['name' => $name]);
+    expect($permission->name)->toEqual($expected);
+})->with([
+    'string' => ['test-permission', 'test-permission'],
+    'enum' => [TestPermissionEnum::TestPermission, TestPermissionEnum::TestPermission->value],
+]);
 
-    expect(fn () => app(Permission::class)->create(['name' => 'test-permission']))
+it('can find by name', function (string|BackedEnum $name, string $expected) {
+    app(Permission::class)->create(['name' => $name]);
+    $permission = app(Permission::class)->findByName($name);
+    expect($permission->name)->toEqual($expected);
+})->with([
+    'string' => ['test-permission', 'test-permission'],
+    'enum' => [TestPermissionEnum::TestPermission, TestPermissionEnum::TestPermission->value],
+]);
+
+it('can find or create by name', function (string|BackedEnum $name, string $expected) {
+    $permission = app(Permission::class)->findOrCreate($name);
+    expect($permission->name)->toEqual($expected);
+})->with([
+    'string' => ['test-permission', 'test-permission'],
+    'enum' => [TestPermissionEnum::TestPermission, TestPermissionEnum::TestPermission->value],
+]);
+
+it('throws an exception when the permission already exists', function (string|BackedEnum $name) {
+    app(Permission::class)->create(['name' => $name]);
+    expect(fn () => app(Permission::class)->create(['name' => $name]))
         ->toThrow(PermissionAlreadyExists::class);
-});
+})->with([
+    'string' => ['test-permission'],
+    'enum' => [TestPermissionEnum::TestPermission],
+]);
 
 it('belongs to a guard', function () {
     $permission = app(Permission::class)->create(['name' => 'can-edit', 'guard_name' => 'admin']);

--- a/tests/Models/RoleTest.php
+++ b/tests/Models/RoleTest.php
@@ -7,6 +7,7 @@ use Spatie\Permission\Exceptions\RoleAlreadyExists;
 use Spatie\Permission\Exceptions\RoleDoesNotExist;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\Tests\Models\TestRoleEnum;
 use Spatie\Permission\Tests\TestSupport\TestModels\Admin;
 use Spatie\Permission\Tests\TestSupport\TestModels\RuntimeRole;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
@@ -40,12 +41,23 @@ it('has user models of the right class', function () {
     expect($this->testAdminRole->users->first())->toBeInstanceOf(Admin::class);
 });
 
-it('throws an exception when the role already exists', function () {
-    app(Role::class)->create(['name' => 'test-role']);
+it('can be created', function (string|BackedEnum $name, string $expected) {
+    $role = app(Role::class)->create(['name' => $name]);
+    expect($role->name)->toEqual($expected);
+})->with([
+    'string' => ['test-role', 'test-role'],
+    'enum' => [TestRoleEnum::TestRole, TestRoleEnum::TestRole->value],
+]);
 
-    expect(fn () => app(Role::class)->create(['name' => 'test-role']))
+it('throws an exception when the role already exists', function (string|BackedEnum $name) {
+    app(Role::class)->create(['name' => $name]);
+
+    expect(fn () => app(Role::class)->create(['name' => $name]))
         ->toThrow(RoleAlreadyExists::class);
-});
+})->with([
+    'string' => ['test-role'],
+    'enum' => [TestRoleEnum::TestRole],
+]);
 
 it('can be given a permission', function () {
     $this->testUserRole->givePermissionTo('edit-articles');
@@ -152,6 +164,15 @@ it('throws an exception if the permission does not exist', function () {
         ->toThrow(PermissionDoesNotExist::class);
 });
 
+it('can be found by name', function (string|BackedEnum $name, string $expected) {
+    app(Role::class)->create(['name' => $name]);
+    $role = app(Role::class)->findByName($name);
+    expect($role->name)->toEqual($expected);
+})->with([
+    'string' => ['test-role', 'test-role'],
+    'enum' => [TestRoleEnum::TestRole, TestRoleEnum::TestRole->value],
+]);
+
 it('returns false if it does not have a permission object', function () {
     $permission = app(Permission::class)->findByName('other-permission');
 
@@ -170,14 +191,16 @@ it('creates permission object with findOrCreate if it does not have a permission
     expect($this->testUserRole->hasPermissionTo('another-permission'))->toBeTrue();
 });
 
-it('creates a role with findOrCreate if the named role does not exist', function () {
-    expect(fn () => app(Role::class)->findByName('non-existing-role'))
+it('creates a role with findOrCreate if the named role does not exist', function (string|BackedEnum $name, string $expected) {
+    expect(fn () => app(Role::class)->findByName($name))
         ->toThrow(RoleDoesNotExist::class);
 
-    $role2 = app(Role::class)->findOrCreate('yet-another-role');
-
-    expect($role2)->toBeInstanceOf(app(Role::class)::class);
-});
+    $role = app(Role::class)->findOrCreate($name);
+    expect($role->name)->toEqual($expected);
+})->with([
+    'string' => ['test-role', 'test-role'],
+    'enum' => [TestRoleEnum::TestRole, TestRoleEnum::TestRole->value],
+]);
 
 it('throws an exception when a permission of the wrong guard is passed in', function () {
     $permission = app(Permission::class)->findByName('wrong-guard-permission', 'admin');

--- a/tests/Models/TestPermissionEnum.php
+++ b/tests/Models/TestPermissionEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Permission\Tests\Models;
+
+enum TestPermissionEnum: string
+{
+    case TestPermission = 'test-permission';
+}

--- a/tests/Models/TestRoleEnum.php
+++ b/tests/Models/TestRoleEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Permission\Tests\Models;
+
+enum TestRoleEnum: string
+{
+    case TestRole = 'test-role';
+}


### PR DESCRIPTION

Iterating on  #2826, since the minimum php version is now 8.3 I don't think this introduces **breaking** changes anymore

This PR adds `BackedEnum` support to `create()`, `findByName()`, and `findOrCreate()` on the `Role` and `Permission` models.

## Changes
- `Permission::create()`, `findByName()`, `findOrCreate()` now accept `BackedEnum|string`
- `Role::create()`, `findByName()`, `findOrCreate()` now accept `BackedEnum|string`
- Contracts updated accordinglu
- Tests updated and/or added covering both string and enum usage
- Extended the existing documentation:
  - enum documentation now reflects these changes
  - extending documentation repeats the tip to use Laravel's `enum_value` when extending the model _(I was not sure about the best place to put this so I added a Tips section)_

### _Breaking?_
 - Both the `Permission` and `Role` contract have been updated to accept a `BackedEnum` as well. This might cause a minor change for custom implementations. _(Though substitution applies so I don't think this requires a major version update?)_