### PR TITLE
Fix quote stripping in convertPipeToArray for mismatched quotes

### DIFF
--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -482,7 +482,7 @@ trait HasRoles
         }
 
         $quoteCharacter = substr($pipeString, 0, 1);
-        $endCharacter = substr($quoteCharacter, -1, 1);
+        $endCharacter = substr($pipeString, -1, 1);
 
         if ($quoteCharacter !== $endCharacter) {
             return explode('|', $pipeString);

--- a/tests/Traits/HasRolesTest.php
+++ b/tests/Traits/HasRolesTest.php
@@ -110,6 +110,26 @@ it('can scope a role using enums', function () {
     expect($scopedUsers3->count())->toEqual(3);
 });
 
+it('can convert pipe strings to arrays, stripping only matched surrounding quotes', function () {
+    $convert = function (string $pipeString) {
+        $method = new ReflectionMethod($this->testUser, 'convertPipeToArray');
+
+        return $method->invoke($this->testUser, $pipeString);
+    };
+
+    // Unquoted input splits on the pipe.
+    expect($convert('writer|admin'))->toBe(['writer', 'admin']);
+
+    // Matched surrounding quotes are stripped before splitting.
+    expect($convert("'writer|admin'"))->toBe(['writer', 'admin']);
+    expect($convert('"writer|admin"'))->toBe(['writer', 'admin']);
+
+    // Mismatched quotes (leading quote only) must NOT be stripped: the leading
+    // quote is part of the first value. The previous self-comparison bug made
+    // this guard dead and incorrectly stripped the quote.
+    expect($convert("'writer|admin"))->toBe(["'writer", 'admin']);
+});
+
 it('can assign and remove a role', function () {
     expect($this->testUser->hasRole('testRole'))->toBeFalse();
 


### PR DESCRIPTION
## The bug

`HasRoles::convertPipeToArray()` is meant to strip a matching pair of surrounding quotes from a pipe-delimited string (e.g. `@hasanyrole("'writer|admin'")`) before splitting it on `|`. The quotes should only be stripped when the string is wrapped in the **same** quote character on both ends.

The check for "same character on both ends" was broken:

```php
$quoteCharacter = substr($pipeString, 0, 1);
$endCharacter   = substr($quoteCharacter, -1, 1); // reads $quoteCharacter, not $pipeString
```

`$quoteCharacter` is already a single character, so `substr($quoteCharacter, -1, 1)` always returns that same character. As a result `$endCharacter` was always equal to `$quoteCharacter`, and the guard:

```php
if ($quoteCharacter !== $endCharacter) {
    return explode('|', $pipeString);
}
```

was dead code that could never run. A string opening with a quote but **not** closing with a matching one would still have its leading quote stripped.

## Example

```php
// input: 'writer|admin   (leading single quote, no closing quote)

// before: ['writer', 'admin']    — leading quote wrongly stripped
// after:  ["'writer", 'admin']   — leading quote preserved
```

## The fix

Read the closing character from `$pipeString` instead of from `$quoteCharacter`, so surrounding quotes are stripped only when they genuinely match on both ends:

```php
$endCharacter = substr($pipeString, -1, 1);
```

Properly quoted (`'a|b'`, `"a|b"`) and unquoted (`a|b`) inputs behave exactly as before; only the previously-mishandled mismatched-quote case changes.

## Tests

Added a regression test (`can convert pipe strings to arrays, stripping only matched surrounding quotes`) covering unquoted, matched-quote, and mismatched-quote inputs. It fails on the previous code and passes with the fix. Full suite remains green (`650 passed`) and Pint is clean.