### PR TITLE
Fix team delete/sync when using custom pivot class

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -5,6 +5,7 @@ namespace Spatie\Permission\Traits;
 use BackedEnum;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Permission;
@@ -385,6 +386,32 @@ trait HasPermissions
             }, []);
     }
 
+    private function detachPermissions(?array $permissions = null): int
+    {
+        $relation = $this->permissions();
+
+        if (! Config::teamsEnabled() || $this instanceof Role || $relation->getPivotClass() === Pivot::class) {
+            return $relation->detach($permissions);
+        }
+
+        // Custom pivot deletes do not include the team key, so keep deletion on the scoped pivot query.
+        $query = $relation->newPivotQuery();
+
+        if (! is_null($permissions)) {
+            if (empty($permissions)) {
+                return 0;
+            }
+
+            $query->whereIn($relation->getQualifiedRelatedPivotKeyName(), $permissions);
+        }
+
+        $results = $query->delete();
+
+        $relation->touchIfTouching();
+
+        return $results;
+    }
+
     /**
      * Grant the given permission(s) to a role.
      *
@@ -458,7 +485,7 @@ trait HasPermissions
                     $this->revokePermissionTo($currentPermissions);
                 }
             } else {
-                $this->permissions()->detach();
+                $this->detachPermissions();
                 $this->setRelation('permissions', collect());
             }
         }
@@ -475,8 +502,9 @@ trait HasPermissions
     public function revokePermissionTo($permission): static
     {
         $storedPermission = $this->getStoredPermission($permission);
+        $permissions = $this->collectPermissions($storedPermission);
 
-        $this->permissions()->detach($storedPermission);
+        $this->detachPermissions($permissions);
 
         if ($this instanceof Role) {
             $this->forgetCachedPermissions();

--- a/src/Traits/HasRoles.php
+++ b/src/Traits/HasRoles.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\Permission\Contracts\Permission;
@@ -209,6 +210,32 @@ trait HasRoles
             }, []);
     }
 
+    private function detachRoles(?array $roles = null): int
+    {
+        $relation = $this->roles();
+
+        if (! Config::teamsEnabled() || $this instanceof Permission || $relation->getPivotClass() === Pivot::class) {
+            return $relation->detach($roles);
+        }
+
+        // Custom pivot deletes do not include the team key, so keep deletion on the scoped pivot query.
+        $query = $relation->newPivotQuery();
+
+        if (! is_null($roles)) {
+            if (empty($roles)) {
+                return 0;
+            }
+
+            $query->whereIn($relation->getQualifiedRelatedPivotKeyName(), $roles);
+        }
+
+        $results = $query->delete();
+
+        $relation->touchIfTouching();
+
+        return $results;
+    }
+
     /**
      * Assign the given role to the model.
      *
@@ -272,7 +299,7 @@ trait HasRoles
     {
         $roles = $this->collectRoles($role);
 
-        $this->roles()->detach($roles);
+        $this->detachRoles($roles);
 
         $this->unsetRelation('roles');
 
@@ -305,7 +332,7 @@ trait HasRoles
                     $this->removeRole($currentRoles);
                 }
             } else {
-                $this->roles()->detach();
+                $this->detachRoles();
                 $this->setRelation('roles', collect());
             }
         }

--- a/tests/Traits/HasPermissionsTest.php
+++ b/tests/Traits/HasPermissionsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
@@ -11,6 +13,22 @@ use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Tests\TestSupport\TestModels\SoftDeletingUser;
 use Spatie\Permission\Tests\TestSupport\TestModels\TestRolePermissionsEnum;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
+use Spatie\Permission\Tests\TestSupport\TestModels\UserWithoutHasRoles;
+use Spatie\Permission\Traits\HasRoles;
+
+class HasPermissionsCustomPivot extends MorphPivot {}
+
+class HasPermissionsCustomPivotUser extends UserWithoutHasRoles
+{
+    use HasRoles {
+        permissions as traitPermissions;
+    }
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->traitPermissions()->using(HasPermissionsCustomPivot::class);
+    }
+}
 
 it('can assign a permission to a user', function () {
     $this->testUser->givePermissionTo($this->testUserPermission);
@@ -50,6 +68,26 @@ it('can revoke a permission from a user', function () {
     $this->testUser->revokePermissionTo($this->testUserPermission);
 
     expect($this->testUser->hasPermissionTo($this->testUserPermission))->toBeFalse();
+});
+
+it('can revoke a permission when using a custom pivot class without teams', function () {
+    config()->set('auth.providers.users.model', HasPermissionsCustomPivotUser::class);
+
+    $user = HasPermissionsCustomPivotUser::create(['email' => 'custom-pivot-permissions-without-teams@test.com']);
+
+    $user->givePermissionTo('edit-articles', 'edit-news');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles', 'edit-news']));
+
+    $user->revokePermissionTo('edit-articles');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-news']));
+
+    $user->syncPermissions([]);
+
+    expect($user->getPermissionNames())->toBeEmpty();
 });
 
 it('can assign and remove a permission using enums', function () {

--- a/tests/Traits/HasRolesTest.php
+++ b/tests/Traits/HasRolesTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Permission;
@@ -14,6 +16,22 @@ use Spatie\Permission\Tests\TestSupport\TestModels\Admin;
 use Spatie\Permission\Tests\TestSupport\TestModels\SoftDeletingUser;
 use Spatie\Permission\Tests\TestSupport\TestModels\TestRolePermissionsEnum;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
+use Spatie\Permission\Tests\TestSupport\TestModels\UserWithoutHasRoles;
+use Spatie\Permission\Traits\HasRoles;
+
+class HasRolesCustomPivot extends MorphPivot {}
+
+class HasRolesCustomPivotUser extends UserWithoutHasRoles
+{
+    use HasRoles {
+        roles as traitRoles;
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->traitRoles()->using(HasRolesCustomPivot::class);
+    }
+}
 
 it('can determine that the user does not have a role', function () {
     expect($this->testUser->hasRole('testRole'))->toBeFalse();
@@ -140,6 +158,26 @@ it('can assign and remove a role', function () {
     $this->testUser->removeRole('testRole');
 
     expect($this->testUser->hasRole('testRole'))->toBeFalse();
+});
+
+it('can remove a role when using a custom pivot class without teams', function () {
+    config()->set('auth.providers.users.model', HasRolesCustomPivotUser::class);
+
+    $user = HasRolesCustomPivotUser::create(['email' => 'custom-pivot-without-teams@test.com']);
+
+    $user->assignRole('testRole', 'testRole2');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole', 'testRole2']));
+
+    $user->removeRole('testRole');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole2']));
+
+    $user->syncRoles([]);
+
+    expect($user->getRoleNames())->toBeEmpty();
 });
 
 it('removes a role and returns roles', function () {

--- a/tests/Traits/TeamHasPermissionsTest.php
+++ b/tests/Traits/TeamHasPermissionsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Permission;
 use Spatie\Permission\Contracts\Role;
@@ -11,6 +13,24 @@ use Spatie\Permission\Exceptions\PermissionDoesNotExist;
 use Spatie\Permission\Tests\TestSupport\TestModels\SoftDeletingUser;
 use Spatie\Permission\Tests\TestSupport\TestModels\TestRolePermissionsEnum;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
+use Spatie\Permission\Tests\TestSupport\TestModels\UserWithoutHasRoles;
+use Spatie\Permission\Traits\HasRoles;
+
+class TeamHasPermissionsCustomPivot extends MorphPivot {}
+
+class TeamHasPermissionsCustomPivotUser extends UserWithoutHasRoles
+{
+    use HasRoles {
+        permissions as traitPermissions;
+    }
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->traitPermissions()
+            ->withPivot('team_test_id')
+            ->using(TeamHasPermissionsCustomPivot::class);
+    }
+}
 
 beforeEach(fn () => $this->setUpTeams());
 
@@ -754,6 +774,114 @@ it('can sync or remove permission without detach on different teams', function (
     $this->testUser->load('permissions');
     expect($this->testUser->getPermissionNames()->sort()->values())
         ->toEqual(collect(['edit-articles', 'edit-blog']));
+});
+
+it('can revoke a permission from one team when using a custom pivot class', function () {
+    config()->set('auth.providers.users.model', TeamHasPermissionsCustomPivotUser::class);
+
+    $user = TeamHasPermissionsCustomPivotUser::create(['email' => 'custom-pivot-revoke-permission@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->givePermissionTo('edit-articles', 'edit-news');
+
+    setPermissionsTeamId(2);
+    $user->givePermissionTo('edit-articles', 'edit-blog');
+    $user->load('permissions');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles', 'edit-blog']));
+
+    setPermissionsTeamId(1);
+    $user->load('permissions');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles', 'edit-news']));
+
+    $user->revokePermissionTo('edit-articles');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-news']));
+
+    setPermissionsTeamId(2);
+    $user->load('permissions');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles', 'edit-blog']));
+});
+
+it('can sync permissions for one team when using a custom pivot class', function () {
+    config()->set('auth.providers.users.model', TeamHasPermissionsCustomPivotUser::class);
+
+    $user = TeamHasPermissionsCustomPivotUser::create(['email' => 'custom-pivot-sync-permissions@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->givePermissionTo('edit-articles', 'edit-news');
+
+    setPermissionsTeamId(2);
+    $user->givePermissionTo('edit-articles', 'edit-blog');
+
+    setPermissionsTeamId(1);
+    $user->syncPermissions('edit-news');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-news']));
+
+    setPermissionsTeamId(2);
+    $user->load('permissions');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles', 'edit-blog']));
+});
+
+it('can sync permissions with events for one team when using a custom pivot class', function () {
+    Event::fake([PermissionDetachedEvent::class, PermissionAttachedEvent::class]);
+    app('config')->set('permission.events_enabled', true);
+    config()->set('auth.providers.users.model', TeamHasPermissionsCustomPivotUser::class);
+
+    $user = TeamHasPermissionsCustomPivotUser::create(['email' => 'custom-pivot-sync-permissions-events@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->givePermissionTo('edit-articles', 'edit-news');
+
+    setPermissionsTeamId(2);
+    $user->givePermissionTo('edit-articles', 'edit-blog');
+
+    setPermissionsTeamId(1);
+    $user->syncPermissions('edit-news');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-news']));
+
+    Event::assertDispatched(PermissionDetachedEvent::class);
+
+    setPermissionsTeamId(2);
+    $user->load('permissions');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles', 'edit-blog']));
+});
+
+it('can sync to no permissions for one team when using a custom pivot class', function () {
+    config()->set('auth.providers.users.model', TeamHasPermissionsCustomPivotUser::class);
+
+    $user = TeamHasPermissionsCustomPivotUser::create(['email' => 'custom-pivot-sync-empty-permissions@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->givePermissionTo('edit-articles', 'edit-news');
+
+    setPermissionsTeamId(2);
+    $user->givePermissionTo('edit-articles');
+
+    setPermissionsTeamId(1);
+    $user->syncPermissions([]);
+
+    expect($user->getPermissionNames())->toBeEmpty();
+
+    setPermissionsTeamId(2);
+    $user->load('permissions');
+
+    expect($user->getPermissionNames()->sort()->values())
+        ->toEqual(collect(['edit-articles']));
 });
 
 it('can scope users on different teams', function () {

--- a/tests/Traits/TeamHasRolesTest.php
+++ b/tests/Traits/TeamHasRolesTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Contracts\Permission;
@@ -14,6 +16,24 @@ use Spatie\Permission\Tests\TestSupport\TestModels\Admin;
 use Spatie\Permission\Tests\TestSupport\TestModels\SoftDeletingUser;
 use Spatie\Permission\Tests\TestSupport\TestModels\TestRolePermissionsEnum;
 use Spatie\Permission\Tests\TestSupport\TestModels\User;
+use Spatie\Permission\Tests\TestSupport\TestModels\UserWithoutHasRoles;
+use Spatie\Permission\Traits\HasRoles;
+
+class TeamHasRolesCustomPivot extends MorphPivot {}
+
+class TeamHasRolesCustomPivotUser extends UserWithoutHasRoles
+{
+    use HasRoles {
+        roles as traitRoles;
+    }
+
+    public function roles(): BelongsToMany
+    {
+        return $this->traitRoles()
+            ->withPivot('team_test_id')
+            ->using(TeamHasRolesCustomPivot::class);
+    }
+}
 
 beforeEach(fn () => $this->setUpTeams());
 
@@ -942,6 +962,67 @@ it('can sync or remove roles without detach on different teams', function () {
     $this->testUser->load('roles');
 
     expect($this->testUser->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole', 'testRole3']));
+});
+
+it('can remove a role from one team when using a custom pivot class', function () {
+    config()->set('auth.providers.users.model', TeamHasRolesCustomPivotUser::class);
+
+    app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
+
+    $user = TeamHasRolesCustomPivotUser::create(['email' => 'custom-pivot-remove-role@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->syncRoles('testRole', 'testRole2');
+
+    setPermissionsTeamId(2);
+    $user->syncRoles('testRole', 'testRole3');
+    $user->load('roles');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole', 'testRole3']));
+
+    setPermissionsTeamId(1);
+    $user->load('roles');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole', 'testRole2']));
+
+    $user->removeRole('testRole');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole2']));
+
+    setPermissionsTeamId(2);
+    $user->load('roles');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole', 'testRole3']));
+});
+
+it('can sync roles for one team when using a custom pivot class', function () {
+    config()->set('auth.providers.users.model', TeamHasRolesCustomPivotUser::class);
+
+    app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
+
+    $user = TeamHasRolesCustomPivotUser::create(['email' => 'custom-pivot-sync-roles@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->assignRole('testRole', 'testRole2');
+
+    setPermissionsTeamId(2);
+    $user->assignRole('testRole', 'testRole3');
+
+    setPermissionsTeamId(1);
+    $user->syncRoles('testRole2');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole2']));
+
+    setPermissionsTeamId(2);
+    $user->load('roles');
+
+    expect($user->getRoleNames()->sort()->values())
         ->toEqual(collect(['testRole', 'testRole3']));
 });
 

--- a/tests/Traits/TeamHasRolesTest.php
+++ b/tests/Traits/TeamHasRolesTest.php
@@ -1026,6 +1026,59 @@ it('can sync roles for one team when using a custom pivot class', function () {
         ->toEqual(collect(['testRole', 'testRole3']));
 });
 
+it('can sync roles with events for one team when using a custom pivot class', function () {
+    Event::fake([RoleDetachedEvent::class, RoleAttachedEvent::class]);
+    app('config')->set('permission.events_enabled', true);
+    config()->set('auth.providers.users.model', TeamHasRolesCustomPivotUser::class);
+
+    app(Role::class)->create(['name' => 'testRole3', 'team_test_id' => 2]);
+
+    $user = TeamHasRolesCustomPivotUser::create(['email' => 'custom-pivot-sync-roles-events@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->assignRole('testRole', 'testRole2');
+
+    setPermissionsTeamId(2);
+    $user->assignRole('testRole', 'testRole3');
+
+    setPermissionsTeamId(1);
+    $user->syncRoles('testRole2');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole2']));
+
+    Event::assertDispatched(RoleDetachedEvent::class);
+
+    setPermissionsTeamId(2);
+    $user->load('roles');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole', 'testRole3']));
+});
+
+it('can sync to no roles for one team when using a custom pivot class', function () {
+    config()->set('auth.providers.users.model', TeamHasRolesCustomPivotUser::class);
+
+    $user = TeamHasRolesCustomPivotUser::create(['email' => 'custom-pivot-sync-empty-roles@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->assignRole('testRole', 'testRole2');
+
+    setPermissionsTeamId(2);
+    $user->assignRole('testRole');
+
+    setPermissionsTeamId(1);
+    $user->syncRoles([]);
+
+    expect($user->getRoleNames())->toBeEmpty();
+
+    setPermissionsTeamId(2);
+    $user->load('roles');
+
+    expect($user->getRoleNames()->sort()->values())
+        ->toEqual(collect(['testRole']));
+});
+
 it('can scope users on different teams', function () {
     User::all()->each(fn ($item) => $item->delete());
     $user1 = User::create(['email' => 'user1@test.com']);


### PR DESCRIPTION
## Summary

Fixes `removeRole()`/`syncRoles()` and `revokePermissionTo()`/`syncPermissions()` when the teams feature is enabled and a model overrides `roles()` or `permissions()` to use a custom pivot class via `->using(CustomPivot::class)`.

Previously, removing a role (or permission) from one team could also remove that same assignment from other teams for the same model.

Fixes #2867

## Bug

When teams are enabled, the `roles()`/`permissions()` relations correctly scope assignments by the current team id.

However, Laravel handles `detach()` differently when a custom pivot class is configured:

1. It selects the currently attached pivot rows using the scoped relation query.
2. It hydrates those rows as custom pivot models.
3. It calls `delete()` on each custom pivot model.

The selected row is team-scoped, but the custom pivot model's delete query does not include the team foreign key — it deletes by pivot identity columns (model id, role/permission id, morph type). As a result, if the same model has the same role or permission on multiple teams, removing it from one team can delete it from other teams too.

## Fix

Adds internal `detachRoles()` and `detachPermissions()` helpers.

For normal cases, both still delegate to Laravel's regular `detach()` behavior:

- teams disabled
- the "wrong-direction" model (`Permission` for roles, `Role` for permissions)
- default pivot class

For the affected case — `teams=true` plus a custom pivot class — deletion goes through the relation's scoped pivot query instead, which preserves the current team id in the delete predicate.

## Userland mitigation

This changes behavior for users who relied on custom pivot model `deleting`/`deleted` lifecycle hooks firing during `removeRole()`, `syncRoles()`, `revokePermissionTo()`, or `syncPermissions()` with teams enabled.

Those hooks were already unreliable in this scenario: Laravel would fire the hook for the selected team-scoped pivot row, but the resulting delete could remove additional matching rows from other teams with no corresponding hook events.

Users who need to react to package-level role/permission removal should listen for `Spatie\Permission\Events\RoleDetachedEvent` / `PermissionDetachedEvent` instead. Users who need row-level custom pivot lifecycle behavior for this specific team/custom-pivot case should perform their own explicitly team-scoped pivot operation and dispatch their own application event.

**Permissions only:** `revokePermissionTo()` now normalizes its input through the same path `givePermissionTo()` uses, which includes a guard-match check. It can now throw `GuardDoesNotMatch` in cases it previously wouldn't have (`removeRole()` already had this check, so roles are unaffected). In practice this should be a no-op — a permission being revoked is already attached to the model and therefore already guard-matched — but it's a real code-path change worth knowing about if you have unusual guard setups.

## Tests

Added coverage, for both roles and permissions, for:

- custom pivot with teams enabled: removing one role/permission from one team does not remove the same one from another team
- custom pivot with teams enabled: syncing to a non-empty set on one team does not touch another team's assignments
- custom pivot with teams enabled and events enabled: sync's events-branch (which revokes individually) does not cross team boundaries either
- custom pivot with teams enabled: syncing to an empty set on one team does not touch another team's assignments
- custom pivot with teams disabled: remove/sync continue to work normally (unaffected baseline)