### PR TITLE
Fire PermissionDetachedEvent when syncing permissions (symmetry with syncRoles)

### DIFF
--- a/src/Traits/HasPermissions.php
+++ b/src/Traits/HasPermissions.php
@@ -443,8 +443,17 @@ trait HasPermissions
     {
         if ($this->getModel()->exists) {
             $this->collectPermissions($permissions);
-            $this->permissions()->detach();
-            $this->setRelation('permissions', collect());
+
+            if (Config::eventsEnabled()) {
+                $currentPermissions = $this->permissions()->get();
+
+                if ($currentPermissions->isNotEmpty()) {
+                    $this->revokePermissionTo($currentPermissions);
+                }
+            } else {
+                $this->permissions()->detach();
+                $this->setRelation('permissions', collect());
+            }
         }
 
         return $this->givePermissionTo($permissions);

--- a/tests/Traits/HasPermissionsTest.php
+++ b/tests/Traits/HasPermissionsTest.php
@@ -675,6 +675,35 @@ it('fires an event when a permission is removed', function () {
     });
 });
 
+it('fires detach event when syncing permissions', function () {
+    Event::fake([PermissionDetachedEvent::class, PermissionAttachedEvent::class]);
+    app('config')->set('permission.events_enabled', true);
+
+    $this->testUser->givePermissionTo('edit-articles', 'edit-news');
+
+    $this->testUser->syncPermissions('edit-articles');
+
+    expect($this->testUser->hasPermissionTo('edit-articles'))->toBeTrue();
+    expect($this->testUser->hasPermissionTo('edit-news'))->toBeFalse();
+
+    Event::assertDispatched(PermissionDetachedEvent::class, function ($event) {
+        $names = collect($event->permissionsOrIds)->map(
+            fn ($permission) => is_object($permission)
+                ? $permission->name
+                : app(Permission::class)::findById($permission)->name
+        );
+
+        return $event->model instanceof User
+            && ! $event->model->hasPermissionTo('edit-news')
+            && $names->contains('edit-news');
+    });
+
+    Event::assertDispatched(PermissionAttachedEvent::class, function ($event) {
+        return $event->model instanceof User
+            && $event->model->hasPermissionTo('edit-articles');
+    });
+});
+
 it('can be given a permission on role when lazy loading is restricted', function () {
     expect(Model::preventsLazyLoading())->toBeTrue();
 


### PR DESCRIPTION
Thank you all for this package — it does an enormous amount of heavy lifting for the Laravel community, and it's been rock-solid for us. 🙏

### What this does

Fixes the small asymmetry reported in #2962: when `permission.events_enabled` is `true`, `syncRoles()` fires `RoleDetachedEvent` for removed roles, but `syncPermissions()` bulk-detaches with no `PermissionDetachedEvent`, so permission removals via `sync` are invisible to listeners.

This mirrors the existing `syncRoles()` events branch inside `syncPermissions()`: when events are enabled, it revokes the current permissions individually (via `revokePermissionTo()`, which already fires `PermissionDetachedEvent`) before granting the new set. When events are disabled the behaviour is unchanged — it keeps the fast bulk `detach()`.

```php
public function syncPermissions(...$permissions): static
{
    if ($this->getModel()->exists) {
        $this->collectPermissions($permissions);

        if (Config::eventsEnabled()) {
            $currentPermissions = $this->permissions()->get();

            if ($currentPermissions->isNotEmpty()) {
                $this->revokePermissionTo($currentPermissions);
            }
        } else {
            $this->permissions()->detach();
            $this->setRelation('permissions', collect());
        }
    }

    return $this->givePermissionTo($permissions);
}
```

### Notes / trade-offs

- This intentionally follows the exact same shape and trade-off as `syncRoles()`: like that method, it fires a "detached" event for the full current set (not only the net-removed items) when events are enabled. Kept it symmetrical rather than trying to be cleverer than the roles path, but happy to change direction if you'd prefer a net-diff approach for both.
- Only the events-enabled path changes; the default (events off) path is untouched, so there should be no performance impact for the common case.

### Tests

Added `fires detach event when syncing permissions` to `tests/Traits/HasPermissionsTest.php`, mirroring the existing `fires detach event when syncing roles`.

- Full suite: `651 passed`
- PHPStan: `No errors`
- Pint: clean

### Closes

Closes #2962

---

_Disclosure: this change was prepared with AI assistance (Claude) under my supervision. I've read the diff, run the full test suite / PHPStan / Pint locally, and I take responsibility for it — very happy to revise anything, address review feedback, or maintain it over time. Thanks again to the Spatie team for everything you build._
