### PR TITLE
Fix team scope when syncing role models

### DIFF
--- a/src/Traits/HasAssignedModels.php
+++ b/src/Traits/HasAssignedModels.php
@@ -142,8 +142,14 @@ trait HasAssignedModels
 
     private function newPivotQueryForRole(): Builder
     {
-        return $this->getConnection()
+        $query = $this->getConnection()
             ->table(Config::modelHasRolesTable())
             ->where(app(PermissionRegistrar::class)->pivotRole, $this->getKey());
+
+        if (Config::teamsEnabled()) {
+            $query->where(Config::teamForeignKey(), getPermissionsTeamId());
+        }
+
+        return $query;
     }
 }

--- a/tests/Traits/HasAssignedModelsTest.php
+++ b/tests/Traits/HasAssignedModelsTest.php
@@ -230,6 +230,26 @@ it('applies the current team id when assigning models with teams enabled', funct
     expect((int) $pivot->team_test_id)->toBe(1);
 });
 
+it('only syncs models for the active team', function () {
+    $this->setUpTeams();
+
+    $user = User::create(['email' => 'team-user@test.com']);
+
+    setPermissionsTeamId(1);
+    $user->assignRole($this->testUserRole);
+
+    setPermissionsTeamId(2);
+    $user->assignRole($this->testUserRole);
+
+    setPermissionsTeamId(1);
+    $this->testUserRole->syncModels([]);
+
+    expect($user->fresh()->hasRole($this->testUserRole))->toBeFalse();
+
+    setPermissionsTeamId(2);
+    expect($user->fresh()->hasRole($this->testUserRole))->toBeTrue();
+});
+
 it('uses config default_model when resolving IDs', function () {
     config()->set('permission.models.default_model', User::class);
 


### PR DESCRIPTION
## Summary

Fixes `Role::syncModels()` removing role assignments from every team when teams are enabled.

The pivot delete query is now scoped to the active permissions team, matching the behavior of the user-side role synchronization APIs.

## Problem

Calling:

```php
setPermissionsTeamId(1);

$role->syncModels([]);
```

previously deleted all assignments for that role, including assignments belonging to other teams.

## Fix

Adds the active team constraint to the inverse role-model pivot query used by `syncModels()`.

## Tests

Added a regression test confirming that syncing models in team 1 removes only team 1’s assignment and preserves the same role assignment in team 2.

```bash
vendor/bin/pest tests/Traits/HasAssignedModelsTest.php --filter="only syncs models for the active team"
```

Passed.
