### PR TITLE
Make role model sync atomic

### DIFF
--- a/src/Traits/HasAssignedModels.php
+++ b/src/Traits/HasAssignedModels.php
@@ -63,19 +63,21 @@ trait HasAssignedModels
      */
     public function syncModels(array|Collection|Model|int|string $models, ?string $modelClass = null): static
     {
-        if ($this->exists) {
-            $this->newPivotQueryForRole()->delete();
-        }
+        return $this->getConnection()->transaction(function () use ($models, $modelClass) {
+            if ($this->exists) {
+                $this->newPivotQueryForRole()->delete();
+            }
 
-        $teamPivot = $this->teamPivot();
+            $teamPivot = $this->teamPivot();
 
-        foreach ($this->groupModelsByMorphClass($models, $modelClass) as $morphClass => $ids) {
-            $this->relationForModel($morphClass)->attach($ids, $teamPivot);
-        }
+            foreach ($this->groupModelsByMorphClass($models, $modelClass) as $morphClass => $ids) {
+                $this->relationForModel($morphClass)->attach($ids, $teamPivot);
+            }
 
-        $this->unsetRelation('users');
+            $this->unsetRelation('users');
 
-        return $this;
+            return $this;
+        });
     }
 
     /**

--- a/tests/Traits/HasAssignedModelsTest.php
+++ b/tests/Traits/HasAssignedModelsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\QueryException;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Support\Config;
@@ -60,6 +61,17 @@ it('can sync models using a single model instance', function () {
     $this->testUserRole->syncModels($user1);
 
     expect($user1->fresh()->hasRole($this->testUserRole))->toBeTrue();
+});
+
+it('does not detach models when syncing an unsaved model', function () {
+    $user = User::create(['email' => 'user@test.com']);
+    $this->testUserRole->syncModels($user);
+
+    $unsavedUser = new User(['email' => 'unsaved-user@test.com']);
+
+    expect(fn () => $this->testUserRole->syncModels($unsavedUser))->toThrow(QueryException::class);
+
+    expect($user->fresh()->hasRole($this->testUserRole))->toBeTrue();
 });
 
 it('can sync models using IDs', function () {


### PR DESCRIPTION
## Summary

Makes `Role::syncModels()` atomic so a failed attachment cannot remove existing role-to-model assignments.

## Problem

`syncModels()` deleted all existing pivot records before attaching the replacement models.

When an unsaved model was supplied, the pivot insert failed because the model key was null. The exception was thrown, but the prior assignments had already been deleted.

## Fix

Wrap the delete-and-attach sequence in a database transaction.

The original `QueryException` still propagates, but the database rolls back the pivot deletion when attachment fails.

## Test

Added a regression test covering an unsaved target model:

```php
expect(fn () => $role->syncModels($unsavedUser))
    ->toThrow(QueryException::class);

expect($assignedUser->fresh()->hasRole($role))
    ->toBeTrue();
```

```bash
vendor/bin/pest tests/Traits/HasAssignedModelsTest.php --filter="does not detach models when syncing an unsaved model"
```

Passed.
